### PR TITLE
UHF-2916: Remove highlight component from WYSIWYG and fix buttons around the site.

### DIFF
--- a/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
+++ b/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
@@ -31,7 +31,7 @@ settings:
         -
           name: Media
           items:
-            - quote
+            1: quote
         -
           name: Links
           items:

--- a/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
+++ b/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
@@ -31,7 +31,6 @@ settings:
         -
           name: Media
           items:
-            - highlight
             - quote
         -
           name: Links

--- a/helfi_features/helfi_content/config/install/filter.format.full_html.yml
+++ b/helfi_features/helfi_content/config/install/filter.format.full_html.yml
@@ -22,7 +22,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type> <li class> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class=" highlighted">'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type> <li class> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class="">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
@@ -7,16 +7,15 @@ editor.editor.full_html:
             - name: Media
               items:
                 - highlight
-                - quote
   update_actions:
-    change:
+    delete:
       settings:
         toolbar:
           rows:
             -
               - name: Media
                 items:
-                  - quote
+                  - highlight
 filter.format.full_html:
   expected_config:
     filters:

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
@@ -1,0 +1,31 @@
+editor.editor.full_html:
+  expected_config:
+    settings:
+      toolbar:
+        rows:
+          -
+            - name: Media
+              items:
+                - highlight
+                - quote
+  update_actions:
+    change:
+      settings:
+        toolbar:
+          rows:
+            -
+              - name: Media
+                items:
+                  - quote
+filter.format.full_html:
+  expected_config:
+    filters:
+      filter_html:
+        settings:
+          allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type> <li class> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class=" highlighted">'
+  update_actions:
+    change:
+      filters:
+        filter_html:
+          settings:
+            allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type class> <ol start type> <li class> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role arial-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-icon data-protocol class=""> <pre> <iframe allowfullscreen frameborder height mozallowfullscreen src webkitallowfullscreen width id> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role arial-* class="">'

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9006.yml
@@ -1,21 +1,3 @@
-editor.editor.full_html:
-  expected_config:
-    settings:
-      toolbar:
-        rows:
-          -
-            - name: Media
-              items:
-                - highlight
-  update_actions:
-    delete:
-      settings:
-        toolbar:
-          rows:
-            -
-              - name: Media
-                items:
-                  - highlight
 filter.format.full_html:
   expected_config:
     filters:

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -16,6 +16,7 @@ function helfi_content_install($is_syncing) {
     helfi_content_update_9002();
     helfi_content_update_9004();
     helfi_content_update_9005();
+    helfi_content_update_9006();
   }
 }
 
@@ -120,6 +121,20 @@ function helfi_content_update_9005() {
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9005');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove highlight component from WYSIWYG.
+ */
+function helfi_content_update_9006() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9006');
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -130,6 +130,27 @@ function helfi_content_update_9005() {
  * Remove highlight component from WYSIWYG.
  */
 function helfi_content_update_9006() {
+  // Load the existing configuration.
+  $config_name = 'editor.editor.full_html';
+  $config = \Drupal::configFactory()->getEditable($config_name);
+  $config_data = $config->getRawData();
+
+  // Check that the WYSIWYG toolbar is set.
+  if (isset($config_data['settings']['toolbar']['rows'])) {
+    foreach ($config_data['settings']['toolbar']['rows'] as &$rows) {
+      // Go through each row of settings and search for the 'highlight' value and remove it if found.
+      foreach ($rows as &$row) {
+        if (array_key_exists('items', $row)) {
+          if (($key = array_search('highlight', $row['items'])) !== FALSE) {
+            unset($row['items'][$key]);
+          }
+        }
+      }
+    }
+  }
+  // Save the configuration without the highlight value.
+  $config->setData($config_data)->save();
+
   /** @var \Drupal\update_helper\Updater $updateHelper */
   $updateHelper = \Drupal::service('update_helper.updater');
 

--- a/helfi_features/helfi_tpr_config/config/install/field.field.tpr_service.tpr_service.field_lower_content.yml
+++ b/helfi_features/helfi_tpr_config/config/install/field.field.tpr_service.tpr_service.field_lower_content.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.gallery
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.remote_video
   module:
@@ -37,6 +38,7 @@ settings:
       list_of_links: list_of_links
       content_cards: content_cards
       banner: banner
+      liftup_with_image: liftup_with_image
       from_library: from_library
       remote_video: remote_video
     target_bundles_drag_drop:
@@ -71,8 +73,8 @@ settings:
         enabled: true
         weight: -26
       liftup_with_image:
+        enabled: true
         weight: -18
-        enabled: false
       list_of_links:
         enabled: true
         weight: -24

--- a/helfi_features/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_lower_content.yml
+++ b/helfi_features/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_lower_content.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.gallery
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.remote_video
   module:
@@ -37,6 +38,7 @@ settings:
       list_of_links: list_of_links
       content_cards: content_cards
       banner: banner
+      liftup_with_image: liftup_with_image
       from_library: from_library
       remote_video: remote_video
     target_bundles_drag_drop:
@@ -71,8 +73,8 @@ settings:
         enabled: true
         weight: -26
       liftup_with_image:
+        enabled: true
         weight: -18
-        enabled: false
       list_of_links:
         enabled: true
         weight: -24

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9008.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9008.yml
@@ -1,0 +1,38 @@
+field.field.tpr_service.tpr_service.field_lower_content:
+  expected_config:
+    settings:
+      handler_settings:
+        target_bundles_drag_drop:
+          liftup_with_image:
+            enabled: false
+  update_actions:
+    add:
+      settings:
+        handler_settings:
+          target_bundles:
+            liftup_with_image: liftup_with_image
+    change:
+      settings:
+        handler_settings:
+          target_bundles_drag_drop:
+            liftup_with_image:
+              enabled: true
+field.field.tpr_unit.tpr_unit.field_lower_content:
+  expected_config:
+    settings:
+      handler_settings:
+        target_bundles_drag_drop:
+          liftup_with_image:
+            enabled: false
+  update_actions:
+    add:
+      settings:
+        handler_settings:
+          target_bundles:
+            liftup_with_image: liftup_with_image
+    change:
+      settings:
+        handler_settings:
+          target_bundles_drag_drop:
+            liftup_with_image:
+              enabled: true

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -142,3 +142,17 @@ function helfi_tpr_config_update_9007() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update lower content field to use liftup with image paragraphs.
+ */
+function helfi_tpr_config_update_9008() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9008');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
How to test on an existing instance:

1. `composer require drupal/hdbt:dev-UHF-2916_style_fixes && composer require drupal/helfi_platform_config:dev-UHF-2916_style_fixes`
2. `make drush-cr`
3. `make drush-cim`
4. `make drush-updb`
5. `make drush-cr`
6. Now you should have all configuration in place and the buttons should return to normal. However sometimes some buttons might still look too small and the content where they are added needs to be saved again.
7. Basically now you should test that all buttons on the site and see if they look and work correctly.
8. Check at least banner paragraph with link, hero with link, text paragraph with link button, liftup with image with link button, unit search paragraph with many units so that pager is visible, service list paragraph with many services so that pager is visible, on unit page list of services with many services so that pager is visible, on service page list of units with many units so that the pager is visible.
9. Check on unit page that if there is only _accessibility sentences block_ but NOT any _services_ on that unit page that there is space between the map and the accessibility sentences block.

Also check these:
https://github.com/City-of-Helsinki/drupal-hdbt/pull/184
https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/182
https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/211
https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/149