### PR TITLE
UHF-2871 Service list items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ A longer description of the task
 ## How to install
 * Make sure your instance is up and running on latest dev branch.
     * `git pull origin dev`
-    * `make fresh` or `make up drush-sync-db drush-cim drush-updb drush-cr drush-uli`
+    * `make fresh`
 * Update the Helfi Platform config
     * `composer require drupal/helfi_platform_config:dev-UHF-0000_insert_correct_branch`
 * Run `make drush-updb drush-cr`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# TASK NAME [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
+A longer description of the task
+
+## What was done
+* Describe what was done
+
+## How to install
+* Make sure your instance is up and running on latest dev branch.
+    * `git pull origin dev`
+    * `make fresh` or `make up drush-sync-db drush-cim drush-updb drush-cr drush-uli`
+* Update the Helfi Platform config
+    * `composer require drupal/helfi_platform_config:dev-UHF-0000_insert_correct_branch`
+* Run `make drush-updb drush-cr`
+
+## How to test
+* Describe how to test the feature
+
+## Other PRs
+* Links to other PRs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# TASK NAME [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
+# TASKNAME [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
 A longer description of the task
 
 ## What was done

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9021.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9021.yml
@@ -1,0 +1,32 @@
+views.view.service_list:
+  expected_config:
+    display:
+      default:
+        display_options:
+          pager:
+            options:
+              items_per_page: 4
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            pager:
+              options:
+                items_per_page: 8
+views.view.unit_services:
+  expected_config:
+    display:
+      default:
+        display_options:
+          pager:
+            options:
+              items_per_page: 4
+  update_actions:
+    change:
+      display:
+        default:
+          display_options:
+            pager:
+              options:
+                items_per_page: 8

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -24,6 +24,7 @@ function helfi_tpr_config_install($is_syncing) {
       helfi_tpr_config_update_9015();
       helfi_tpr_config_update_9017();
       helfi_tpr_config_update_9018();
+      helfi_tpr_config_update_9021();
     }
 
     // If HELfi Announcements module is installed, install also
@@ -385,11 +386,10 @@ function helfi_tpr_config_update_9019() {
   }
 }
 
-
 /**
  * Install and configure content_lock module.
  */
-function helfi_tpr_config_update_90209() {
+function helfi_tpr_config_update_9020() {
   // Add TPR-entity specific views for locked content listing page.
   $configLocation = dirname(__FILE__) . '/config/install/';
   $configTranslationLocation = dirname(__FILE__) . '/config/language/';
@@ -421,4 +421,18 @@ function helfi_tpr_config_update_90209() {
     ConfigHelper::installNewConfig($configOptionalLocation, $configuration);
     ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
   }
+}
+
+/**
+ * Updated TPR Service lists to show eight (8) items when loading for more.
+ */
+function helfi_tpr_config_update_9021() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9021');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
 }


### PR DESCRIPTION
# Service list items [UHF-2871](https://helsinkisolutionoffice.atlassian.net/browse/UHF-2871)

## What was done
* Updated TPR Service views to show eight (8) items initially and when clicking load more. The value was four (4).

## How to install
* Make sure your instance is up and running on latest dev branch. Preferably Sote.
   * `git pull origin dev`
   * `make fresh` or `make up drush-sync-db drush-cim drush-updb drush-cr drush-uli`
* Update the Helfi Platform config
   * `composer require drupal/helfi_platform_config:dev-UHF-2871_service_list_items`
* Run `make drush-updb drush-cr`

## How to test
* Go to any unit which you know have a lot of services and check that there are initially eight services listed
   * F.e. https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/terveysasemat/haagan-terveysasema
* Check also the service list paragraph for the change
   * F.e. https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/terveysasemat

