### PR TITLE
Remove RNS cookie consent heading from ToC

### DIFF
--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -37,6 +37,7 @@
         ':not(.service__sidebar *)' +
         ':not(#helfi-toc-table-of-contents *)' +
         ':not(.embedded-content-cookie-compliance *)' +
+        ':not(.react-and-share-cookie-compliance *)' +
         ':not(.handorgel__header)'; // Accordion headings get their id's overridden by handorgel script
 
       var titleComponents = [


### PR DESCRIPTION
Removed react and share cookie consent heading from appearing in table of contents listing

## How to test

* Create a page that has ToC enabled
* Open the page with cookies disabled
* Notice ToC containing RNS heading
* Get this branch on drupal-helfi-plaform-config of the test site
* Notice this getting fixed
* Approve