### PR TITLE
UHF-3883: Remove metatag canonical URL override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.0', '8.1']
     container:
-      image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}
+      image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}-alpine
 
     services:
       db:

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -295,3 +295,28 @@ function helfi_tpr_config_update_9015() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Remove canonical url metatag override.
+ */
+function helfi_tpr_config_update_9016() : void {
+  if (!\Drupal::moduleHandler()->moduleExists('metatag')) {
+    return;
+  }
+
+  foreach (['tpr_unit', 'tpr_service'] as $type) {
+    $config = \Drupal::configFactory()->getEditable('metatag.metatag_defaults.' . $type);
+
+    if (!$config || !$tags = $config->get('tags')) {
+      continue;
+    }
+
+    // Remove canonical url from metatag overrides.
+    if (isset($tags['canonical_url'])) {
+      unset($tags['canonical_url']);
+
+      $config->set('tags', $tags)
+        ->save();
+    }
+  }
+}


### PR DESCRIPTION
To test this:

`drush updb`

Open any TPR service or unit page and make sure the canonical URL is an absolute URL.