### PR TITLE
UHF-2158: Fix creating and translating terms

### DIFF
--- a/helfi_features/helfi_tpr_unit_districts/modules/helfi_helsinki_neighbourhoods/helfi_helsinki_neighbourhoods.install
+++ b/helfi_features/helfi_tpr_unit_districts/modules/helfi_helsinki_neighbourhoods/helfi_helsinki_neighbourhoods.install
@@ -188,10 +188,10 @@ function helfi_helsinki_neighbourhoods_install() {
     "Östersundom",
   ];
 
-  $defaultLangcode = Drupal::configFactory()->get('language.content_settings.taxonomy_term.neighbourhoods')->getOriginal('default_langcode');
+  $defaultLangcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
   $languages = Drupal::languageManager()->getLanguages();
   unset($languages[$defaultLangcode]);
-  $langcodes = array_keys($languages);
+  $otherLangcodes = array_keys($languages);
 
   // Add terms for the default language.
   foreach ($neighbourhoods as $neighbourhood) {
@@ -199,6 +199,7 @@ function helfi_helsinki_neighbourhoods_install() {
       'parent' => [],
       'name' => $neighbourhood,
       'vid' => 'neighbourhoods',
+      'langcode' => $defaultLangcode,
     ]);
     try {
       $term->save();
@@ -211,7 +212,7 @@ function helfi_helsinki_neighbourhoods_install() {
     }
 
     // Add default translations for all available languages.
-    foreach ($langcodes as $langcode) {
+    foreach ($otherLangcodes as $langcode) {
       try {
         $term->addTranslation($langcode, [
           'name' => $neighbourhood,


### PR DESCRIPTION
Fixes creating and translating terms when installing the Helsinki neighbourhoods module.

How to test:
* It's easiest to test with the `sote` site, where this module is used.
  * Checkout branch `UHF-2158-sote-district-search`.
* Get the new changes from this PR: `composer require drupal/helfi_platform_config:dev-UHF-2158-district-search-terms-fix`
* Run `make fresh` or `make new`.
  * At this point, remember to have the `DRUPAL_SYNC_FILES=no` at the .env file so that the `make fresh` command actually finishes.
* There shouldn't be any error messages related to translating terms.
* (You can also check that there is `neighbourhoods`taxonomy and it has a lot of terms.)