### PR TITLE
UHF-X fixed linkit link path to translation [WIP]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
         "https://www.drupal.org/project/paragraphs_asymmetric_translation_widgets/issues/3171810#comment-13836806": "https://www.drupal.org/files/issues/2020-09-25/3171810-2.patch"
       },
       "drupal/linkit": {
-        "[#UHF-1872] Linkit support for link field": "https://www.drupal.org/files/issues/2021-08-20/avoid-linkit-CI-issue.patch"
+        "[#UHF-1872] Linkit support for link field": "https://www.drupal.org/files/issues/2021-08-20/avoid-linkit-CI-issue.patch",
+        "[#UHF-2529] Linkit to translation": "https://www.drupal.org/files/issues/2021-07-22/fix-entity-patch-in-autocomplete-3224985-1.patch"
       }
     }
   }


### PR DESCRIPTION
This PR applies a patch which fixes linkit modules autocomplete.

How to test:

Start with an existing instance
Run composer require drupal/helfi_platform_config:dev-UHF-2529_linkit_translation_fix
Run composer update, Ensure that the patch has been applied to Linkit module.

make drush-cr

Decide a language you want to test this with. The original problem was that if an internal link was added to finnish page's wysiwyg, the link would lead to english entity.

- (If you don't have any existing data, import some TPR entities or create some content yourself before proceeding)
- Go edit any finnish or swedish content page which has a wysiwyg on it.
- Add a link to the wysiwyg editor's content area.
- The popup opens, leave the protocol empty
- Start writing in the url field, let Linkit offer you internal links
- Select something from the autocomplete list.

After you have selected something from the autocomplete list, the url field should be filled with the content's internal path (including the language code) instead of node/{id} or tpr_service/{id}.

Save the link and content and go test the link. It should lead to a page with correct language.