### PR TITLE
UHF-3479: Read only role

### DIFF
--- a/helfi_features/helfi_content/config/install/user.role.admin.yml
+++ b/helfi_features/helfi_content/config/install/user.role.admin.yml
@@ -98,6 +98,7 @@ permissions:
   - 'update media'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view any unpublished content'
   - 'view landing_page revisions'
   - 'view media'
   - 'view own unpublished content'

--- a/helfi_features/helfi_content/config/install/user.role.content_producer.yml
+++ b/helfi_features/helfi_content/config/install/user.role.content_producer.yml
@@ -46,6 +46,8 @@ permissions:
   - 'update media'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view any unpublished landing_page content'
+  - 'view any unpublished page content'
   - 'view landing_page revisions'
   - 'view own unpublished content'
   - 'view own unpublished media'

--- a/helfi_features/helfi_content/config/install/user.role.read_only.yml
+++ b/helfi_features/helfi_content/config/install/user.role.read_only.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: read_only
+label: 'Read only'
+weight: 4
+is_admin: null
+permissions:
+  - 'access toolbar'
+  - 'view any unpublished landing_page content'
+  - 'view any unpublished page content'
+  - 'view unpublished paragraphs'

--- a/helfi_features/helfi_content/config/language/fi/user.role.read_only.yml
+++ b/helfi_features/helfi_content/config/language/fi/user.role.read_only.yml
@@ -1,0 +1,1 @@
+label: 'Vain luku'

--- a/helfi_features/helfi_content/config/language/sv/user.role.read_only.yml
+++ b/helfi_features/helfi_content/config/language/sv/user.role.read_only.yml
@@ -1,0 +1,1 @@
+label: 'Endast läs'

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9010.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9010.yml
@@ -1,0 +1,13 @@
+user.role.admin:
+  expected_config: {  }
+  update_actions:
+    add:
+      permissions:
+        - 'view any unpublished content'
+user.role.content_producer:
+  expected_config: {  }
+  update_actions:
+    add:
+      permissions:
+        - 'view any unpublished landing_page content'
+        - 'view any unpublished page content'

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -206,3 +206,21 @@ function helfi_content_update_9009() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Update permissions for Admin and Content producer roles.
+ */
+function helfi_content_update_9010() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Added manually the creation of configuration. Cannot be handled automatically.
+  $configLocation = dirname(__FILE__) . '/config/install/';
+  ConfigHelper::installNewConfig($configLocation, 'user.role.read_only');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9010');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -24,6 +24,7 @@ function helfi_content_install($is_syncing) {
     helfi_content_update_9006();
     helfi_content_update_9007();
     helfi_content_update_9009();
+    helfi_content_update_9010();
   }
 }
 
@@ -93,7 +94,6 @@ function helfi_content_update_9004() {
   /** @var \Drupal\update_helper\Updater $updateHelper */
   $updateHelper = \Drupal::service('update_helper.updater');
 
-  // Added manually the creation of configuration. Cannot be handled automatically.
   // Added manually the creation of configuration. Cannot be handled automatically.
   $configLocation = dirname(__FILE__) . '/config/install/';
 
@@ -216,7 +216,11 @@ function helfi_content_update_9010() {
 
   // Added manually the creation of configuration. Cannot be handled automatically.
   $configLocation = dirname(__FILE__) . '/config/install/';
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  // Install configurations and translations.
   ConfigHelper::installNewConfig($configLocation, 'user.role.read_only');
+  ConfigHelper::installNewConfigTranslation($configTranslationLocation, 'user.role.read_only');
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9010');

--- a/helfi_features/helfi_content/translations/fi.po
+++ b/helfi_features/helfi_content/translations/fi.po
@@ -433,6 +433,9 @@ msgstr "Lohkot"
 msgid "Promoted to front page"
 msgstr "Näytetään etusivulla"
 
+msgid "Read only"
+msgstr "Vain luku"
+
 msgid "Remote video"
 msgstr "Video ulkoisesta palvelusta"
 

--- a/helfi_features/helfi_content/translations/sv.po
+++ b/helfi_features/helfi_content/translations/sv.po
@@ -115,6 +115,9 @@ msgstr "Paragraf"
 msgid "Promoted to front page"
 msgstr "Visas på startsidan"
 
+msgid "Read only"
+msgstr "Endast läs"
+
 msgid "Shown when hovering over the menu link."
 msgstr "Visas när man för musmarkören över menylänken."
 
@@ -132,3 +135,4 @@ msgstr "Innehåll"
 
 msgid "White"
 msgstr "Vit"
+

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9013.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9013.yml
@@ -1,0 +1,27 @@
+user.role.admin:
+  expected_config: {  }
+  update_actions:
+    add:
+      permissions:
+        - 'view unpublished tpr_errand_service'
+        - 'view unpublished tpr_service'
+        - 'view unpublished tpr_service_channel'
+        - 'view unpublished tpr_unit'
+user.role.content_producer:
+  expected_config: {  }
+  update_actions:
+    add:
+      permissions:
+        - 'view unpublished tpr_errand_service'
+        - 'view unpublished tpr_service'
+        - 'view unpublished tpr_service_channel'
+        - 'view unpublished tpr_unit'
+user.role.read_only:
+  expected_config: {  }
+  update_actions:
+    add:
+      permissions:
+        - 'view unpublished tpr_errand_service'
+        - 'view unpublished tpr_service'
+        - 'view unpublished tpr_service_channel'
+        - 'view unpublished tpr_unit'

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -45,6 +45,9 @@ function helfi_tpr_config_update_dependencies() {
   $dependencies['helfi_tpr_config'][9003] = [
     'helfi_content' => 9003,
   ];
+  $dependencies['helfi_tpr_config'][9013] = [
+    'helfi_content' => 9010,
+  ];
   return $dependencies;
 }
 
@@ -245,6 +248,20 @@ function helfi_tpr_config_update_9012() {
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9012');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Add view unpublished TPR entities permissions to Admin and Content producer.
+ */
+function helfi_tpr_config_update_9013() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9013');
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();


### PR DESCRIPTION
How to test / install:
- Make sure your instance is up and running on latest dev branch.
- Update the modules/themes
   - `composer require drupal/helfi_platform_config:dev-UHF-3479_read_only_role && composer require drupal/helfi_tpr:dev-UHF-3479_read_only_role`
- Run `make drush-updb drush-cr drush-uli`
- Log in with the link provided and go to /admin/content page
  - Edit a published landing page and basic page, which have menu links enabled
  - Unpublish the nodes and make a note of the nodes what you unpublished
- Go to Integrations page and search for published unit and published service.
  - Unpublish these as well and make sure they've been added to menu. If not, add them to menu. Make a note of these entities as well.
- Open an incognito tab and explore the pages what you've unpublished and make sure you cannot access them.   
- Open terminal and go to shell `make shell`
  - In shell, type `drush user:create Readonly --password="readonly"; drush user:role:add "read_only" Readonly; drush uli --name="Readonly"`
  - Log in with the link provided (in incognito), explore the pages again and make sure you can access them
  
Check also: 
- https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/82/files