### PR TITLE
UHF-3911 Views ajax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
       "drupal/core": {
         "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
         "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
-        "[#UHF-3812] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2021-12-15/2858890-71.patch",
+        "[#UHF-3812] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2021-12-29/2858890-75.patch",
         "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch"
       },
       "drupal/default_content": {


### PR DESCRIPTION
How to test / install:
- Make sure your instance is up and running on latest dev branch. _**Preferably kasko**_
- Update the platform config module
   - `composer require drupal/helfi_platform_config:dev-UHF-3911_views_ajax`
- Run `composer install && make drush-cr`
- Go to a page which has a view with exposed filters and check that the ajax works when a selection is made from the filter
   - For example: https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/lukiokoulutus-0 or similar to this page in test-site https://nginx-kasvatus-koulutus-test.agw.arodevtest.hel.fi/fi/test-kasvatus-ja-koulutus/lukiokoulutus-0
