### PR TITLE
UHF-2005 General fixes

### DIFF
--- a/features/helfi_media_map_config/config/install/language/fi/core.entity_view_display.media.hel_map.default.yml
+++ b/features/helfi_media_map_config/config/install/language/fi/core.entity_view_display.media.hel_map.default.yml
@@ -1,0 +1,4 @@
+content:
+  field_media_hel_map:
+    settings:
+      link_title: 'Avaa kartta uudessa ikkunassa'


### PR DESCRIPTION
How to test (if you have no setup etc.):
- `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
- `cd hel-platform`
- Switch to corresponding branches: 
  - `composer require drupal/hdbt:dev-UHF-2005-general-fixes && composer require drupal/helfi_platform_config:dev-UHF-2005-general-fixes && composer require drupal/helfi_tpr:dev-UHF-2005-general-fixes`
- Run `make new`
- Log in and go to add a landing page.
- Add a map to the content and view the landing page. If the maps is added to Finnish page the "Open map in a new window" should be translated now. If on English side the map should say the English version.
- Edit the same landing page and add unit search as the first paragraph on the page. Also add a hero with such design that has korofigure on the bottom of the hero-block. Save the page and check that the unit search gray background goes under the hero block.
- Add some quite long menu item to the main-menu first level and add some children to it. Go to view the desktop version of the menu and hover with mouse over the first level item. The secondary menu that becomes visible after hovering over the first menu item should be reference its width from the first level item. It should be as wide as the first level item and have some 32px paddings on both sides.
- Go to view a unit with services. You should see the services listed as second last item if you have React and share enabled. The services shouldn't go under the React and share block. Now remove the React and share block from dom. The services block gray background should go under the footer.
- Now check the same thing with a service with units and its "units that offer this service" block.