### PR TITLE
UHF-1416: Disable user creation from anyone else except admin

### DIFF
--- a/features/helfi_base_config/config/rewrite/user.settings.yml
+++ b/features/helfi_base_config/config/rewrite/user.settings.yml
@@ -1,0 +1,15 @@
+anonymous: Anonymous
+verify_mail: true
+notify:
+  cancel_confirm: true
+  password_reset: true
+  status_activated: true
+  status_blocked: false
+  status_canceled: false
+  register_admin_created: true
+  register_no_approval_required: true
+  register_pending_approval: true
+register: admin_only
+cancel_method: user_cancel_block
+password_reset_timeout: 86400
+password_strength: true


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- `cd hel-platform`
- Switch to corresponding branches: `composer require drupal/helfi_platform_config:dev-UHF-1416-disable-user-creation-unless-admin`
- `make new`
- Don't login to the site but go to the login page instead and make sure you can't create a new account.

Test also these:
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/5
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/3