### PR TITLE
UHF-833 Announcements

### DIFF
--- a/helfi_features/helfi_announcements/config/install/core.base_field_override.node.announcement.promote.yml
+++ b/helfi_features/helfi_announcements/config/install/core.base_field_override.node.announcement.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement.promote
+field_name: promote
+entity_type: node
+bundle: announcement
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/helfi_features/helfi_announcements/config/install/core.entity_form_display.node.announcement.default.yml
+++ b/helfi_features/helfi_announcements/config/install/core.entity_form_display.node.announcement.default.yml
@@ -1,0 +1,156 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_announcement_all_pages
+    - field.field.node.announcement.field_announcement_content_pages
+    - field.field.node.announcement.field_announcement_link
+    - field.field.node.announcement.field_announcement_service_pages
+    - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_announcement_unit_pages
+    - node.type.announcement
+  module:
+    - hdbt_admin_editorial
+    - link
+    - path
+    - scheduler
+    - select2
+    - text
+id: node.announcement.default
+targetEntityType: node
+bundle: announcement
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 15
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_announcement_all_pages:
+    weight: 11
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_announcement_content_pages:
+    weight: 12
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      autocomplete: false
+      width: 100%
+    third_party_settings: {  }
+    type: select2_entity_reference
+    region: content
+  field_announcement_link:
+    weight: 16
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_announcement_service_pages:
+    weight: 14
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      autocomplete: false
+      width: 100%
+    third_party_settings: {  }
+    type: select2_entity_reference
+    region: content
+  field_announcement_type:
+    weight: 10
+    settings:
+      width: 100%
+    third_party_settings: {  }
+    type: select2
+    region: content
+  field_announcement_unit_pages:
+    weight: 13
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      autocomplete: false
+      width: 100%
+    third_party_settings: {  }
+    type: select2_entity_reference
+    region: content
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 8
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  promote: true
+  sticky: true
+  url_redirects: true

--- a/helfi_features/helfi_announcements/config/install/core.entity_view_display.node.announcement.default.yml
+++ b/helfi_features/helfi_announcements/config/install/core.entity_view_display.node.announcement.default.yml
@@ -1,0 +1,59 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_announcement_all_pages
+    - field.field.node.announcement.field_announcement_content_pages
+    - field.field.node.announcement.field_announcement_link
+    - field.field.node.announcement.field_announcement_service_pages
+    - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_announcement_unit_pages
+    - node.type.announcement
+  module:
+    - link
+    - options
+    - text
+    - user
+id: node.announcement.default
+targetEntityType: node
+bundle: announcement
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_announcement_link:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_announcement_type:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  links:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_announcement_all_pages: true
+  field_announcement_content_pages: true
+  field_announcement_service_pages: true
+  field_announcement_unit_pages: true
+  langcode: true

--- a/helfi_features/helfi_announcements/config/install/core.entity_view_display.node.announcement.teaser.yml
+++ b/helfi_features/helfi_announcements/config/install/core.entity_view_display.node.announcement.teaser.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.announcement.body
+    - field.field.node.announcement.field_announcement_all_pages
+    - field.field.node.announcement.field_announcement_content_pages
+    - field.field.node.announcement.field_announcement_link
+    - field.field.node.announcement.field_announcement_service_pages
+    - field.field.node.announcement.field_announcement_type
+    - field.field.node.announcement.field_announcement_unit_pages
+    - node.type.announcement
+  module:
+    - text
+    - user
+id: node.announcement.teaser
+targetEntityType: node
+bundle: announcement
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_announcement_all_pages: true
+  field_announcement_content_pages: true
+  field_announcement_link: true
+  field_announcement_service_pages: true
+  field_announcement_type: true
+  field_announcement_unit_pages: true
+  langcode: true

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.body.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.announcement
+  module:
+    - text
+id: node.announcement.body
+field_name: body
+entity_type: node
+bundle: announcement
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.body.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.body.yml
@@ -5,18 +5,24 @@ dependencies:
     - field.storage.node.body
     - node.type.announcement
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    minimal: minimal
+    full_html: '0'
+    plain_text: '0'
 id: node.announcement.body
 field_name: body
 entity_type: node
 bundle: announcement
 label: Body
