### PR TITLE
UHF-252 Liftup with image

### DIFF
--- a/features/helfi_content/config/install/field.field.node.landing_page.field_content.yml
+++ b/features/helfi_content/config/install/field.field.node.landing_page.field_content.yml
@@ -6,6 +6,7 @@ dependencies:
     - node.type.landing_page
     - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.columns
+    - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
   module:
     - entity_reference_revisions
@@ -27,38 +28,42 @@ settings:
       columns: columns
       banner: banner
       list_of_links: list_of_links
+      liftup_with_image: liftup_with_image
     target_bundles_drag_drop:
-      columns:
-        enabled: true
-        weight: 1
-      banner:
-        enabled: true
-        weight: 2
-      list_of_links:
-        enabled: true
-        weight: 3
       accordion:
-        weight: 4
+        weight: -21
         enabled: false
       accordion_item:
-        weight: 5
+        weight: -20
         enabled: false
+      banner:
+        enabled: true
+        weight: -24
+      columns:
+        enabled: true
+        weight: -25
       gallery:
-        weight: 6
+        weight: -19
         enabled: false
       gallery_slide:
-        weight: 7
+        weight: -18
         enabled: false
       hero:
-        weight: 8
+        weight: -17
         enabled: false
       image:
-        weight: 9
+        weight: -16
         enabled: false
+      liftup_with_image:
+        enabled: true
+        weight: -22
+      list_of_links:
+        enabled: true
+        weight: -23
       list_of_links_item:
-        weight: 10
+        weight: -15
         enabled: false
       text:
-        weight: 11
+        weight: -14
         enabled: false
 field_type: entity_reference_revisions

--- a/features/helfi_example_content/content/node/7f3b3413-fbf6-4f0b-873c-1fafd3c7912f.yml
+++ b/features/helfi_example_content/content/node/7f3b3413-fbf6-4f0b-873c-1fafd3c7912f.yml
@@ -36,9 +36,6 @@ default:
   sticky:
     -
       value: false
-  revision_translation_affected:
-    -
-      value: true
   path:
     -
       alias: /esimerkki-laskeutumissivusta
@@ -69,9 +66,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_list_of_links_design:
             -
               value: without-image-desc
@@ -94,9 +88,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: c2b41989-c715-4ec4-8df1-42655293fdfc
@@ -120,9 +111,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: efc11410-25ca-48ef-bfe0-f03860a3b7e7
@@ -146,9 +134,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: 3a313b2f-8b70-41a6-a655-3f9805cb1f48
@@ -172,9 +157,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: 0f14edf8-bb60-4c3b-8d02-4433aac0d3e6
@@ -198,9 +180,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: 77e5183c-4d25-447e-a4e1-58776b2b545b
@@ -224,9 +203,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: 8455251b-91bd-4c71-9756-94112e8912c1
@@ -250,9 +226,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_link:
                     -
                       target_uuid: d5bf4eac-26d6-420e-bd19-7d66ff969181
@@ -279,9 +252,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_banner_desc:
             -
               value: "<p>Maecenas convallis faucibus finibus. Phasellus et arcu diam. <strong>Cras tempor </strong>arcu in felis maximus convallis. Duis congue eu risus a placerat. Etiam faucibus erat et placerat sagittis. Duis venenatis interdum elit, nec dapibus nulla rhoncus at.&nbsp;</p>\r\n"
@@ -318,9 +288,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_columns_design:
             -
               value: 50-50
@@ -343,9 +310,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_text:
                     -
                       value: "<p>Mieleni minun tekevi, aivoni ajattelevi lähteäni laulamahan, saa'ani sanelemahan, sukuvirttä suoltamahan, lajivirttä laulamahan. Sanat suussani sulavat, puhe'et putoelevat, kielelleni kerkiävät, hampahilleni hajoovat.</p>\r\n\r\n<p><strong>Veli kulta, veikkoseni,</strong>&nbsp;kaunis kasvinkumppalini! Lähe nyt kanssa laulamahan, saa kera sanelemahan yhtehen yhyttyämme, kahta'alta käytyämme! Harvoin yhtehen yhymme, saamme toinen toisihimme näillä raukoilla rajoilla, poloisilla Pohjan mailla.</p>\r\n"
