### PR TITLE
UHF-3254: drush command for changing database field collation

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -4,3 +4,8 @@ services:
     arguments: ['@entity_type.manager', '@database']
     tags:
       - { name: drush.command }
+  helfi_platform_config.change_collation_commands:
+    class: \Drupal\helfi_platform_config\Commands\ChangeCollationCommands
+    arguments: ['@database']
+    tags:
+      - { name: drush.command }

--- a/src/Commands/ChangeCollationCommands.php
+++ b/src/Commands/ChangeCollationCommands.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_platform_config\Commands;
+
+use Drupal\Core\Database\Connection;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A drush command file.
+ */
+final class ChangeCollationCommands extends DrushCommands {
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $connection;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(Connection $connection) {
+    $this->connection = $connection;
+  }
+
+  /**
+   * Changes the collation of two database fields for view sorting.
+   *
+   * @command helfi:change-collation
+   */
+  public function change() : void {
+    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;');
+    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name_override varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;');
+  }
+
+}

--- a/src/Commands/ChangeCollationCommands.php
+++ b/src/Commands/ChangeCollationCommands.php
@@ -35,8 +35,8 @@ final class ChangeCollationCommands extends DrushCommands {
    * @command helfi:change-collation
    */
   public function change() : void {
-    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;');
-    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name_override varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL;');
+    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci DEFAULT NULL;');
+    $this->connection->query('ALTER TABLE {tpr_unit_field_data} MODIFY COLUMN name_override varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci DEFAULT NULL;');
   }
 
 }


### PR DESCRIPTION
Introduces a custom drush command that changes the collation of `tpr_unit_field_data.name` and `tpr_unit_field_data.name_override` to `utf8mb4_swedish_ci` (default is `utf8mb4_general_ci`) to enable correct sorting with Scandinavian characters (ÅÖÄ).

How to test:

1. Setup a site (SOTE is good)
2. Import and publish some TPR Units
3. Create a page with a Unit search paragraph and add some of the units there (choose ones starting with ÅÖÄ)
4. See how the view is sorted incorrectly, i.e. Å and Ä is treated as A etc.
5. Checkout this branch: `composer require drupal/helfi_platform_config:dev-UHF-3254_database_collation_change`
6. Run the drush command (in the container): `drush helfi:change-collation`
7. Clear cache and see the view again and observe the correct sorting

See PR https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/75 about the view sorting logic.