-description: ''
-required: false
+description: 'Please note that title is not shown alongside with the body text.'
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  display_summary: true
+  display_summary: false
   required_summary: false
 field_type: text_with_summary

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_all_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_all_pages.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_all_pages
+    - node.type.announcement
+id: node.announcement.field_announcement_all_pages
+field_name: field_announcement_all_pages
+entity_type: node
+bundle: announcement
+label: 'Show on all pages'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_content_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_content_pages.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_content_pages
+    - node.type.announcement
+    - node.type.article
+    - node.type.landing_page
+    - node.type.page
+id: node.announcement.field_announcement_content_pages
+field_name: field_announcement_content_pages
+entity_type: node
+bundle: announcement
+label: 'Show on content pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+      page: page
+      landing_page: landing_page
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: article
+field_type: entity_reference

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_link.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_link.yml
@@ -18,5 +18,5 @@ default_value: {  }
 default_value_callback: ''
 settings:
   link_type: 17
-  title: 0
+  title: 2
 field_type: link

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_link.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_link
+    - node.type.announcement
+  module:
+    - link
+id: node.announcement.field_announcement_link
+field_name: field_announcement_link
+entity_type: node
+bundle: announcement
+label: Link
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 0
+field_type: link

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_service_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_service_pages.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_service_pages
+    - node.type.announcement
+id: node.announcement.field_announcement_service_pages
+field_name: field_announcement_service_pages
+entity_type: node
+bundle: announcement
+label: 'Show on service pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:tpr_service'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_type.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_type
+    - node.type.announcement
+  module:
+    - options
+id: node.announcement.field_announcement_type
+field_name: field_announcement_type
+entity_type: node
+bundle: announcement
+label: Type
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_unit_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.field.node.announcement.field_announcement_unit_pages.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_announcement_unit_pages
+    - node.type.announcement
+id: node.announcement.field_announcement_unit_pages
+field_name: field_announcement_unit_pages
+entity_type: node
+bundle: announcement
+label: 'Show on unit pages'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:tpr_unit'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: name
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_all_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_all_pages.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_announcement_all_pages
+field_name: field_announcement_all_pages
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_content_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_content_pages.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_announcement_content_pages
+field_name: field_announcement_content_pages
+entity_type: node
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_link.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_announcement_link
+field_name: field_announcement_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_service_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_service_pages.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - node
+id: node.field_announcement_service_pages
+field_name: field_announcement_service_pages
+entity_type: node
+type: entity_reference
+settings:
+  target_type: tpr_service
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_type.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_type.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_announcement_type
+field_name: field_announcement_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: notification
+      label: Notification
+    -
+      value: attention
+      label: Attention
+    -
+      value: alert
+      label: Alert
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_unit_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/field.storage.node.field_announcement_unit_pages.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - node
+id: node.field_announcement_unit_pages
+field_name: field_announcement_unit_pages
+entity_type: node
+type: entity_reference
+settings:
+  target_type: tpr_unit
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_announcements/config/install/language.content_settings.node.announcement.yml
+++ b/helfi_features/helfi_announcements/config/install/language.content_settings.node.announcement.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.announcement
+target_entity_type_id: node
+target_bundle: announcement
+default_langcode: fi
+language_alterable: true

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.body.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.body.yml
@@ -1,0 +1,2 @@
+label: Sisältö
+description: 'Huomioithan, että otsikkoa ei näytetä sisältötekstin yhteydessä.'

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_all_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_all_pages.yml
@@ -1,0 +1,1 @@
+label: 'Näytä kaikilla sivuilla'

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_content_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_content_pages.yml
@@ -1,0 +1,1 @@
+label: 'Näytä sisältösivuilla'

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_link.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_link.yml
@@ -1,0 +1,1 @@
+label: Linkki

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_service_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_service_pages.yml
@@ -1,0 +1,1 @@
+label: 'Näytä palvelusivuilla'

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_type.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_type.yml
@@ -1,0 +1,1 @@
+label: Tyyppi

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_unit_pages.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.field.node.announcement.field_announcement_unit_pages.yml
@@ -1,0 +1,1 @@
+label: 'Näytä toimipistesivuilla'

--- a/helfi_features/helfi_announcements/config/install/language/fi/field.storage.node.field_announcement_type.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/field.storage.node.field_announcement_type.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: Ilmoitus
+    -
+      label: Huomio
+    -
+      label: Hälytys

--- a/helfi_features/helfi_announcements/config/install/language/fi/node.type.announcement.yml
+++ b/helfi_features/helfi_announcements/config/install/language/fi/node.type.announcement.yml
@@ -1,0 +1,2 @@
+name: Poikkeusilmoitus
+description: 'Poikkeusilmoituksien avulla eri sivuilla voidaan näyttää ilmoituksia, huomioilmoituksia ja hälytysilmoituksia.'

