### PR TITLE
UHF-1709: Media library form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "drupal/features": "^3.12",
     "drupal/field_group": "^3.1",
     "drupal/focal_point": "^1.5",
-    "drupal/helfi_media_map": "1.x-dev",
+    "drupal/helfi_media_map": "*",
     "drupal/image_style_quality": "^1.4",
     "drupal/imagecache_external": "^3.0",
     "drupal/linkit": "^6.0@beta",


### PR DESCRIPTION
Switched helfi_media_map module to depend on * instead of 1.x-dev.