### PR TITLE
UHF-2956: Fix JS error from cookie preferences page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "https://www.drupal.org/project/default_content/issues/2698425#comment-13809863": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"
       },
       "drupal/eu_cookie_compliance": {
-        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://gist.githubusercontent.com/khalima/25c1972340725bc57ac088b268c5736a/raw/a5dd1a39b2e3da23105c4aa5bfa9fd8c2373eb6f/eu_cookie_compliance_block_8.x-1.19.patch"
+        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/d1a6866b2138f7d3597df79f395a5c1a9e19ee2e/patches/eu_cookie_compliance_block_8.x-1.19.patch"
       },
       "drupal/features": {
         "https://www.drupal.org/project/features/issues/2869336": "https://www.drupal.org/files/issues/features_export-config-translation-2869336-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         "https://www.drupal.org/project/default_content/issues/2698425#comment-13809863": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"
       },
       "drupal/eu_cookie_compliance": {
-        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/d1a6866b2138f7d3597df79f395a5c1a9e19ee2e/patches/eu_cookie_compliance_block_8.x-1.19.patch"
+        "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/d1a6866b2138f7d3597df79f395a5c1a9e19ee2e/patches/eu_cookie_compliance_block_8.x-1.19.patch",
+        "[#UHF-2956] Fix JavaScript error at cookie preference page": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/97683d32e57808a4c9a4f6a2d20757af7a0b8c37/patches/eu_cookie_compliance_js_error_8.x-1.19-patched.patch"
       },
       "drupal/features": {
         "https://www.drupal.org/project/features/issues/2869336": "https://www.drupal.org/files/issues/features_export-config-translation-2869336-2.patch"

--- a/patches/eu_cookie_compliance_block_8.x-1.19.patch
+++ b/patches/eu_cookie_compliance_block_8.x-1.19.patch
@@ -1,0 +1,515 @@
+diff --git a/config/schema/cookie_category.schema.yml b/config/schema/cookie_category.schema.yml
+index 041bf25..c708f6f 100644
+--- a/config/schema/cookie_category.schema.yml
++++ b/config/schema/cookie_category.schema.yml
+@@ -11,7 +11,7 @@ eu_cookie_compliance.cookie_category.*:
+     uuid:
+       type: string
+     description:
+-      type: text
++      type: text_format
+       label: 'Description'
+     checkbox_default_state:
+       type: string
+diff --git a/eu_cookie_compliance.libraries.yml b/eu_cookie_compliance.libraries.yml
+index f64bd25..05317d1 100644
+--- a/eu_cookie_compliance.libraries.yml
++++ b/eu_cookie_compliance.libraries.yml
+@@ -29,3 +29,9 @@ admin:
+       css/eu_cookie_compliance_admin.css: {}
+   js:
+     js/eu_cookie_compliance_admin.js: {}
++eu_cookie_compliance_cookie_values:
++  version: 1.9
++  js:
++    js/eu_cookie_compliance_cookie_values.js: {}
++  dependencies:
++    - eu_cookie_compliance/eu_cookie_compliance
+diff --git a/eu_cookie_compliance.module b/eu_cookie_compliance.module
+index aa291e8..e6b63a1 100644
+--- a/eu_cookie_compliance.module
++++ b/eu_cookie_compliance.module
+@@ -378,7 +378,7 @@ function eu_cookie_compliance_build_data() {
+       $click_confirmation = FALSE;
+       $scroll_confirmation = FALSE;
+       if ($config->get('enable_save_preferences_button')) {
+-        $save_preferences_button_label = $config->get('save_preferences_button_label');
++        $save_preferences_button_label = t('Accept only essential cookies');
+         $primary_button_label = $config->get('accept_all_categories_button_label');
+       }
+       else {
+diff --git a/js/eu_cookie_compliance.js b/js/eu_cookie_compliance.js
+index 2865333..4d5496e 100644
+--- a/js/eu_cookie_compliance.js
++++ b/js/eu_cookie_compliance.js
+@@ -444,7 +444,7 @@
+
+     if (drupalSettings.eu_cookie_compliance.method === 'categories') {
+       // Select Checked categories.
+-      var categories = $("#eu-cookie-compliance-categories input:checkbox:checked").map(function () {
++      var categories = $("#eu-cookie-compliance-categories input[type=\"hidden\"]").map(function () {
+         return $(this).val();
+       }).get();
+       Drupal.eu_cookie_compliance.setAcceptedCategories(categories);
+@@ -474,8 +474,8 @@
+   }
+
+   Drupal.eu_cookie_compliance.savePreferencesAction = function () {
+-    var categories = $("#eu-cookie-compliance-categories input:checkbox:checked").map(function () {
+-      return $(this).val();
++    var categories = $("#eu-cookie-compliance-categories input[type=\"hidden\"]").map(function () {
++      return $(this).prop('checked') ? $(this).val() : null;
+     }).get();
+     var agreedEnabled = drupalSettings.eu_cookie_compliance.popup_agreed_enabled;
+     var nextStatus = cookieValueAgreedShowThankYou;
+diff --git a/js/eu_cookie_compliance_cookie_values.js b/js/eu_cookie_compliance_cookie_values.js
+new file mode 100644
+index 0000000..9e25704
+--- /dev/null
++++ b/js/eu_cookie_compliance_cookie_values.js
+@@ -0,0 +1,58 @@
++/**
++ * @file
++ * eu_cookie_compliance_cookie_values.js
++ *
++ * Get cookie values.
++ */
++(function ($, Drupal, drupalSettings, cookies) {
++  'use strict';
++
++  Drupal.behaviors.euCookieComplianceCookieValues = {
++    attach: function (context, settings) {
++      $('body').once('eu-cookie-compliance-block').each(function () {
++
++        var cookieName = drupalSettings.eu_cookie_compliance_cookie_values.cookieName === '' ? 'cookie-agreed' : drupalSettings.eu_cookie_compliance_cookie_values.cookieName;
++        var categories = drupalSettings.eu_cookie_compliance_cookie_values.cookieCategories;
++        var values = cookies.get(cookieName + '-categories');
++        var selectedCategories = undefined;
++
++        if (values) {
++          try {
++            selectedCategories = JSON.parse(decodeURI(values.replace(/%2C/g,",")));
++          }
++          catch (e) { }
++        }
++
++        // No suitable cookie categories set.
++        if (selectedCategories === undefined || selectedCategories === '[]') {
++          $('#edit-accept-all', '.eu-cookie-compliance-block-form .buttons').parent().removeClass('hidden');
++        }
++
++        var selectionCount = 0;
++
++        // Get required categories and reflect those on the form
++        var requiredCategories = [];
++        for (var _categoryName in drupalSettings.eu_cookie_compliance.cookie_categories_details) {
++          var _category = drupalSettings.eu_cookie_compliance.cookie_categories_details[_categoryName];
++          if (_category.checkbox_default_state === 'required' && $.inArray(_category.id, requiredCategories) === -1) {
++            $('#edit-categories-' + _category.id.replace("_", "-"), '#edit-categories').prop("checked", true).prop("disabled", true);
++            selectionCount++;
++          }
++        }
++
++        $.each(selectedCategories, function () {
++          $('#edit-categories-' + this.replace("_", "-"), '#edit-categories').prop("checked", true);
++          selectionCount++;
++        });
++
++        if (selectionCount > 0) {
++          $('#edit-withdraw', '.eu-cookie-compliance-block-form .buttons').parent().removeClass('hidden');
++        }
++
++        if (selectionCount < categories.length) {
++          $('#edit-accept-all', '.eu-cookie-compliance-block-form .buttons').parent().removeClass('hidden');
++        }
++      });
++    }
++  }
++})(jQuery, Drupal, drupalSettings, window.Cookies);
+diff --git a/src/CookieCategoryListBuilder.php b/src/CookieCategoryListBuilder.php
+index 5a6c160..2062e95 100644
+--- a/src/CookieCategoryListBuilder.php
++++ b/src/CookieCategoryListBuilder.php
+@@ -46,7 +46,7 @@ class CookieCategoryListBuilder extends DraggableListBuilder {
+     $row['sorter'] = ['#markup' => ''];
+     $row['label'] = $entity->label();
+     $row['id'] = ['#markup' => $entity->id()];
+-    $row['description'] = ['#markup' => $entity->get('description')];
++    $row['description'] = ['#markup' => $entity->get('description')['value']];
+     $row['checkbox_default_state'] = ['#markup' => isset($mapping[$entity->get('checkbox_default_state')]) ? $mapping[$entity->get('checkbox_default_state')] : $mapping['unchecked']];
+
+     return $row + parent::buildRow($entity);
+diff --git a/src/Form/CookieCategoryForm.php b/src/Form/CookieCategoryForm.php
+index 1bc1277..8980d53 100644
+--- a/src/Form/CookieCategoryForm.php
++++ b/src/Form/CookieCategoryForm.php
+@@ -80,9 +80,10 @@ class CookieCategoryForm extends EntityForm {
+       '#changeable_state' => !$cookie_category->isNew(),
+     ];
+     $form['description'] = [
+-      '#type' => 'textarea',
++      '#type' => 'text_format',
++      '#format' => 'full_html',
+       '#title' => $this->t('Description'),
+-      '#default_value' => $cookie_category->get('description'),
++      '#default_value' => $cookie_category->get('description')['value'],
+       '#description' => $this->t("The description that will be shown to the website visitor."),
+       '#required' => FALSE,
+     ];
+@@ -106,6 +107,7 @@ class CookieCategoryForm extends EntityForm {
+     $this->euccClearCache->clearCache();
+     $cookie_category = $this->entity;
+     $status = $cookie_category->save();
++    $status = 0;
+
+     switch ($status) {
+       case SAVED_NEW:
+diff --git a/src/Form/EuCookieComplianceBlockForm.php b/src/Form/EuCookieComplianceBlockForm.php
+new file mode 100644
+index 0000000..77cb34b
+--- /dev/null
++++ b/src/Form/EuCookieComplianceBlockForm.php
+@@ -0,0 +1,223 @@
++<?php
++
++namespace Drupal\eu_cookie_compliance\Form;
++
++use Drupal\Component\Serialization\Json;
++use Drupal\Core\Form\FormBase;
++use Drupal\Core\Form\FormStateInterface;
++use Symfony\Component\DependencyInjection\ContainerInterface;
++use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Drupal\Core\StringTranslation\TranslationInterface;
++
++/**
++ * Generate the form displayed inside the EuCookieComplianceBlock.
++ */
++class EuCookieComplianceBlockForm extends FormBase {
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getFormId() {
++    return 'eu_cookie_compliance_block_form';
++  }
++
++  /**
++   * Eu cookie compliance settings.
++   *
++   * @var \Drupal\Core\Config\ImmutableConfig
++   */
++  protected static $config;
++
++  /**
++   * Eu cookie compliance cookie.
++   *
++   * @var string
++   */
++  protected static $cookieName;
++
++  /**
++   * {@inheritdoc}
++   */
++  public static function create(ContainerInterface $container) {
++    self::$config = \Drupal::config('eu_cookie_compliance.settings');
++    self::$cookieName = !empty(self::$config->get('cookie_name')) ? self::$config->get('cookie_name') : 'cookie-agreed';
++    return new static();
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function buildForm(array $form, FormStateInterface $form_state) {
++    $config = self::$config;
++    $current_cookie_value = isset($_COOKIE[self::$cookieName]) ? $_COOKIE[self::$cookieName] : null;
++
++    if ($config->get('method') !== 'categories') {
++      return;
++    }
++
++    $eu_cookie_categories = \Drupal::entityTypeManager()->getStorage('cookie_category')->getCookieCategories();
++
++    $cookie_categories = [];
++    $cookie_categories_descriptions = [];
++    foreach ($eu_cookie_categories as $key => $value) {
++      $cookie_categories[$key] = $value['label'];
++      $cookie_categories_descriptions[$key] = ['#description' => $value['description']['value']];
++    }
++
++    // If user has already chosen something, show helpful information
++    if ($current_cookie_value !== null) {
++      if ($current_cookie_value == 0) {
++        $form['#markup'] = '<div class="cookie-selection-instruction">' . $this->t('<p>Your current setting is to <strong>only allow essential cookies, that are required for the site to function correctly.</strong> Submit the form below to make changes.</p>') . '</div>';
++      } else {
++        $form['#markup'] = '<div class="cookie-selection-instruction">' . $this->t('<p>Your current cookie settings are below. Submit the form to make changes.</p>') . '</div>';
++      }
++    } else {
++      $form['#markup'] = '<div class="cookie-selection-instruction">' . $this->t('<p><strong>You have not saved any cookie preferences.</strong> By default only essential cookies are saved. See details below.</p>') . '</div>';
++    }
++
++    $form['categories'] = [
++      '#type' => 'checkboxes',
++      '#options' => $cookie_categories,
++      '#attributes' => [
++        'class' => ['categories'],
++      ],
++    ];
++    $form['categories'] += $cookie_categories_descriptions;
++
++    foreach ($eu_cookie_categories as $key => $value) {
++      if (isset($value['checkbox_default_state']) && $value['checkbox_default_state'] === 'required') {
++        $form['categories'][$key] += [
++          '#default_value' => $key,
++          '#value' => $key,
++          '#attributes' => [
++            'checked' => TRUE,
++            'disabled' => TRUE,
++          ],
++        ];
++      }
++    }
++
++    $form['buttons'] = [
++      'save' => [
++        '#type' => 'submit',
++        '#value' => $config->get('save_preferences_button_label'),
++        '#attributes' => [
++          'class' => ['save'],
++        ],
++      ],
++      'accept_all' => [
++        '#type' => 'submit',
++        '#value' => $config->get('accept_all_categories_button_label'),
++        '#submit' => ['::submitAcceptAllHandler'],
++        '#attributes' => [
++          'class' => ['accept'],
++        ],
++        '#prefix' => '<span class="hidden">',
++        '#suffix' => '</span>',
++      ],
++      'withdraw' => [
++        '#type' => 'submit',
++        '#value' => $config->get('withdraw_action_button_label'),
++        '#submit' => ['::submitWithdrawHandler'],
++        '#attributes' => [
++          'class' => ['withdraw'],
++        ],
++        '#prefix' => '<span class="hidden">',
++        '#suffix' => '</span>',
++      ],
++      '#type' => 'container',
++      '#wrapper' => 'div',
++      '#attributes' => [
++        'class' => ['buttons'],
++      ],
++    ];
++
++    $form['#attached'] = [
++      'library' => [
++        'eu_cookie_compliance/eu_cookie_compliance_cookie_values',
++      ],
++      'drupalSettings' => [
++        'eu_cookie_compliance_cookie_values' => [
++          'cookieName' => self::$cookieName,
++          'cookieCategories' => array_keys($cookie_categories),
++        ],
++      ],
++    ];
++
++    $form['#cache']['contexts'][] = 'session';
++
++    return $form;
++  }
++
++  /**
++   * Default submission handler for saving selected categories.
++   */
++  public function submitForm(array &$form, FormStateInterface $form_state) {
++    $cookie_lifetime = self::$config->get('cookie_lifetime');
++    $values = array_reverse($form_state->getValue('categories'));
++
++    $selected = [];
++    foreach ($values as $key => $value) {
++      if ($value) {
++        $selected[] = $key;
++      }
++    }
++    $values = $this->stringify($selected);
++
++    $time = \Drupal::time()->getRequestTime() + ($cookie_lifetime * 24 * 60 * 60);
++    setrawcookie(self::$cookieName, '2', $time, '/');
++    setrawcookie(self::$cookieName . '-categories', $values, $time, '/');
++  }
++
++  /**
++   * Custom submission handler for accepting all categories.
++   *
++   * @param array $form
++   *   An associative array containing the structure of the form.
++   * @param \Drupal\Core\Form\FormStateInterface $form_state
++   *   The current state of the form.
++   */
++  public function submitAcceptAllHandler(array &$form, FormStateInterface $form_state) {
++    $cookie_lifetime = self::$config->get('cookie_lifetime');
++    $values = $this->stringify(array_keys($form_state->getValue('categories')));
++    $time = \Drupal::time()->getRequestTime() + ($cookie_lifetime * 24 * 60 * 60);
++    setrawcookie(self::$cookieName, '2', $time, '/');
++    setrawcookie(self::$cookieName . '-categories', $values, $time, '/');
++  }
++
++  /**
++   * Custom submission handler for withdrawing consent for all categories.
++   */
++  public function submitWithdrawHandler(array &$form, FormStateInterface $form_state) {
++    $first_read_only = !empty(self::$config->get('fix_first_cookie_category')) ? self::$config->get('fix_first_cookie_category') : FALSE;
++    if (!$first_read_only) {
++      setrawcookie(self::$cookieName, '', \Drupal::time()->getRequestTime() - 3600, '/');
++    }
++    setrawcookie(self::$cookieName . '-categories', '', \Drupal::time()->getRequestTime() - 3600, '/');
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function getCacheMaxAge() {
++    return 0;
++  }
++
++  /**
++   * Replace reserved characters in json.
++   *
++   * @var array
++   *
++   * @return string
++   *   'Sanitized' string
++   */
++  private function stringify($values) {
++    $json = JSON::encode($values);
++    $json = str_replace('[', '%5B', $json);
++    $json = str_replace(']', '%5D', $json);
++    $json = str_replace('"', '%22', $json);
++    $json = str_replace(',', '%2C', $json);
++    return $json;
++  }
++
++}
+diff --git a/src/Plugin/Block/EuCookieComplianceBlock.php b/src/Plugin/Block/EuCookieComplianceBlock.php
+new file mode 100644
+index 0000000..8db047b
+--- /dev/null
++++ b/src/Plugin/Block/EuCookieComplianceBlock.php
+@@ -0,0 +1,84 @@
++<?php
++
++namespace Drupal\eu_cookie_compliance\Plugin\Block;
++
++use Drupal\Core\Form\FormStateInterface;
++use Drupal\Core\Block\BlockBase;
++use Drupal\eu_cookie_compliance\Form\EuCookieComplianceBlockForm;
++
++/**
++ * EU Cookie Compliance Block.
++ *
++ * @Block(
++ *     id = "eu_cookie_compliance_block",
++ *     admin_label = @Translation("EU Cookie Compliance Block"),
++ * )
++ */
++class EuCookieComplianceBlock extends BlockBase {
++
++  /**
++   * Return block settings.
++   */
++  private function getBlockSettings() {
++    $config = $this->getConfiguration();
++    return !empty($config[$this->getBaseId() . '_settings']) ? $config[$this->getBaseId() . '_settings'] : NULL;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function build() {
++
++    $form = \Drupal::formBuilder()->getForm(EuCookieComplianceBlockForm::class);
++
++    if (!isset($form['categories'])) {
++      return;
++    }
++
++    $build = [];
++
++    $settings = $this->getBlockSettings();
++
++    $value = !empty($settings['description']['value']) ? $settings['description']['value'] : NULL;
++    $format = !empty($settings['description']['format']) ? $settings['description']['format'] : NULL;
++
++    if ($value && $format) {
++
++      $build['description'] = [
++        '#type' => 'processed_text',
++        '#format' => $format,
++        '#text' => $value,
++      ];
++    }
++    $build['form'] = $form;
++
++    return $build;
++
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function blockForm($form, FormStateInterface $form_state) {
++
++    $settings = $this->getBlockSettings();
++
++    $form[$this->getBaseId() . '_settings']['description'] = [
++      '#type' => 'text_format',
++      '#title' => $this->t('Description'),
++      '#default_value' => !empty($settings['description']['value']) ? $settings['description']['value'] : NULL,
++      '#format' => !empty($settings['description']['format']) ? $settings['description']['format'] : NULL,
++      '#description' => $this->t('Provide some information about the form shown and EU Cookie Compliance Categories.'),
++    ];
++    return $form;
++  }
++
++  /**
++   * {@inheritdoc}
++   */
++  public function blockSubmit($form, FormStateInterface $form_state) {
++    $settingsKey = $this->getBaseId() . '_settings';
++    $this->configuration[$settingsKey] = $form_state->getValue($settingsKey);
++  }
++
++}
+diff --git a/templates/eu_cookie_compliance_popup_info.html.twig b/templates/eu_cookie_compliance_popup_info.html.twig
+index 196f6cf..c1213f1 100644
+--- a/templates/eu_cookie_compliance_popup_info.html.twig
++++ b/templates/eu_cookie_compliance_popup_info.html.twig
+@@ -52,19 +52,13 @@
+
+     {% if cookie_categories %}
+       <div id="eu-cookie-compliance-categories" class="eu-cookie-compliance-categories">
++        {# Hide categories by using hidden fields in place of checkboxes on popup #}
+         {% for key, category in cookie_categories %}
+-          <div class="eu-cookie-compliance-category">
+-            <div>
+-              <input type="checkbox" name="cookie-categories" id="cookie-category-{{ key }}"
+-                     value="{{ key }}"
+-                     {% if category.checkbox_default_state in ['checked', 'required'] %} checked {% endif %}
+-                     {% if category.checkbox_default_state == 'required' %} disabled {% endif %} >
+-              <label for="cookie-category-{{ key }}">{{ category.label }}</label>
+-            </div>
+-            {% if category.description %}
+-              <div class="eu-cookie-compliance-category-description">{{ category.description }}</div>
+-            {% endif %}
+-          </div>
++          {% if category.checkbox_default_state in ['checked', 'required'] %}
++            <input type="hidden" name="cookie-categories[]" id="cookie-category-{{ key }}" value="{{ key }}">
++          {% else %}
++            <input type="hidden" name="cookie-categories[]" id="cookie-category-{{ key }}" value="">
++          {% endif %}
+         {% endfor %}
+         {% if save_preferences_button_label %}
+           <div class="eu-cookie-compliance-categories-buttons">

--- a/patches/eu_cookie_compliance_js_error_8.x-1.19-patched.patch
+++ b/patches/eu_cookie_compliance_js_error_8.x-1.19-patched.patch
@@ -1,0 +1,13 @@
+diff --git a/js/eu_cookie_compliance.js b/js/eu_cookie_compliance.js
+index 4d5496e..bb605c4 100644
+--- a/js/eu_cookie_compliance.js
++++ b/js/eu_cookie_compliance.js
+@@ -628,7 +628,7 @@
+     if (storedCategories !== null && typeof storedCategories !== 'undefined') {
+       // JS cookie introduced unescaped cookie values.
+       if (storedCategories.indexOf('%') !== -1) {
+-        storedCategories = decodeURI(storedCategories).replace('%2C', ',');
++        storedCategories = decodeURI(storedCategories).replaceAll('%2C', ',');
+       }
+       _euccSelectedCategories = JSON.parse(storedCategories);
+     }


### PR DESCRIPTION
This PR includes two changes:
* The custom patch to `eu_cookie_compliance` module is moved from gist to this repository.
* A new custom patch is added to fix the JavaScript error at the cookie preference page.
  * Fixing the JS error will also fix the issue of not setting the `cookie-agreed-version` cookie.

**How to test:**
* Set up a local development environment.
* You can check the current behaviour by going to the `/cookie-information-and-settings` page:
  * Remove existing cookies (`cookie-agreed-categories`, `cookie-agreed-version`, `cookie-agreed`) using the browser's development tools.
  * Refresh the page.
  * Use the checkboxes to select e.g. all but the last category.
  * Save changes by pressing the "Accept selected cookies".
  * Now you should see a JS error _"Uncaught SyntaxError: Unexpected token %"_ at the console and the `cookie-agreed-version` cookie is missing.
* Get the changes: `composer require "drupal/helfi_platform_config:dev-UHF-2956-cookie-settings-js-error"`
* Install the patches: `composer install`
* Clear caches: `drush cr`
* Now do the same testing steps as above. There shouldn't be any JS errors and the `cookie-agreed-version` cookie is set.