### PR TITLE
UHF-251 Add missing translations to list of links paragraph

### DIFF
--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_design.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_design.yml
@@ -1,0 +1,2 @@
+label: Tyyli
+description: 'Valitse lohkon tyyli alasvetovalikosta. Tarvittavat tiedot riippuvat siitä minkä tyylin valitset.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_links.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_links.yml
@@ -1,0 +1,2 @@
+label: Linkit
+description: 'Linkkilistan linkit.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_title.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links.field_list_of_links_title.yml
@@ -1,0 +1,2 @@
+label: Otsikko
+description: 'Linkkilistalohkon otsikko.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_desc.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_desc.yml
@@ -1,0 +1,2 @@
+label: Kuvaus
+description: 'Voit lisätä lyhyen kuvauksen linkkiin.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_image.yml
@@ -1,0 +1,2 @@
+label: Kuva
+description: 'Kuva jota käytetään linkin yhteydessä.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_link.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.list_of_links_item.field_list_of_links_link.yml
@@ -1,0 +1,2 @@
+label: Linkki
+description: 'Sisäinen tai ulkoinen linkki haluttuun kohteeseen. Linkin teksti -kentän arvo näytetään sivuston käyttäjälle.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.storage.paragraph.field_list_of_links_design.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.storage.paragraph.field_list_of_links_design.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Kuvallinen
+    -
+      label: 'Ilman kuvaa'
+    -
+      label: 'Ilman kuvaa ja kuvausta'

--- a/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.list_of_links.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.list_of_links.yml
@@ -1,0 +1,2 @@
+label: Linkkilista
+description: 'Lista sisäisiä tai ulkoisia linkkejä. Valittavissa erilaisia listatyylejä.'

--- a/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.list_of_links_item.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.list_of_links_item.yml
@@ -1,0 +1,2 @@
+label: Linkki
+description: 'Yksittäinen linkki lisätietoineen linkkilistalohkoon.'


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/helfi_platform_config:dev-UHF-251-list-of-links`
- Run `make new`
- Go to edit content in Finnish and make sure that the list of links paragraph is translated.