### PR TITLE
UHF-X Infinite scroll update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
       "drupal/core": {
         "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
         "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
-        "[#UHF-3812] Drupal.views.ajaxView is not initializing pagers in nested views (https://www.drupal.org/project/drupal/issues/2858890).": "https://www.drupal.org/files/issues/2021-12-29/2858890-75.patch",
+        "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299).": "https://www.drupal.org/files/issues/2022-01-03/3163299-49.patch",
         "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch"
       },
       "drupal/default_content": {


### PR DESCRIPTION
How to test: 
- Get kasko instance up an running
- Run `composer require drupal/helfi_tpr:dev-UHF-X_views_infinite_scroll_update --with-all-dependencies && composer require drupal/helfi_platform_config:dev-UHF-X_views_infinite_scroll_update`
- Run `make drush-cr`
- Go to a page with multiple views and test their ajax functionalities
- Test also that admin views (media library) doesn't get ajax error when choosing an image for the hero

Check also: https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/90