@@ -369,9 +333,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_text:
                     -
                       value: "<p>Niit' ennen isoni lauloi kirvesvartta vuollessansa; niitä äitini opetti väätessänsä värttinätä, minun lasna lattialla eessä polven pyöriessä, maitopartana pahaisna, piimäsuuna pikkaraisna. Sampo ei puuttunut sanoja eikä Louhi luottehia: vanheni sanoihin sampo, katoi Louhi luottehisin, virsihin Vipunen kuoli, Lemminkäinen leikkilöihin.</p>\r\n"
@@ -397,9 +358,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_banner_desc:
             -
               value: "<p>Vivamus aliquet ligula sit amet mauris condimentum, vel tempus ex elementum. Sed ex dolor, dapibus in justo a, ullamcorper scelerisque lacus. Vestibulum lacinia nulla in purus condimentum tempor. Fusce nec arcu ut massa sodales accumsan nec quis nulla. Nam vel rutrum nunc.</p>\r\n"
@@ -436,9 +394,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_list_of_links_design:
             -
               value: with-image
@@ -461,9 +416,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   field_list_of_links_image:
                     -
                       entity: 923ecd78-00ff-47f9-a017-012b781d6bab
@@ -475,6 +427,142 @@ default:
           field_list_of_links_title:
             -
               value: 'Esimerkki palstat-komponentista'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 76b5dc01-a2b3-45c4-bb7b-94639dd04ccd
+          bundle: liftup_with_image
+          default_langcode: fi
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1614428787
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_liftup_with_image_desc:
+            -
+              value: "<p>Curabitur vel fringilla libero. Vivamus placerat, purus in venenatis scelerisque, turpis purus posuere lorem, eget iaculis orci justo in nulla.</p>\r\n\r\n<p><a class=\"hds-button hds-button--primary\" href=\"https://hel.fi\"><span class=\"hds-button__label\">Hel.fi ulkoinen linkki</span></a></p>\r\n"
+              format: full_html
+          field_liftup_with_image_design:
+            -
+              value: image-on-right
+          field_liftup_with_image_image:
+            -
+              entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+          field_liftup_with_image_title:
+            -
+              value: 'Kuvallinen nosto jossa kuva oikealla'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 94a0d90a-994b-4ed1-a762-d3fa0ca9d41f
+          bundle: liftup_with_image
+          default_langcode: fi
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1614428928
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_liftup_with_image_desc:
+            -
+              value: "<p>Aliquam molestie tristique dolor, in interdum lacus molestie vel. Nulla nec sagittis orci. Nulla facilisis fringilla nibh, vitae molestie ligula ornare non.</p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary\" href=\"/node/10\"><span class=\"hds-button__label\">Esimerkkisivu</span></a></p>\r\n"
+              format: full_html
+          field_liftup_with_image_design:
+            -
+              value: image-on-left
+          field_liftup_with_image_image:
+            -
+              entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+          field_liftup_with_image_title:
+            -
+              value: 'Kuvallinen nosto jossa kuva vasemmalla'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 36b8516a-1017-431a-9a73-d2c6fea886fa
+          bundle: liftup_with_image
+          default_langcode: fi
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1614428973
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_liftup_with_image_desc:
+            -
+              value: "<p>Donec a ipsum enim. Nulla vel lorem non ante tempor mollis at nec ex. Sed ornare est rhoncus nisl suscipit sollicitudin. Etiam ut massa sed nulla bibendum laoreet.</p>\r\n\r\n<p><a class=\"hds-button hds-button--supplementary\" href=\"https://oodi.fi\" target=\"_blank\"><span class=\"hds-button__label\">Oodin sivustolle tästä</span></a></p>\r\n"
+              format: full_html
+          field_liftup_with_image_design:
+            -
+              value: background-text-on-right
+          field_liftup_with_image_image:
+            -
+              entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+          field_liftup_with_image_title:
+            -
+              value: 'Taustakuvallinen teksti oikealla'
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: fc4e09fd-1742-4aba-ac74-253ce5d7924a
+          bundle: liftup_with_image
+          default_langcode: fi
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1614429029
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          field_liftup_with_image_desc:
+            -
+              value: "<p>Sed auctor pellentesque ante ut porta. Nulla tristique nisi ut sem ultrices, eu fermentum orci dictum. Curabitur sodales viverra sem quis sollicitudin.</p>\r\n"
+              format: full_html
+          field_liftup_with_image_design:
+            -
+              value: background-text-on-left
+          field_liftup_with_image_image:
+            -
+              entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+          field_liftup_with_image_title:
+            -
+              value: 'Taustakuvallinen teksti vasemmalla'
   field_has_hero:
     -
       value: true
