### PR TITLE
UHF-402: Cookie compliance banner styling

### DIFF
--- a/features/helfi_gdpr_compliance/config/install/eu_cookie_compliance.settings.yml
+++ b/features/helfi_gdpr_compliance/config/install/eu_cookie_compliance.settings.yml
@@ -14,19 +14,19 @@ popup_agreed:
   format: full_html
 popup_agree_button_message: Accept
 popup_agreed_enabled: false
-popup_bg_hex: 0779bf
+popup_bg_hex: ''
 popup_clicking_confirmation: false
 popup_scrolling_confirmation: false
 popup_delay: 1000
 show_more_info: true
-popup_more_info_button_message: 'More info'
+popup_more_info_button_message: 'Show cookies'
 popup_enabled: true
-popup_find_more_button_message: 'More info'
+popup_find_more_button_message: 'Show cookies'
 popup_height: null
 popup_hide_agreed: false
 popup_hide_button_message: Hide
 popup_info:
-  value: "<h2>We use cookies on this site to enhance your user experience</h2>\r\n\r\n<p>By clicking the Accept button, you agree to us doing so.</p>\r\n"
+  value: "<h2>Hel.fi uses cookies&nbsp;</h2>\r\n\r\n<p>We use essential cookies on our website to make the site work. Also third party cookies are used if you give us your permission.</p>\r\n"
   format: full_html
 mobile_popup_info:
   value: ''
@@ -37,9 +37,9 @@ popup_link: /node/1
 popup_link_new_window: false
 popup_position: false
 fixed_top_position: true
-popup_text_hex: ffffff
-popup_width: 100%
-use_bare_css: false
+popup_text_hex: ''
+popup_width: ''
+use_bare_css: true
 disagree_do_not_show_popup: false
 reload_page: true
 cookie_name: ''
@@ -53,13 +53,13 @@ automatic_cookies_removal: true
 allowed_cookies: 'marketing:form-test-cookie'
 consent_storage_method: do_not_store
 withdraw_message:
-  value: "<h2>We use cookies on this site to enhance your user experience</h2>\r\n\r\n<p>You have given your consent for us to set cookies.</p>\r\n"
+  value: "<h2>Hel.fi uses cookies</h2>\r\n\r\n<p>You have given your consent for us to set cookies.</p>\r\n"
   format: full_html
 withdraw_action_button_label: 'Withdraw consent'
 withdraw_tab_button_label: 'Privacy settings'
 withdraw_enabled: false
 enable_save_preferences_button: true
-save_preferences_button_label: 'Save preferences'
+save_preferences_button_label: 'Allow only essential cookies'
 accept_all_categories_button_label: 'Accept all cookies'
 withdraw_button_on_info_popup: false
 domain_all_sites: true


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/hdbt:dev-UHF-402-cookie-banner-styling && composer require drupal/helfi_platform_config:dev-UHF-402-cookie-banner-styling`
- Run `make new`
- The cookie compliance banner should now look good and there should be overlay on the site until you accept the cookies. You should be able to use the site despite the overlay tho.
- Check that the banner looks good and works in desktop and mobile and matches about these layouts: https://app.abstract.com/projects/6a2238d2-fcb7-40e4-b2aa-a4487941ad8a/branches/master/collections/ee5cddf8-7f89-4688-95a1-cf4188174d5b

Check out also these PRs: 
https://github.com/City-of-Helsinki/drupal-helfi/pull/64
https://github.com/City-of-Helsinki/drupal-hdbt/pull/50