### PR TITLE
UHF-147 Basic site features

### DIFF
--- a/features/helfi_base_config/helfi_base_config.features.yml
+++ b/features/helfi_base_config/helfi_base_config.features.yml
@@ -1,0 +1,2 @@
+bundle: helfi
+required: true

--- a/features/helfi_base_config/helfi_base_config.info.yml
+++ b/features/helfi_base_config/helfi_base_config.info.yml
@@ -1,0 +1,16 @@
+name: 'HELfi Base config'
+type: module
+description: 'Provides base configuration and basic site features to run the Drupal in most efficient way.'
+core: 8.x
+core_version_requirement: '^8 || ^9'
+version: 9.x-1.0
+package: HELfi
+dependencies:
+  - admin_toolbar
+  - block
+  - gin_toolbar
+  - hdbt_component_library
+  - helfi_languages
+  - menu_link_content
+  - system
+  - twig_tweak

--- a/features/helfi_base_config/helfi_base_config.install
+++ b/features/helfi_base_config/helfi_base_config.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Implements hook_install().
+ *
+ * Install HDBT and HDBT admin themes and make them as default themes.
+ */
+function helfi_base_config_install() {
+  \Drupal::service('theme_installer')->install(['hdbt', 'hdbt_admin']);
+
+  $system_theme = \Drupal::configFactory()->getEditable('system.theme');
+  $system_theme->set('default', 'hdbt')->set('admin', 'hdbt_admin')->save();
+}


### PR DESCRIPTION
How to test: 
- Either install a new site with the platform from https://github.com/City-of-Helsinki/drupal-helfi-platform or use hel.fi drupal https://github.com/City-of-Helsinki/drupal-helfi
- Before creating the environment run these commands to temporarily switch the version for composer: ```composer require drupal/hdbt_admin:dev-UHF-147_basic_site_feature && composer require drupal/hdbt:dev-UHF-147_basic_site_feature```
- Create the environment by running `make new` and open the shell `make shell`
- In shell, run `drush en -y helfi_base_config`
- Once installation is complete, log in to the site and check that the  HDBT and HDBT admin themes are enabled
- If all is good, check these PRs as well:
   - 
   -
   -