### PR TITLE
UHF-443: Add Smartti Chatbot block

### DIFF
--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -10,3 +10,11 @@ react_and_share:
   version: 1.0.x
   js:
     assets/js/reactAndShareSettings.js: {}
+
+smartti_chatbot:
+  version: 1.0.x
+  js:
+    'https://cdn.smartifik.com/files/clients/helsingin_kaupunki/smartti_client.js': { type: external, minified: true }
+  css:
+    theme:
+      'https://cdn.smartifik.com/files/clients/helsingin_kaupunki/smartti_client.css': { type: external, minified: true }

--- a/src/Plugin/Block/SmarttiChatbot.php
+++ b/src/Plugin/Block/SmarttiChatbot.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Drupal\helfi_platform_config\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'SmarttiChatbot' block.
+ *
+ * @Block(
+ *  id = "smartti_chatbot",
+ *  admin_label = @Translation("Smartti Chatbot"),
+ * )
+ */
+class SmarttiChatbot extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $library = ['helfi_platform_config/smartti_chatbot'];
+    $build = [];
+
+    $build['smartti_chatbot'] = [
+      '#title' => t('Smartti Chatbot'),
+      '#attached' => [
+        'library' => $library,
+      ],
+    ];
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
Testing:
* If you don't already have a site for testing, create one:
  * `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
  * `cd hel-platform`
  * `make new`
* Update the module to include the changes: `composer require drupal/helfi_platform_config:dev-UHF-443-smartti-chatbot`
* Clear caches.
* Log-in to the site.
* From the block layout page (`/admin/structure/block`) add "Smartti Chatbot" block to the "Attachments" section.
* Check that the Chatbot ("Kysy robotilta") is shown at the page(s) specified at the block configuration. By default, the block is placed to all content pages.