### PR TITLE
UHF-2295: TPR url alias fix

### DIFF
--- a/features/helfi_tpr_config/config/install/pathauto.pattern.service_entity_pattern.yml
+++ b/features/helfi_tpr_config/config/install/pathauto.pattern.service_entity_pattern.yml
@@ -1,0 +1,14 @@
+uuid: 676c86ed-b8c2-450a-b77b-672a2b037f03
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: service_entity_pattern
+label: 'Service entity pattern'
+type: 'canonical_entities:tpr_service'
+pattern: '[tpr_service:menu-link-parents]/[tpr_service:label]'
+selection_criteria: {  }
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/features/helfi_tpr_config/config/install/pathauto.pattern.unit_entity_pattern.yml
+++ b/features/helfi_tpr_config/config/install/pathauto.pattern.unit_entity_pattern.yml
@@ -1,0 +1,14 @@
+uuid: 8f858873-d7e9-472d-b521-106c30c5783d
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+id: unit_entity_pattern
+label: 'Unit entity pattern'
+type: 'canonical_entities:tpr_unit'
+pattern: '[tpr_unit:menu-link-parents]/[tpr_unit:label]'
+selection_criteria: {  }
+selection_logic: and
+weight: 0
+relationships: {  }

--- a/features/helfi_tpr_config/config/install/pathauto.settings.yml
+++ b/features/helfi_tpr_config/config/install/pathauto.settings.yml
@@ -1,0 +1,54 @@
+enabled_entity_types:
+  - tpr_service
+  - tpr_unit
+  - user
+punctuation:
+  double_quotes: 0
+  quotes: 0
+  backtick: 0
+  comma: 0
+  period: 0
+  hyphen: 1
+  underscore: 0
+  colon: 0
+  semicolon: 0
+  pipe: 0
+  left_curly: 0
+  left_square: 0
+  right_curly: 0
+  right_square: 0
+  plus: 0
+  equal: 0
+  asterisk: 0
+  ampersand: 0
+  percent: 0
+  caret: 0
+  dollar: 0
+  hash: 0
+  at: 0
+  exclamation: 0
+  tilde: 0
+  left_parenthesis: 0
+  right_parenthesis: 0
+  question_mark: 0
+  less_than: 0
+  greater_than: 0
+  slash: 0
+  back_slash: 0
+verbose: false
+separator: '-'
+max_length: 100
+max_component_length: 100
+transliterate: true
+reduce_ascii: false
+case: true
+ignore_words: ''
+update_action: 2
+safe_tokens:
+  - alias
+  - path
+  - join-path
+  - login-url
+  - url
+  - url-brief
+  - menu-link-parents


### PR DESCRIPTION
How to test:

1. Setup a fresh environment
2. Checkout this branch: `composer require drupal/helfi_platform_config:dev-UHF-2295_tpr_url_alias_fix`
3. Install the site: `make new`
4. Enable the HELfi TPR Config feature: `drush en -y helfi_tpr_config`
5. Login to the site as admin
6. See `/admin/config/search/path/settings` and make sure that `menu-link-parents` is listed in the `Safe tokens` field
7. See `/admin/config/search/path/patterns` and make sure that
- `Service entity pattern` is `[tpr_service:menu-link-parents]/[tpr_service:label]`
- `Unit entity pattern` is `[tpr_unit:menu-link-parents]/[tpr_unit:label]`