### PR TITLE
UHF-3550 remove video paragraph heading from toc

### DIFF
--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -21,7 +21,6 @@
       }
 
       var anchors = [];
-      var anchorLinks = [];
       var tableOfContents = $('#helfi-toc-table-of-contents');
       var tableOfContentsList = $('#helfi-toc-table-of-contents-list > ul');
       var mainContent = $('main.layout-main-wrapper');
@@ -32,13 +31,20 @@
       });
 
       // Do not include sidebar H2, Table of contents H2 or cookie compliance warnings.
+      var exclusions = '' +
+        ':not(aside *)' +
+        ':not(.unit__sidebar *)' +
+        ':not(.service__sidebar *)' +
+        ':not(#helfi-toc-table-of-contents *)' +
+        ':not(.embedded-content-cookie-compliance *)' +
+        ':not(.handorgel__header)'; // Accordion headings get their id's overridden by handorgel script
+
       var titleComponents = [
-        'h2:not(aside *)' +
-          ':not(.unit__sidebar *)' +
-          ':not(.service__sidebar *)' +
-          ':not(#helfi-toc-table-of-contents *)' +
-          ':not(.embedded-content-cookie-compliance *)' +
-          ':not(.handorgel__header)', // Accordion headings get their id's overridden by handorgel script
+        'h2'+exclusions,
+        'h3'+exclusions,
+        'h4'+exclusions,
+        'h5'+exclusions,
+        'h6'+exclusions,
         '.handorgel__header > button', // Instead of targeting accordion headings, lets target the button inside them.
       ];
 
@@ -55,6 +61,11 @@
             .replace(/\W/g, '-')
             .replace(/-(\d+)$/g, '_$1');
 
