### PR TITLE
UHF-2520: Translate service list correctly

### DIFF
--- a/helfi_features/helfi_tpr_config/config/install/language/fi/views.view.service_list.yml
+++ b/helfi_features/helfi_tpr_config/config/install/language/fi/views.view.service_list.yml
@@ -1,0 +1,31 @@
+display:
+  default:
+    display_title: Isäntä
+    display_options:
+      exposed_form:
+        options:
+          submit_button: Käytä
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      pager:
+        options:
+          tags:
+            previous: '‹ Edellinen'
+            next: 'Seuraava ›'
+          expose:
+            items_per_page_label: 'Merkintöjä sivua kohti'
+            items_per_page_options_all_label: '- Kaikki -'
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Lataa lisää palveluita'
+      fields:
+        name:
+          separator: ', '
+      arguments:
+        id:
+          exception:
+            title: Kaikki
+  service_units:
+    display_title: Lohko

--- a/helfi_features/helfi_tpr_config/config/install/language/sv/views.view.service_list.yml
+++ b/helfi_features/helfi_tpr_config/config/install/language/sv/views.view.service_list.yml
@@ -1,0 +1,8 @@
+display:
+  default:
+    display_options:
+      pager:
+        options:
+          views_infinite_scroll:
+            button_text: 'Ladda fler tjänster'
+

--- a/helfi_features/helfi_tpr_config/config/install/views.view.service_list.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.service_list.yml
@@ -65,7 +65,7 @@ display:
             offset: false
             offset_label: Offset
           views_infinite_scroll:
-            button_text: 'Load more results'
+            button_text: 'Load more services'
             automatically_load_content: false
             initially_load_all_pages: false
       style:


### PR DESCRIPTION
How to test:

* `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main hel-platform --no-interaction --repository https://repository.drupal.hel.ninja/`
* `cd hel-platform`
* `make new`
* Update the platform config module to include changes: `composer require drupal/helfi_platform_config:dev-UHF-2520_service_list_paragraph_translations`
* Make sure you have some services imported from TPR. Using `make shell`:
  * `drush en -y helfi_tpr_config`
  * `drush migrate:import tpr_service`
* Create a landing page with paragraph "Service list" and add at least 5 services.
* Save the page and make sure the load more button says "Load more services" and result counter says "5 services".
* Make sure the values are translated to Finnish as well.

Also check these PRs:
https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/34
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/77
https://github.com/City-of-Helsinki/drupal-helfi/pull/192
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/82
https://github.com/City-of-Helsinki/drupal-hdbt/pull/146