### PR TITLE
UHF-1775 Footer settings to config ignore 

### DIFF
--- a/features/helfi_base_config/config/install/config_ignore.settings.yml
+++ b/features/helfi_base_config/config/install/config_ignore.settings.yml
@@ -1,2 +1,3 @@
 ignored_config_entities:
   - 'eu_cookie_compliance.cookie_category*'
+  - '*.site_settings'


### PR DESCRIPTION
Test with no previous setup:

1. Run the composer one liner to get the site: `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
2. Go to the newly created folder and switch to correct branch: `composer require drupal/helfi_platform_config:dev-UHF-1775-footer-settings-to-config-ignore`
3. Get the site running: `make new`
4. Log in to the site using the link that the install gives and go to https://hel-platform.docker.so/fi/admin/config/development/configuration/ignore to make sure there is *site_settings line on the configuration.
5. Run `make drush-cex` to get all the config exported.
6. Go to https://hel-platform.docker.so/fi/admin/tools/site-settings and change the site settings (for example write something new to the footer) and save the settings. Make sure the change you did to your footer is visible on the site (make sure you are viewing the site with the language that you made the change to.
7. Run `make drush-cim`
8. The configuration import shouldn't revert your changes and it should say that there is nothing to import.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi/pull/150
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/31
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/40