+          let nodeName = this.nodeName.toLowerCase();
+          if (nodeName === 'button') {
+            nodeName = this.parentElement.nodeName.toLowerCase();
+          }
+
           let anchorName;
           if (this.id) {
             anchorName = this.id;
@@ -64,8 +75,7 @@
           anchors.push(anchorName);
 
           // Create table of contents if component is enabled.
-          anchorLinks.push(this.textContent.trim());
-          if (tableOfContentsList.length > 0) {
+          if (tableOfContentsList.length > 0 && nodeName === "h2") {
             tableOfContentsList.append(
               '<li class="table-of-contents__item"><a class="table-of-contents__link' +
               '" href="#' +

--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -9,12 +9,13 @@
       var tableOfContentsList = $('#helfi-toc-table-of-contents-list > ul');
       var mainContent = $('main.layout-main-wrapper');
 
-      // Do not include sidebar H2 or Table of contents H2.
+      // Do not include sidebar H2, Table of contents H2 or cookie compliance warnings.
       var titleComponents = [
         'h2:not(aside *)' +
         ':not(.unit__sidebar *)' +
         ':not(.service__sidebar *)' +
-        ':not(#helfi-toc-table-of-contents *)'
+        ':not(#helfi-toc-table-of-contents *)' +
+        ':not(.embedded-content-cookie-compliance *)'
       ];
 
       // Craft table of contents.

--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -3,19 +3,43 @@
 (function ($, Drupal) {
   Drupal.behaviors.table_of_contents = {
     attach: function attach() {
-      var anchorMap = {};
+
+      function findAvailableId(name, reserved, anchors, count) {
+        var newName = name;
+        if (count > 0) { // Only when headings are not unique on page we want to add counter
+          newName += '-' + count;
+        }
+        if (reserved.includes(newName)) {
+          return findAvailableId(name, reserved, anchors, ++count);
+        } else if (anchors.includes(newName)) {
+          if (count === 0) {
+            count++; // When reserved heading is visible on page, lets start counting from 2 instead of 1
+          }
+          return findAvailableId(name, reserved, anchors, ++count);
+        }
+        return newName;
+      }
+
+      var anchors = [];
       var anchorLinks = [];
       var tableOfContents = $('#helfi-toc-table-of-contents');
       var tableOfContentsList = $('#helfi-toc-table-of-contents-list > ul');
       var mainContent = $('main.layout-main-wrapper');
+      var reservedElems = document.querySelectorAll('[id]');
+      var reserved = []; // Lets list current id's here to avoid creating duplicates
+      reservedElems.forEach(function (elem) {
+        reserved.push(elem.id);
+      });
 
       // Do not include sidebar H2, Table of contents H2 or cookie compliance warnings.
       var titleComponents = [
         'h2:not(aside *)' +
-        ':not(.unit__sidebar *)' +
-        ':not(.service__sidebar *)' +
-        ':not(#helfi-toc-table-of-contents *)' +
-        ':not(.embedded-content-cookie-compliance *)'
+          ':not(.unit__sidebar *)' +
+          ':not(.service__sidebar *)' +
+          ':not(#helfi-toc-table-of-contents *)' +
+          ':not(.embedded-content-cookie-compliance *)' +
+          ':not(.handorgel__header)', // Accordion headings get their id's overridden by handorgel script
+        '.handorgel__header > button', // Instead of targeting accordion headings, lets target the button inside them.
       ];
 
       // Craft table of contents.
@@ -32,13 +56,12 @@
             .replace(/-(\d+)$/g, '_$1');
 
           let anchorName;
-          if (!anchorMap[name]) {
-            anchorName = name;
-            anchorMap[name] = 2;
+          if (this.id) {
+            anchorName = this.id;
           } else {
-            anchorName = name + '-' + anchorMap[name];
-            anchorMap[name]++;
+            anchorName = findAvailableId(name, reserved, anchors, 0);
           }
+          anchors.push(anchorName);
 
           // Create table of contents if component is enabled.
           anchorLinks.push(this.textContent.trim());

--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -91,6 +91,43 @@
 
       // Remove loading text.
       $('.js-remove', tableOfContents).remove();
+
+      // Open accordions that contain linked anchors
+      function handleAccordionAnchors() {
+        var hash = window.location.hash;
+        if (!hash) return;
+
+        var hashTarget = document.getElementById(hash.replace('#', ''));
+        if (!hashTarget) return;
+
+        var hashParent = hashTarget.closest('.handorgel__content');
+        if (!hashParent) return;
+
+        if (document.readyState === 'complete') { // if document has already been loaded
+
+          if (!window.handorgel_accordions) return; // We need access to the accordion objects to open them
+
+          window.handorgel_accordions.forEach(function (accordion) {
+            accordion.folds.forEach(function (fold) {
+              if (fold.id === hashParent.id.replace('-content','')) {
+                fold.open(false); // false prevents animation
+                hashTarget.scrollIntoView();
+              }
+            });
+          });
+          hashTarget.scrollIntoView();
+
+        } else { // If we have not yet loaded the document
+          hashParent.setAttribute('data-open', '');
+          window.addEventListener('DOMContentLoaded', function () {
+            window.setTimeout(function () {
+              hashTarget.scrollIntoView();
+            }, 1000);
+          })
+        }
+      }
+      handleAccordionAnchors();
+      window.addEventListener('popstate', handleAccordionAnchors); //popstate instead of hashchange to handle re-click
     },
   };
 })(jQuery, Drupal);


### PR DESCRIPTION
# [UHF-3550](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3550)

## What was done

* Excluded cookie compliance headings from ToC
* Fix ToC script to not generate duplicate ids. (scans whole page for ids and avoids those when generating anchors)
* Fix anchor link generation for accordions that get their ids from handorgel script after our script
* Add anchor ids to all heading levels, not just h2 (only h2 is shown when ToC is visible)
* Accordions now open if anchors inside them are requested

## How to test
* Get the [HDBT branch](https://github.com/City-of-Helsinki/drupal-hdbt/pull/208)
* Get this branch
* Open/Create a page that has these things:
  * Heading 2: "Mobile navigation" (Should not generate #mobile-navigation id that clashes with nav)
  * Heading 2: "Heading test A" (Should get #heading-test-a, without a number as this is the most common case)
  * Heading 3: "Heading test A" (Should get #heading-test-a-2, test that you can navigate here from url bar)
  * Heading 2: "Heading test A" (Should get #heading-test-a-3, showing that deeper level headings influence lower items, keeping source order)
  * Heading 2: "Heading test B" that's also a accordion fold button. (Should get #heading-test-b on the button just inside the heading)
  * Heading 2: "Heading test C" that's inside an closed accordion. (Should get #heading-test-c and open the accordion both from page reload and on click on the page, including a second click when the url is already set)

Related: https://github.com/City-of-Helsinki/drupal-hdbt/pull/208