@@ -497,9 +585,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           field_hero_bg_color:
             -
               value: gold
@@ -572,9 +657,6 @@ translations:
             behavior_settings:
               -
                 value: {  }
-            revision_translation_affected:
-              -
-                value: true
             field_list_of_links_design:
               -
                 value: without-image-desc
@@ -597,9 +679,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: c2b41989-c715-4ec4-8df1-42655293fdfc
@@ -623,9 +702,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: efc11410-25ca-48ef-bfe0-f03860a3b7e7
@@ -649,9 +725,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: 3a313b2f-8b70-41a6-a655-3f9805cb1f48
@@ -675,9 +748,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: 0f14edf8-bb60-4c3b-8d02-4433aac0d3e6
@@ -701,9 +771,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: 77e5183c-4d25-447e-a4e1-58776b2b545b
@@ -727,9 +794,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: 8455251b-91bd-4c71-9756-94112e8912c1
@@ -753,9 +817,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_link:
                       -
                         target_uuid: d5bf4eac-26d6-420e-bd19-7d66ff969181
@@ -782,9 +843,6 @@ translations:
             behavior_settings:
               -
                 value: {  }
-            revision_translation_affected:
-              -
-                value: true
             field_columns_design:
               -
                 value: 50-50
@@ -807,9 +865,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_text:
                       -
                         value: "<p>Leoetiam enean lus bibendu tempor onec. Molestie iquam ante lacinia justov faucibus semnunc magnis. Mollis abitur ris lacusp arcualiq loremn isque. Eratphas morbi iumsed blandit posuered sodalesm.</p>\r\n"
@@ -833,9 +888,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_text:
                       -
                         value: "<p>Leoetiam enean lus bibendu tempor onec. Molestie iquam ante lacinia justov faucibus semnunc magnis. Mollis abitur ris lacusp arcualiq loremn isque. Eratphas morbi iumsed blandit posuered sodalesm.</p>\r\n"
@@ -861,9 +913,6 @@ translations:
             behavior_settings:
               -
                 value: {  }
-            revision_translation_affected:
-              -
-                value: true
             field_banner_desc:
               -
                 value: "<p>Quisque at pellentesque risus. Suspendisse vel mattis felis. Suspendisse potenti. Vestibulum scelerisque viverra lacus eu ultricies. Ut euismod condimentum magna, a condimentum ligula tempus in. Mauris egestas ultrices faucibus. Nullam et tincidunt felis</p>\r\n"
@@ -900,9 +949,6 @@ translations:
             behavior_settings:
               -
                 value: {  }
-            revision_translation_affected:
-              -
-                value: true
             field_list_of_links_design:
               -
                 value: with-image
@@ -925,9 +971,6 @@ translations:
                     behavior_settings:
                       -
                         value: {  }
-                    revision_translation_affected:
-                      -
-                        value: true
                     field_list_of_links_image:
                       -
                         entity: 923ecd78-00ff-47f9-a017-012b781d6bab
@@ -946,7 +989,7 @@ translations:
             entity_type: paragraph
             uuid: 3e3c3368-60c0-4f7f-8112-b4ca6d465503
             bundle: list_of_links
-            default_langcode: fi
+            default_langcode: en
           default:
             status:
               -
@@ -971,7 +1014,7 @@ translations:
                     entity_type: paragraph
                     uuid: 70b3f4b4-77b9-44c7-b587-2b420f7d6cdc
                     bundle: list_of_links_item
-                    default_langcode: fi
+                    default_langcode: en
                   default:
                     status:
                       -
@@ -996,6 +1039,74 @@ translations:
             field_list_of_links_title:
               -
                 value: 'Esimerkki palstat-komponentista'
