### PR TITLE
UHF-X Collapse column paragraphs in edit mode

### DIFF
--- a/features/helfi_paragraphs/config/install/core.entity_form_display.paragraph.columns.default.yml
+++ b/features/helfi_paragraphs/config/install/core.entity_form_display.paragraph.columns.default.yml
@@ -26,7 +26,7 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed_expand_nested
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0
@@ -45,7 +45,7 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed_expand_nested
       closed_mode: summary
       autocollapse: none
       closed_mode_threshold: 0


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/hdbt_admin:dev-UHF-X-admin-ui-adjustments && composer require drupal/helfi_platform_config:dev-UHF-X-admin-ui-adjustments`
- Run `make new`
- Log in and go to edit "Palstat" content and make sure that each of the columns paragraph content is collapsed.
- Add image paragraph and it should look more sleek especially on desktop. Screenshot attached.

Also check:
https://github.com/City-of-Helsinki/drupal-helfi/pull/56
https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/17