### PR TITLE
UHF-3087: non-published menu links as parent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
       "drupal/core": {
         "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
         "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
-        "[#UHF-949] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2020-11-29/2858890-58.patch"
+        "[#UHF-949] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2020-11-29/2858890-58.patch",
+        "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch"
       },
       "drupal/default_content": {
         "https://www.drupal.org/project/default_content/issues/2698425#comment-13809863": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"


### PR DESCRIPTION
Allows selecting a menu item of an unpublished node as a parent when placing an entity in the menu. See the original issue: https://www.drupal.org/project/drupal/issues/2807629

How to test:

1. Set up any site instance
2. Create a node and place it in a menu but leave it unpublished
3. Create another node and try to put in in a menu using the previously created node as parent → no can do (the unpublished node is not in the dropdown)
4. Checkout this branch of the module: `composer require drupal/helfi_platform_config:dev-UHF-3087_non_published_navigation`
5. Install patched core: `composer install`
6. Repeat step 3 → can do!