+      -
+        entity:
+          _meta:
+            version: '1.0'
+            entity_type: paragraph
+            uuid: 224cb643-4cb7-4136-a0fc-4ec7aaf2fce4
+            bundle: liftup_with_image
+            default_langcode: en
+          default:
+            status:
+              -
+                value: true
+            created:
+              -
+                value: 1614429101
+            behavior_settings:
+              -
+                value: {  }
+            revision_translation_affected:
+              -
+                value: true
+            field_liftup_with_image_desc:
+              -
+                value: "<p>Sed auctor pellentesque ante ut porta. Nulla tristique nisi ut sem ultrices, eu fermentum orci dictum. Curabitur sodales viverra sem quis sollicitudin.</p>\r\n\r\n<p><a class=\"link\" href=\"https://hel.fi\" target=\"_blank\">Hel.fi website</a></p>\r\n"
+                format: full_html
+            field_liftup_with_image_design:
+              -
+                value: image-on-right
+            field_liftup_with_image_image:
+              -
+                entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+            field_liftup_with_image_title:
+              -
+                value: 'Liftup with image on the right'
+      -
+        entity:
+          _meta:
+            version: '1.0'
+            entity_type: paragraph
+            uuid: 70eb12d7-58a9-498a-9982-d4ddcae339de
+            bundle: liftup_with_image
+            default_langcode: en
+          default:
+            status:
+              -
+                value: true
+            created:
+              -
+                value: 1614429144
+            behavior_settings:
+              -
+                value: {  }
+            revision_translation_affected:
+              -
+                value: true
+            field_liftup_with_image_desc:
+              -
+                value: "<p>Nullam tempor dui vel sodales mattis. Pellentesque faucibus nunc vitae vehicula mattis. In nisl odio, accumsan eu urna efficitur, viverra euismod erat. Aliquam venenatis vulputate vestibulum.</p>\r\n\r\n<p><a class=\"hds-button hds-button--secondary\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"b62f70bb-3e19-4c21-be5e-621b96169fe1\" data-link-text=\"Example page\" href=\"/node/10\"><span class=\"hds-button__label\">Example page</span></a></p>\r\n"
+                format: full_html
+            field_liftup_with_image_design:
+              -
+                value: background-text-on-left
+            field_liftup_with_image_image:
+              -
+                entity: 923ecd78-00ff-47f9-a017-012b781d6bab
+            field_liftup_with_image_title:
+              -
+                value: 'Liftup with image as background'
     field_has_hero:
       -
         value: true
@@ -1018,9 +1129,6 @@ translations:
             behavior_settings:
               -
                 value: {  }
-            revision_translation_affected:
-              -
-                value: true
             field_hero_bg_color:
               -
                 value: gold

--- a/features/helfi_paragraphs/config/install/core.entity_form_display.paragraph.liftup_with_image.default.yml
+++ b/features/helfi_paragraphs/config/install/core.entity_form_display.paragraph.liftup_with_image.default.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_desc
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_design
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_image
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_title
+    - paragraphs.paragraphs_type.liftup_with_image
+  module:
+    - media_library
+    - text
+id: paragraph.liftup_with_image.default
+targetEntityType: paragraph
+bundle: liftup_with_image
+mode: default
+content:
+  field_liftup_with_image_desc:
+    weight: 3
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_liftup_with_image_design:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_liftup_with_image_image:
+    type: media_library_widget
+    weight: 2
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_liftup_with_image_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/features/helfi_paragraphs/config/install/core.entity_view_display.paragraph.liftup_with_image.default.yml
+++ b/features/helfi_paragraphs/config/install/core.entity_view_display.paragraph.liftup_with_image.default.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_desc
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_design
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_image
+    - field.field.paragraph.liftup_with_image.field_liftup_with_image_title
+    - paragraphs.paragraphs_type.liftup_with_image
+  module:
+    - options
+    - text
+id: paragraph.liftup_with_image.default
+targetEntityType: paragraph
+bundle: liftup_with_image
+mode: default
+content:
+  field_liftup_with_image_desc:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_liftup_with_image_design:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
+  field_liftup_with_image_image:
+    type: entity_reference_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: image
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_liftup_with_image_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_desc.yml
+++ b/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_desc.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_liftup_with_image_desc
+    - paragraphs.paragraphs_type.liftup_with_image
+  module:
+    - text
+id: paragraph.liftup_with_image.field_liftup_with_image_desc
+field_name: field_liftup_with_image_desc
+entity_type: paragraph
+bundle: liftup_with_image
+label: Description
+description: 'Optional short description for liftup block.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_design.yml
+++ b/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_design.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_liftup_with_image_design
+    - paragraphs.paragraphs_type.liftup_with_image
+  module:
+    - options
+id: paragraph.liftup_with_image.field_liftup_with_image_design
+field_name: field_liftup_with_image_design
+entity_type: paragraph
+bundle: liftup_with_image
+label: Design
+description: 'Choose the paragraph design from the dropdown.'
+required: true
+translatable: false
+default_value:
+  -
+    value: image-on-right
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
+++ b/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_liftup_with_image_image
+    - media.type.image
+    - paragraphs.paragraphs_type.liftup_with_image
+id: paragraph.liftup_with_image.field_liftup_with_image_image
+field_name: field_liftup_with_image_image
+entity_type: paragraph
+bundle: liftup_with_image
+label: Image
+description: 'Image to be used as an illustration or as a background of the liftup depending on what design you chose.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_title.yml
+++ b/features/helfi_paragraphs/config/install/field.field.paragraph.liftup_with_image.field_liftup_with_image_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_liftup_with_image_title
+    - paragraphs.paragraphs_type.liftup_with_image
+id: paragraph.liftup_with_image.field_liftup_with_image_title
+field_name: field_liftup_with_image_title
+entity_type: paragraph
+bundle: liftup_with_image
+label: Title
+description: 'Title for the liftup with image block.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_desc.yml
+++ b/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_desc.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_liftup_with_image_desc
+field_name: field_liftup_with_image_desc
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_design.yml
+++ b/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_design.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_liftup_with_image_design
+field_name: field_liftup_with_image_design
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: image-on-right
+      label: 'Image on right'
+    -
+      value: image-on-left
+      label: 'Image on left'
+    -
+      value: background-text-on-right
+      label: 'Background image, text on right'
+    -
+      value: background-text-on-left
+      label: 'Background image, text on left'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_image.yml
+++ b/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_liftup_with_image_image
+field_name: field_liftup_with_image_image
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_title.yml
+++ b/features/helfi_paragraphs/config/install/field.storage.paragraph.field_liftup_with_image_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_liftup_with_image_title
+field_name: field_liftup_with_image_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_desc.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_desc.yml
@@ -1,0 +1,2 @@
+label: Kuvaus
+description: 'Vapaaehtoinen lyhyt kuvaus nostolohkolle.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_design.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_design.yml
@@ -1,0 +1,2 @@
+label: Tyyli
+description: 'Valitse lohkon tyyli alasvetovalikosta.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_image.yml
@@ -1,0 +1,2 @@
+label: Kuva
+description: 'Kuva jota käytetään kuvituskuvana tai taustakuvana lohkossa riippuen siitä minkä tyylin olet lohkolle valinnut.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_title.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.field.paragraph.liftup_with_image.field_liftup_with_image_title.yml
@@ -1,0 +1,2 @@
+label: Otsikko
+description: 'Näkyvä otsikko lohkolle.'

