### PR TITLE
UHF-X: Fix quote configuration

### DIFF
--- a/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
+++ b/helfi_features/helfi_content/config/install/editor.editor.full_html.yml
@@ -31,7 +31,7 @@ settings:
         -
           name: Media
           items:
-            1: quote
+            - quote
         -
           name: Links
           items:


### PR DESCRIPTION
This should fix issue with new sites being built with this configuration having the quote option missing from the WYSIWYG.