### PR TITLE
UHF-X Branding navigation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "drupal/linkit": "^6.0@beta",
     "drupal/media_entity_soundcloud": "^3.0.0",
     "drupal/menu_block_current_language": "^1.5",
+    "drupal/menu_link_attributes": "^1.2",
     "drupal/metatag": "^1.16",
     "drupal/paragraphs": "^1.12",
     "drupal/paragraphs_asymmetric_translation_widgets": "^1.0-beta4",

--- a/features/helfi_base_config/config/install/menu_link_attributes.config.yml
+++ b/features/helfi_base_config/config/install/menu_link_attributes.config.yml
@@ -1,0 +1,13 @@
+attributes:
+  icon:
+    label: ''
+  class:
+    label: ''
+    description: ''
+  target:
+    label: ''
+    description: ''
+    options:
+      _blank: 'New window (_blank)'
+      _self: 'Same window (_self)'
+    default_value: ''

--- a/features/helfi_base_config/helfi_base_config.info.yml
+++ b/features/helfi_base_config/helfi_base_config.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - 'drupal:block'
   - 'drupal:config_translation'
   - 'drupal:field_ui'
+  - 'drupal:menu_link_attributes'
   - 'drupal:menu_link_content'
   - 'drupal:node'
   - 'drupal:system'


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- `cd hel-platform`
- Switch to corresponding branches: 
  - `composer require drupal/hdbt:dev-UHF-X-branding-navigation && composer require drupal/helfi_platform_config:dev-UHF-X-branding-navigation` 
- Run `make new`
- Log into the site and make sure you can add link to the Branding navigation https://hel-platform.docker.so/en/admin/structure/menu/manage/branding-navigation/add
- When adding the link also make sure to check that there is "Attributes" fieldset present and that under it you can add text to "Icon". Write there `signout`
- Save the menu link and go to the front page to see if the link with icon has appeared on the branding navigaton (NOTICE: make sure you view the page with the same language as you created your link)
- Resize the page so that branding navigation gets to mobile size. It should work responsively and the language switcher should hide when you scroll down and pop back when you scroll back up.

Also check these:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/95
https://github.com/City-of-Helsinki/drupal-helfi/pull/125
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/11
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/17