--- a/helfi_features/helfi_announcements/config/install/node.type.announcement.yml
+++ b/helfi_features/helfi_announcements/config/install/node.type.announcement.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    show_message_after_update: true
+    unpublish_enable: true
+    unpublish_required: false
+    unpublish_revision: false
+name: Announcement
+type: announcement
+description: 'Content type for announcements that can be used to show notifications, attentions and alerts on different pages.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/helfi_features/helfi_announcements/helfi_announcements.info.yml
+++ b/helfi_features/helfi_announcements/helfi_announcements.info.yml
@@ -1,0 +1,10 @@
+name: 'HELfi Announcements'
+type: module
+description: 'Adds announcements that can be shown on other pages.'
+core_version_requirement: '^8.9 || ^9'
+package: HELfi
+dependencies:
+  - 'helfi_content:helfi_content'
+  - 'helfi_tpr:helfi_tpr'
+  - 'select2:select2'
+  - 'update_helper:update_helper'

--- a/helfi_features/helfi_announcements/helfi_announcements.module
+++ b/helfi_features/helfi_announcements/helfi_announcements.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function helfi_announcements_form_node_form_alter(&$form, &$form_state, $form_id) {
+  switch ($form_id) {
+    case 'node_announcement_edit_form':
+    case 'node_announcement_form':
+      $form['field_announcement_content_pages']['#states'] =
+      $form['field_announcement_unit_pages']['#states'] =
+      $form['field_announcement_service_pages']['#states'] =  [
+        'visible' => [
+          ':input[name="field_announcement_all_pages[value]"]' => ['checked' => FALSE],
+        ],
+      ];
+      break;
+  }
+}

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\helfi_announcements\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -151,11 +152,21 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
 
   /**
    * {@inheritdoc}
-   *
-   * @todo Make cacheable.
    */
