### PR TITLE
UHF-X Features deprecation notices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,10 @@
       },
       "drupal/paragraphs_asymmetric_translation_widgets": {
         "https://www.drupal.org/project/paragraphs_asymmetric_translation_widgets/issues/3171810#comment-13836806": "https://www.drupal.org/files/issues/2020-09-25/3171810-2.patch"
+      },
+      "drupal/features": {
+        "https://www.drupal.org/project/features/issues/3068461#comment-13908491": "https://www.drupal.org/files/issues/2020-11-19/features-ui_theme_agnostic_rtl-3068461-6.patch",
+        "https://www.drupal.org/project/features/issues/3147028": "https://www.drupal.org/files/issues/2020-10-14/3147028-features_templates.patch"
       }
     }
   }


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/helfi_platform_config:dev-UHF-X_features_deprecation_notice`
- Run `make new`
- Log in to the site.
- Clear caches from the https://hel-platform.docker.sh/fi/admin/config/development/performance
   - Make sure this doesn't occur anymore
![virheviesti](https://user-images.githubusercontent.com/1712902/102600878-144cb200-4128-11eb-9592-7011153909fb.png)

Also check this:
- https://github.com/City-of-Helsinki/drupal-helfi/pull/27