### PR TITLE
Uhf x menu external link translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "drupal/siteimprove": "^1.11",
     "drupal/token": "^1.9",
     "drupal/token_filter": "^1.2",
+    "drupal/translatable_menu_link_uri": "^2.0",
     "drupal/update_helper": "^2.0"
   },
   "extra": {

--- a/helfi_features/helfi_base_config/helfi_base_config.info.yml
+++ b/helfi_features/helfi_base_config/helfi_base_config.info.yml
@@ -36,6 +36,7 @@ dependencies:
   - 'pathauto:pathauto'
   - 'select2_icon:select2_icon'
   - 'simple_sitemap:simple_sitemap'
+
   - 'token:token'
   - 'twig_tweak:twig_tweak'
   - 'update_helper:update_helper'

--- a/helfi_features/helfi_base_config/helfi_base_config.info.yml
+++ b/helfi_features/helfi_base_config/helfi_base_config.info.yml
@@ -36,7 +36,7 @@ dependencies:
   - 'pathauto:pathauto'
   - 'select2_icon:select2_icon'
   - 'simple_sitemap:simple_sitemap'
-
+  - 'translatable_menu_link_uri:translatable_menu_link_uri'
   - 'token:token'
   - 'twig_tweak:twig_tweak'
   - 'update_helper:update_helper'

--- a/helfi_platform_config.info.yml
+++ b/helfi_platform_config.info.yml
@@ -8,4 +8,3 @@ dependencies:
   - 'helfi_api_base:helfi_api_base'
   - 'menu_block_current_language:menu_block_current_language'
   - 'update_helper:update_helper'
-  - 'translatable_menu_link_uri:translatable_menu_link_uri'

--- a/helfi_platform_config.info.yml
+++ b/helfi_platform_config.info.yml
@@ -8,3 +8,4 @@ dependencies:
   - 'helfi_api_base:helfi_api_base'
   - 'menu_block_current_language:menu_block_current_language'
   - 'update_helper:update_helper'
+  - 'translatable_menu_link_uri:translatable_menu_link_uri'

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -151,3 +151,14 @@ function helfi_platform_config_update_9004() {
     ]);
   }
 }
+
+/**
+ * Install menu external link translation module if it doesn't exist.
+ */
+function helfi_platform_config_update_9005() {
+  if (!Drupal::moduleHandler()->moduleExists('translatable_menu_link_uri')) {
+    Drupal::service('module_installer')->install([
+      'translatable_menu_link_uri',
+    ]);
+  }
+}


### PR DESCRIPTION
Added menu external link translation module to platform_config.

Test this with existing site and new site:

**Existing site with the module already installed (sote, kymp, strategia):**
Site should be up and running
Run `composer require drupal/helfi_platform_config:dev-UHF-X_menu_external_link_translation`
Run `drush deploy`
Go check existing menu item from /admin/structure/menu/manage/main

You should see:
new override field for the link field.

**New site(kasko/elo):**
Run `git clone https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus.git`
Run `composer require drupal/helfi_platform_config:dev-UHF-X_menu_external_link_translation`
Run make new
Create new menu item by going to /admin/structure/menu/manage/main

You should see:
new override field for the link field.