-  public function getCacheMaxAge(): int {
-    return 0;
+  public function getCacheContexts(): array {
+    return Cache::mergeContexts(parent::getCacheContexts(), [
+      'user.permissions',
+      'url.path',
+      'url.query_args',
+      'languages:language_content',
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags(): array {
+    return Cache::mergeTags(parent::getCacheTags(), ['node_list:announcement']);
   }
 
 }

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -149,4 +149,13 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
     return NULL;
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * @todo Make cacheable.
+   */
+  public function getCacheMaxAge(): int {
+    return 0;
+  }
+
 }

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -24,21 +24,21 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * The current route match.
    *
-   * @var RouteMatchInterface
+   * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   protected RouteMatchInterface $routeMatch;
 
   /**
    * The node storage.
    *
-   * @var EntityTypeManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
    * The language manager.
    *
-   * @var LanguageManagerInterface
+   * @var \Drupal\Core\Language\LanguageManagerInterface
    */
   protected LanguageManagerInterface $languageManager;
 
@@ -51,11 +51,11 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param RouteMatchInterface $route_match
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The current route match.
-   * @param EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param LanguageManagerInterface $language_manager
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, EntityTypeManagerInterface $entity_type_manager, LanguageManagerInterface $language_manager) {
@@ -92,7 +92,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
     // Get all published announcement nodes.
     $nids = \Drupal::entityQuery('node')
       ->accessCheck(TRUE)
-      ->condition('type','announcement')
+      ->condition('type', 'announcement')
       ->condition('status', NodeInterface::PUBLISHED)
       ->condition('langcode', $this->languageManager->getCurrentLanguage()->getId())
       ->execute();
@@ -136,7 +136,8 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    *
    * @param array $entityTypes
    *   Entity names to be used to check the current page.
-   * @return EntityInterface|null
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
    *   Current page's entity, if any.
    */
   protected function getCurrentPageEntity(array $entityTypes): ?EntityInterface {

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Drupal\helfi_announcements\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an 'Announcements' block.
+ *
+ * @Block(
+ *   id = "announcements",
+ *   admin_label = @Translation("Announcements"),
+ * )
+ */
+class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The current route match.
+   *
+   * @var RouteMatchInterface
+   */
+  protected RouteMatchInterface $routeMatch;
+
+  /**
+   * The node storage.
+   *
+   * @var EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The language manager.
+   *
+   * @var LanguageManagerInterface
+   */
+  protected LanguageManagerInterface $languageManager;
+
+  /**
+   * Constructs a new AnnouncementsBlock instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param RouteMatchInterface $route_match
+   *   The current route match.
+   * @param EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, EntityTypeManagerInterface $entity_type_manager, LanguageManagerInterface $language_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('entity_type.manager'),
+      $container->get('language_manager'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    // Entity types supported by announcements and the corresponding field
+    // names.
+    $entityTypeFields = [
+      'node' => 'field_announcement_content_pages',
+      'tpr_unit' => 'field_announcement_unit_pages',
+      'tpr_service' => 'field_announcement_service_pages',
+    ];
+
+    $currentEntity = $this->getCurrentPageEntity(array_keys($entityTypeFields));
+
+    // Get all published announcement nodes.
+    $nids = \Drupal::entityQuery('node')
+      ->accessCheck(TRUE)
+      ->condition('type','announcement')
+      ->condition('status', NodeInterface::PUBLISHED)
+      ->condition('langcode', $this->languageManager->getCurrentLanguage()->getId())
+      ->execute();
+    $announcementNodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
+
+    $showAnnouncements = [];
+    foreach ($announcementNodes as $announcementNode) {
+      // Check if the announcement should be shown at all pages.
+      if ($announcementNode->get('field_announcement_all_pages')->value === "1") {
+        $showAnnouncements[] = $announcementNode;
+        continue;
+      }
+
+      if (empty($currentEntity)) {
+        continue;
+      }
+
+      // Get announcement's referenced entities from the appropriate field,
+      // depending on the current page's entity.
+      $referencedEntities = $announcementNode->get($entityTypeFields[$currentEntity->getEntityType()->id()])->referencedEntities();
+
+      // Add announcement to showed announcements if current page's entity
+      // is found from the list of referenced entities.
+      foreach ($referencedEntities as $referencedEntity) {
+        if ($referencedEntity->id() === $currentEntity->id()) {
+          $showAnnouncements[] = $announcementNode;
+        }
+      }
+    }
+
+    if (empty($showAnnouncements)) {
+      return [];
+    }
+
+    $viewMode = 'default';
+    return $this->entityTypeManager->getViewBuilder('node')->viewMultiple($showAnnouncements, $viewMode);
+  }
+
+  /**
+   * Get current page's entity from given possibilities.
+   *
+   * @param array $entityTypes
+   *   Entity names to be used to check the current page.
+   * @return EntityInterface|null
+   *   Current page's entity, if any.
+   */
+  protected function getCurrentPageEntity(array $entityTypes): ?EntityInterface {
+    foreach ($entityTypes as $entityType) {
+      if (!empty($this->routeMatch->getParameter($entityType))) {
+        return $this->routeMatch->getParameter($entityType);
+      }
+    }
+    return NULL;
+  }
+
+}


### PR DESCRIPTION
How to test:
* If you don't already have a site for testing, create one:
  * `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
  * `cd hel-platform`
  * `make new`

* Update the platform config module to include changes: `composer require drupal/helfi_platform_config:dev-UHF-833-announcements`

* Enable the new Announcements module (using `make shell`): `drush en -y helfi_announcements`

* Make sure you have some node content.

* Make sure you have some content imported from TPR. Using `make shell`:
  * `MIGRATE_LIMIT=50 drush migrate:import tpr_unit`
  * `drush migrate:import tpr_errand_service`
  * `drush migrate:import tpr_service`
  * `drush migrate:import tpr_service_channel`

* Go to the "Block layout" admin page and add "Announcements" block on top of the "Before content" section.

* From the "Add content" admin page, add some new announcements with different types.
  * Add one that is shown on all pages.
  * Add some that are shown on specific pages.
  * Add some that are unpublished and should not be visible.
  * Add some with different languages / translate announcements.

* Check that the announcements are shown at correct pages.
  * It should be possible to show announcements on all pages.
  * It should be possible to show announcements on specific nodes, TPR Unit pages and TPR Service pages.
  * **Especially check that the block is cached correctly**: after editing announcements, correct announcements are shown at correct pages.

Also check the related, site specific PRs:
* [drupal-helfi/pull/191](https://github.com/City-of-Helsinki/drupal-helfi/pull/191)
* [drupal-helfi-sote/pull/84](https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/84)
* [drupal-helfi-kymp/pull/79](https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/79)
* [drupal-helfi-strategia/pull/35](https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/35)