### PR TITLE
Matomo patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,9 @@
       },
       "drupal/linkit": {
         "[#UHF-1872] Linkit support for link field": "https://www.drupal.org/files/issues/2021-08-20/avoid-linkit-CI-issue.patch"
+      },
+      "drupal/matomo": {
+        "https://www.drupal.org/project/matomo/issues/3244555#comment-14261524": "https://www.drupal.org/files/issues/2021-10-19/3244555_matomo_strict.patch"
       }
     }
   }


### PR DESCRIPTION
Latest version (8.x-1.12) of the Matomo module introduced a bug, which this patch fixes. See issue: https://www.drupal.org/project/matomo/issues/3244555.