### PR TITLE
Added helfi_api_base module as dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "drupal/focal_point": "^1.5",
     "drupal/helfi_api_base": "*",
     "drupal/helfi_media_map": "*",
-    "drupal/helfi_tpr": "^2.0",
+    "drupal/helfi_tpr": "*",
     "drupal/helfi_media_formtool": "*",
     "drupal/image_style_quality": "^1.4",
     "drupal/imagecache_external": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "drupal/features": "^3.12",
     "drupal/field_group": "^3.1",
     "drupal/focal_point": "^1.5",
+    "drupal/helfi_api_base": "^2.0",
     "drupal/helfi_media_map": "*",
     "drupal/helfi_tpr": "^2.0",
     "drupal/helfi_media_formtool": "*",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "drupal/features": "^3.12",
     "drupal/field_group": "^3.1",
     "drupal/focal_point": "^1.5",
-    "drupal/helfi_api_base": "^2.0",
+    "drupal/helfi_api_base": "*",
     "drupal/helfi_media_map": "*",
     "drupal/helfi_tpr": "^2.0",
     "drupal/helfi_media_formtool": "*",

--- a/helfi_platform_config.info.yml
+++ b/helfi_platform_config.info.yml
@@ -5,5 +5,6 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - 'drupal:language'
+  - 'helfi_api_base:helfi_api_base'
   - 'menu_block_current_language:menu_block_current_language'
   - 'update_helper:update_helper'


### PR DESCRIPTION
# Helfi Api base module as dependency

Installing new site fails when the installation is run using [composer oneliner](https://github.com/City-of-Helsinki/drupal-helfi-platform) and with `make new`. The drush command `drush helfi:locale-import helfi_platform_config` will fail as the helfi_api_base module is not installed. 

## What was done
* Added helfi_api_base module as a dependency.

## How to install and test
* Run `composer create-project City-of-Helsinki/drupal-helfi-platform:dev-main yoursite --no-interaction --repository https://repository.drupal.hel.ninja/`
* Run `composer require drupal/helfi_platform_config:dev-UHF-X_helfi_api_base_dependency`
* Run `make new`
* Make sure the installation finishes without fatal errors 
