### PR TITLE
UHF-1734 Basic page changes

### DIFF
--- a/features/helfi_content/config/install/core.entity_form_display.node.page.default.yml
+++ b/features/helfi_content/config/install/core.entity_form_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -28,7 +29,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 12
+    weight: 13
     region: content
     settings:
       title: Paragraph
@@ -71,16 +72,24 @@ content:
     third_party_settings: {  }
     type: paragraphs
     region: content
+  field_lead_in:
+    weight: 12
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
   field_liftup_image:
     type: media_library_widget
-    weight: 3
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_lower_content:
     type: paragraphs
-    weight: 52
+    weight: 19
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -98,7 +107,7 @@ content:
     third_party_settings: {  }
     region: content
   field_metatags:
-    weight: 51
+    weight: 18
     settings:
       sidebar: false
     third_party_settings: {  }
@@ -126,12 +135,12 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 20
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -174,12 +183,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/features/helfi_content/config/install/core.entity_view_display.node.page.default.yml
+++ b/features/helfi_content/config/install/core.entity_view_display.node.page.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -20,13 +21,20 @@ mode: default
 content:
   field_content:
     type: entity_reference_revisions_entity_view
-    weight: 1
+    weight: 2
     region: content
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+  field_lead_in:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
     weight: 4
@@ -37,7 +45,7 @@ content:
     third_party_settings: {  }
     region: content
   field_metatags:
-    weight: 2
+    weight: 3
     label: above
     settings: {  }
     third_party_settings: {  }

--- a/features/helfi_content/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/features/helfi_content/config/install/core.entity_view_display.node.page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_lead_in
     - field.field.node.page.field_liftup_image
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
@@ -30,6 +31,7 @@ hidden:
   field_content: true
   field_has_hero: true
   field_hero: true
+  field_lead_in: true
   field_lower_content: true
   field_metatags: true
   langcode: true

--- a/features/helfi_content/config/install/field.field.node.page.field_lead_in.yml
+++ b/features/helfi_content/config/install/field.field.node.page.field_lead_in.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lead_in
+    - node.type.page
+id: node.page.field_lead_in
+field_name: field_lead_in
+entity_type: node
+bundle: page
+label: Lead-in
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/features/helfi_content/config/install/field.storage.node.field_lead_in.yml
+++ b/features/helfi_content/config/install/field.storage.node.field_lead_in.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_lead_in
+field_name: field_lead_in
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/features/helfi_content/config/install/language/fi/field.field.node.page.field_lead_in.yml
+++ b/features/helfi_content/config/install/language/fi/field.field.node.page.field_lead_in.yml
@@ -1,0 +1,1 @@
+label: Johdanto

--- a/features/helfi_content/config/install/metatag.metatag_defaults.node.yml
+++ b/features/helfi_content/config/install/metatag.metatag_defaults.node.yml
@@ -6,6 +6,7 @@ label: Content
 tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
+  description: '[node:field_lead_in]'
   title: '[node:title] | [site:name]'
   article_modified_time: '[node:created:html_datetime]'
   article_published_time: '[node:created:html_datetime]'


### PR DESCRIPTION
NOTICE: This should be tested and merged AFTER the https://github.com/City-of-Helsinki/drupal-hdbt/pull/124 is merged to avoid conflicts since this feature is partly based on the work done it that PR.

Test with no previous setup:

1. Run the composer one liner to get the site: `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
2. Go to the newly created folder and switch to correct branch: `composer require drupal/helfi_platform_config:dev-UHF-1734-basic-page-changes && composer require drupal/hdbt:dev-UHF-1734-basic-page-changes`
3. Get the site running: `make new`
4. Log in to the site using the link that the install gives and go to create / edit any basic page. There should now be new field "Lead-in" before the content areas. It should be plaintext field. Write something to the field and if you don't have any other content then add some like text paragraphs etc. Save the node and go view it.
6. The new lead-in paragraph should be right under the page title. It should have font size 20px and line height 32px.
7. The lead-in text should also be found from the page meta-data description visible in the page source on head-tag.
8. The content should now be aligned to left on all breakpoints (there used to be 96px margin on left on desktop sizes)
9. There should be sufficient spacing before titles, heros etc. There is a lot of small changes here but the main thing is that the layout doesn't look broken.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/125
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/43
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/34
https://github.com/City-of-Helsinki/drupal-helfi/pull/153