### PR TITLE
UHF-X Added update hook to import locked views translations

### DIFF
--- a/helfi_features/helfi_content/config/language/fi/views.view.locked_services.yml
+++ b/helfi_features/helfi_content/config/language/fi/views.view.locked_services.yml
@@ -1,0 +1,39 @@
+label: 'Lukitut palvelut'
+display:
+  default:
+    display_title: Oletus
+    display_options:
+      title: 'Lukitut palvelut'
+      pager:
+        options:
+          tags: {  }
+          expose: {  }
+      exposed_form:
+        options:
+          submit_button: Käytä
+          exposed_sorts_label: Järjestä
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
+      empty:
+        area_text_custom:
+          content: 'Lukittuja palveluja ei ole.'
+      filters:
+        name:
+          expose:
+            label: Otsikko
+      fields:
+        tpr_service_bulk_form:
+          label: Bulkkipäivitys
+          action_title: Toiminto
+        name:
+          label: Otsikko
+        name_1:
+          label: 'Lukituksen tekijä'
+        timestamp:
+          label: 'Lukituksen ajankohta'
+        langcode:
+          label: 'Sisällön kieli'
+        operations:
+          label: Toiminnot
+  locked_services_block:
+    display_title: Lohko

--- a/helfi_features/helfi_content/config/language/fi/views.view.locked_units.yml
+++ b/helfi_features/helfi_content/config/language/fi/views.view.locked_units.yml
@@ -1,0 +1,40 @@
+label: 'Lukitut toimipisteet'
+display:
+  default:
+    display_title: Oletus
+    display_options:
+      title: 'Lukitut toimipisteet'
+      pager:
+        options:
+          tags: {  }
+          expose: {  }
+      exposed_form:
+        options:
+          submit_button: Käytä
+          reset_button_label: Palauta
+          exposed_sorts_label: Järjestä
+          sort_asc_label: Nouseva
+          sort_desc_label: Laskeva
+      filters:
+        name:
+          expose:
+            label: Otsikko
+      fields:
+        tpr_unit_bulk_form:
+          label: Bulkkipäivitys
+          action_title: Toiminto
+        name:
+          label: Otsikko
+        name_1:
+          label: 'Lukituksen tekijä'
+        timestamp:
+          label: 'Lukituksen ajankohta'
+        langcode:
+          label: 'Sisällön kieli'
+        operations:
+          label: Toiminnot
+      empty:
+        area_text_custom:
+          content: 'Lukittuja toimipisteitä ei ole.'
+  locked_units_block:
+    display_title: Lohko

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -27,6 +27,7 @@ function helfi_content_install($is_syncing) {
     helfi_content_update_9011();
     helfi_content_update_9016();
     helfi_content_update_9019();
+    helfi_content_update_9021();
   }
 }
 
@@ -428,6 +429,23 @@ function helfi_content_update_9019() {
   ];
 
   // Update translations.
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
+  }
+}
+
+/**
+ * Update configuration translations for Helfi Base config.
+ */
+function helfi_content_update_9021() {
+  // Handle the configuration translation update manually.
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  $configurations = [
+    'views.view.locked_services',
+    'views.view.locked_units',
+  ];
+  // Install configurations and translations.
   foreach ($configurations as $configuration) {
     ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
   }


### PR DESCRIPTION
# Added update hook to import locked views translations
Locked views translations were not implemented correctly originally - now here is a PR that does.

## What was done
* Added an update hook that imports the translations when run.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_locked_units_services_translations`
* Run `make drush-updb drush-cr`

## How to test
* Make sure that after the update hook is run your locked views are translated and if you run `make drush-cex` the two configuration files are added to your codebase.
