### PR TITLE
UHF-3184: Add Announcements block as optional config

### DIFF
--- a/helfi_features/helfi_announcements/config/optional/block.block.announcements.yml
+++ b/helfi_features/helfi_announcements/config/optional/block.block.announcements.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_announcements
+  theme:
+    - hdbt
+id: announcements
+theme: hdbt
+region: before_content
+weight: -11
+provider: null
+plugin: announcements
+settings:
+  id: announcements
+  label: Announcements
+  provider: helfi_announcements
+  label_display: '0'
+visibility: {  }


### PR DESCRIPTION
Adds _Announcements_ block to _before_content_ region if _hdbt_ theme is installed.

**How to test:**

* Test with a development environment which doesn't have the Announcements module installed.
  * For example, install a new site from [drupal-helfi-platform](https://github.com/City-of-Helsinki/drupal-helfi-platform).
* Get the changes: `composer require 'drupal/helfi_platform_config:dev-UHF-3184-announcements-block-config'`.
* Install the module: `drush en -y helfi_announcements`
* Go to the `/structure/block` and check that Announcements block is located as a first item at the Before content region.