### PR TITLE
UHF-1072: Patch nested paragraphs issue on platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   "extra": {
     "patches": {
       "drupal/core": {
-        "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch"
+        "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
+        "[#UHF-1072] Nested Paragraphs create multiple drag handles (https://www.drupal.org/project/drupal/issues/3092181#comment-13931509)": "https://www.drupal.org/files/issues/2020-12-08/3092181-142-9X_0.patch"
       },
       "drupal/default_content": {
         "https://www.drupal.org/project/default_content/issues/2698425#comment-13809863": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- Switch to corresponding branches: 
   - `composer require drupal/helfi_platform_config:dev-UHF-1072-multiple-paragraph-handles-patch && composer require drupal/hdbt_admin:dev-UHF-1072-multiple-paragraph-handles-bug-fix-removal` NOTICE: Branches have different names depending on the repository.
- `make new`
- Log into the site and edit any content. Make sure there is only one drag handle per draggable item and that you can drag the items to new order.

Also check this PR:
 https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/30