### PR TITLE
UHF-X Add responsive image as dependency on media feature

### DIFF
--- a/features/helfi_media/config/install/core.entity_form_display.media.file.default.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.file.default.yml
@@ -53,6 +53,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/features/helfi_media/config/install/core.entity_form_display.media.file.media_library.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.file.media_library.yml
@@ -18,6 +18,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_file: true

--- a/features/helfi_media/config/install/core.entity_form_display.media.image.default.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.image.default.yml
@@ -55,6 +55,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/features/helfi_media/config/install/core.entity_form_display.media.image.media_library.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.image.media_library.yml
@@ -29,6 +29,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   langcode: true

--- a/features/helfi_media/config/install/core.entity_form_display.media.remote_video.default.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.remote_video.default.yml
@@ -46,6 +46,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/features/helfi_media/config/install/core.entity_form_display.media.remote_video.media_library.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.remote_video.media_library.yml
@@ -18,6 +18,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_oembed_video: true

--- a/features/helfi_media/config/install/core.entity_form_display.media.soundcloud.default.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.soundcloud.default.yml
@@ -53,6 +53,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/features/helfi_media/config/install/core.entity_form_display.media.soundcloud.media_library.yml
+++ b/features/helfi_media/config/install/core.entity_form_display.media.soundcloud.media_library.yml
@@ -18,6 +18,11 @@ content:
     weight: 0
     third_party_settings: {  }
     region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_soundcloud: true

--- a/features/helfi_media/config/install/core.entity_view_mode.media.full.yml
+++ b/features/helfi_media/config/install/core.entity_view_mode.media.full.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: false
+dependencies:
+  module:
+    - media
+id: media.full
+label: 'Full content'
+targetEntityType: media
+cache: true

--- a/features/helfi_media/config/install/core.entity_view_mode.media.media_library.yml
+++ b/features/helfi_media/config/install/core.entity_view_mode.media.media_library.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+  module:
+    - media
+id: media.media_library
+label: 'Media library'
+targetEntityType: media
+cache: true

--- a/features/helfi_media/config/install/crop.settings.yml
+++ b/features/helfi_media/config/install/crop.settings.yml
@@ -1,0 +1,1 @@
+flush_derivative_images: true

--- a/features/helfi_media/config/install/crop.type.focal_point.yml
+++ b/features/helfi_media/config/install/crop.type.focal_point.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: focal_point
+label: 'Focal point'
+description: 'Crop type used by Focal point module.'
+aspect_ratio: ''
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/features/helfi_media/config/install/language.content_settings.media.file.yml
+++ b/features/helfi_media/config/install/language.content_settings.media.file.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: media.file
 target_entity_type_id: media
 target_bundle: file
-default_langcode: site_default
+default_langcode: fi
 language_alterable: true

--- a/features/helfi_media/config/install/language.content_settings.media.image.yml
+++ b/features/helfi_media/config/install/language.content_settings.media.image.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: media.image
 target_entity_type_id: media
 target_bundle: image
-default_langcode: site_default
+default_langcode: fi
 language_alterable: true

--- a/features/helfi_media/config/install/language.content_settings.media.remote_video.yml
+++ b/features/helfi_media/config/install/language.content_settings.media.remote_video.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: media.remote_video
 target_entity_type_id: media
 target_bundle: remote_video
-default_langcode: site_default
+default_langcode: fi
 language_alterable: true

--- a/features/helfi_media/config/install/language.content_settings.media.soundcloud.yml
+++ b/features/helfi_media/config/install/language.content_settings.media.soundcloud.yml
@@ -11,5 +11,5 @@ third_party_settings:
 id: media.soundcloud
 target_entity_type_id: media
 target_bundle: soundcloud
-default_langcode: site_default
+default_langcode: fi
 language_alterable: true

--- a/features/helfi_media/config/install/media.type.image.yml
+++ b/features/helfi_media/config/install/media.type.image.yml
@@ -11,7 +11,7 @@ label: Image
 description: 'Media type image.'
 source: image
 queue_thumbnail_downloads: false
-new_revision: false
+new_revision: true
 source_configuration:
   source_field: field_media_image
 field_map: {  }

--- a/features/helfi_media/config/install/system.image.gd.yml
+++ b/features/helfi_media/config/install/system.image.gd.yml
@@ -1,0 +1,1 @@
+jpeg_quality: 75

--- a/features/helfi_media/config/install/system.image.yml
+++ b/features/helfi_media/config/install/system.image.yml
@@ -1,0 +1,1 @@
+toolkit: gd

--- a/features/helfi_media/helfi_media.info.yml
+++ b/features/helfi_media/helfi_media.info.yml
@@ -1,4 +1,4 @@
-name: HELfi media
+name: 'HELfi media'
 description: 'Media configuration for platform.'
 type: module
 core: 8.x
@@ -12,9 +12,11 @@ dependencies:
   - image
   - language
   - media
-  - media_library
   - media_entity_soundcloud
+  - media_library
   - path
   - responsive_image
+  - system
+  - user
 version: 9.x-1.0
 package: HELfi

--- a/features/helfi_media/helfi_media.info.yml
+++ b/features/helfi_media/helfi_media.info.yml
@@ -15,5 +15,6 @@ dependencies:
   - media_library
   - media_entity_soundcloud
   - path
+  - responsive_image
 version: 9.x-1.0
 package: HELfi


### PR DESCRIPTION
How to test (if you have no setup etc.):
- Clone hel.fi environment (https://github.com/City-of-Helsinki/drupal-helfi) and switch to UHF-81_branding_selector OR `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branch: 
   - `composer require drupal/helfi_platform_config:dev-UHF-X-enable-responsive-image-on-media-feature`
- Run `make new`
- Log in to the site.
- Make sure that the responsive image module is on.