--- a/features/helfi_paragraphs/config/install/language/fi/field.storage.paragraph.field_liftup_with_image_design.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/field.storage.paragraph.field_liftup_with_image_design.yml
@@ -1,0 +1,10 @@
+settings:
+  allowed_values:
+    -
+      label: 'Kuva oikealla'
+    -
+      label: 'Kuva vasemmalla'
+    -
+      label: 'Taustakuva, teksti oikealla'
+    -
+      label: 'Taustakuva, teksti vasemmalla'

--- a/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.liftup_with_image.yml
+++ b/features/helfi_paragraphs/config/install/language/fi/paragraphs.paragraphs_type.liftup_with_image.yml
@@ -1,0 +1,2 @@
+label: 'Kuvallinen nosto'
+description: 'Kuvallinen nosto on melko suuri nostoelementti, jolla voit korostaa sisältöä. Elementti koostuu kuvasta ja sen vieressä olevasta tekstialueesta.'

--- a/features/helfi_paragraphs/config/install/paragraphs.paragraphs_type.liftup_with_image.yml
+++ b/features/helfi_paragraphs/config/install/paragraphs.paragraphs_type.liftup_with_image.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: liftup_with_image
+label: 'Liftup with image'
+icon_uuid: null
+icon_default: null
+description: 'Liftup with image is a fairly large element that you can use to promote content with large image next to the text.'
+behavior_plugins: {  }


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/hdbt:dev-UHF-252-liftup-with-image && composer require drupal/helfi_platform_config:dev-UHF-252-liftup-with-image`
- Run `make new`
- You should now have liftup with image paragraph available in landing pages. Go to https://hel-platform.docker.sh/fi/esimerkki-laskeutumissivusta and scroll down. There should be four example banners for you to check how the element looks like.
- Go to edit the content and add one more liftup with image. You should have options for the liftup with image paragraph design. Links are added to the description field.
- Check that the translations work as well.

Check out also these PRs: 
https://github.com/City-of-Helsinki/drupal-hdbt/pull/52
https://github.com/City-of-Helsinki/drupal-helfi/pull/66