### PR TITLE
UHF-3659: role_delegation installation & config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "drupal/pathauto": "^1.8",
     "drupal/publication_date": "^2.0@beta",
     "drupal/redirect": "^1.6",
+    "drupal/role_delegation" : "^1.1",
     "drupal/search_api": "^1.0",
     "drupal/scheduler": "^1.3",
     "drupal/select2": "^1.12",

--- a/helfi_features/helfi_base_config/config/update/helfi_base_config_update_9005.yml
+++ b/helfi_features/helfi_base_config/config/update/helfi_base_config_update_9005.yml
@@ -1,0 +1,14 @@
+core.extension:
+  expected_config: { }
+  update_actions:
+    change:
+      module:
+        role_delegation: 0
+user.role.admin:
+  expected_config: { }
+  update_actions:
+    add:
+      permissions:
+        - 'assign admin role'
+        - 'assign content_producer role'
+        - 'assign read_only role'

--- a/helfi_features/helfi_base_config/helfi_base_config.info.yml
+++ b/helfi_features/helfi_base_config/helfi_base_config.info.yml
@@ -34,6 +34,7 @@ dependencies:
   - 'linkit:linkit'
   - 'menu_block_current_language:menu_block_current_language'
   - 'pathauto:pathauto'
+  - 'role_delegation:role_delegation'
   - 'select2_icon:select2_icon'
   - 'simple_sitemap:simple_sitemap'
   - 'translatable_menu_link_uri:translatable_menu_link_uri'

--- a/helfi_features/helfi_base_config/helfi_base_config.install
+++ b/helfi_features/helfi_base_config/helfi_base_config.install
@@ -143,3 +143,18 @@ function helfi_base_config_update_9004() {
     ]);
   }
 }
+
+
+/**
+ * Permission update.
+ */
+function helfi_base_config_update_9005() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_base_config', 'helfi_base_config_update_9005');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
Adds Role Delegation module (https://www.drupal.org/project/role_delegation) and sets permissions for the Admin role to assign roles for users.

How to test:

1. Set up a fresh (for example) KASKO instance
2. Require this branch of the module: `composer require drupal/helfi_platform_config:dev-UHF-3659_admin_assign_roles`
3. Run database updates: `make drush-updb`
4. Access https://helfi-kasko.docker.so/en/childhood-and-education/admin/people/permissions/module/role_delegation and make sure that the Admin role has three permissions checked: Assign Admin role, Assign Content producer role, Assign Read only role

Once this PR is accepted and merged, the configs can be exported and taken into use on all sites.