### PR TITLE
UHF-3474 Color palette

### DIFF
--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -193,3 +193,31 @@ function helfi_tpr_config_update_9009() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Install 'color palette' field to TPR Unit and TPR Service entities.
+ */
+function helfi_tpr_config_update_9010() {
+
+  // Field to be installed and entity types.
+  $field = 'color_palette';
+  $entity_types = [
+    'tpr_unit',
+    'tpr_service',
+  ];
+
+  foreach ($entity_types as $entity_type) {
+    $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+    $field_definitions = \Drupal::service('entity_field.manager')->getFieldDefinitions($entity_type, $entity_type);
+
+    // Install color palette field, if color palette field has not
+    // been installed to current entity.
+    if (
+      !empty($field_definitions[$field]) &&
+      $field_definitions[$field] instanceof FieldStorageDefinitionInterface &&
+      empty($entity_definition_update_manager->getFieldStorageDefinition($field, $entity_type))
+    ) {
+      $entity_definition_update_manager->installFieldStorageDefinition($field, $entity_type, 'hdbt_admin_editorial', $field_definitions[$field]);
+    }
+  }
+}


### PR DESCRIPTION
How to test with running instance:

- Make sure your instance is up and running and has fairly new database dump, preferably Sote
- Go to shell `make shell`
  - In shell, type `drush sqlc`
  - In SQL Cli type `describe tpr_service_field_data;` and look for `color_palette` field, in Sote and Kymp case it is missing.
- Update the modules/themes
   - `composer require drupal/hdbt_admin:dev-UHF-3474_color_palette && composer require drupal/helfi_platform_config:dev-UHF-3474_color_palette`
- Run updates: make drush-cim drush-updb drush-cr
- Go back to shell and SQL cli. Describe the `tpr_service_field_data` table again and look for `color_palette` field. It should be listed now. 

If you want to test this with the site
- Log in, go to https://helfi-sote.docker.so/admin/content/integrations/tpr-service and edit one of the services
- Select a different color palette for the service page and hit save
- Go back to edit the service page and check that the color palette you chose is still selected and not reverted to default

Check also: 
- https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/76