### PR TITLE
UHF-910: Add Kuura Health chat bot block

### DIFF
--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -1,0 +1,7 @@
+kuura_health_chat:
+  version: 1.0.x
+  js:
+    https://hel-thk-botti.kuurahealth.com/widget/kuura-chat.js: { type: external, minified: true }
+  css:
+    theme:
+      https://hel-thk-botti.kuurahealth.com/widget/kuura-chat.css: { type: external, minified: true }

--- a/src/Plugin/Block/KuuraHealthChat.php
+++ b/src/Plugin/Block/KuuraHealthChat.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\helfi_platform_config\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'KuuraHealthChat' block.
+ *
+ * @Block(
+ *  id = "kuura_health_chat",
+ *  admin_label = @Translation("Kuura Health Chat"),
+ * )
+ */
+class KuuraHealthChat extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $library = ['helfi_platform_config/kuura_health_chat'];
+    $build = [];
+
+    $build['kuura_health_chat'] = [
+      '#title' => t('Kuura Health Chat'),
+      '#attached' => [
+        'library' => $library,
+      ],
+    ];
+
+    return $build;
+  }
+}

--- a/src/Plugin/Block/KuuraHealthChat.php
+++ b/src/Plugin/Block/KuuraHealthChat.php
@@ -30,4 +30,5 @@ class KuuraHealthChat extends BlockBase {
 
     return $build;
   }
+
 }


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- `cd hel-platform`
- Switch to corresponding branches: 
  - `composer require drupal/hdbt:dev-UHF-910-kuura-chat-bot && composer require drupal/helfi_platform_config:dev-UHF-910-kuura-chat-bot`
- Run `make new`
- Log in to the site and go to https://hel-platform.docker.so/fi/admin/structure/block and you should see a new region "Attachments". Add a block to this region called "Kuura Health Chat". Hide the block title and save.
- Go to site front page and the chat bot should be available on the right bottom corner of the site.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/106
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/26