### PR TITLE
UHF-4556 CKEditor link conversion

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -182,14 +182,14 @@ function helfi_platform_config_update_9007() {
 
   // Search and replace following data.
   $data_to_be_converted = [
-    'hdbt-icon--link-external' => '', // Remove manually added external link icon.
-    'hdbt-icon--' => '" data-selected-icon="', // Convert icon to data-selected-icon.
-    'hdbt-icon' => '', // Remove hdbt-icon class.
-    'target="_blank"' => '', // Remove target=_blank.
-    'data-protocol="false"' => '', // Remove false data-attributes.
-    'data-is-external="false"' => '', // Remove false data-attributes.
-    'data-is-external="true"' => '', // Remove manually added data-attribute.
-    'data-icon=' => 'data-selected-icon=', // Convert icon to selected icon.
+    'hdbt-icon--link-external' => '',
+    'hdbt-icon--' => '" data-selected-icon="',
+    'hdbt-icon' => '',
+    'target="_blank"' => '',
+    'data-protocol="false"' => '',
+    'data-is-external="false"' => '',
+    'data-is-external="true"' => '',
+    'data-icon=' => 'data-selected-icon=',
   ];
 
   // Load all field configurations.

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -172,3 +172,56 @@ function helfi_platform_config_update_9006() {
     ]);
   }
 }
+
+/**
+ * Reconstruct CKEditor generated links with icons.
+ */
+function helfi_platform_config_update_9007() {
+  $entity_type_manager = Drupal::entityTypeManager();
+  $field_storage = $entity_type_manager->getStorage('field_config');
+
+  // Search and replace following data.
+  $data_to_be_converted = [
+    'hdbt-icon--link-external' => '', // Remove manually added external link icon.
+    'hdbt-icon--' => '" data-selected-icon="', // Convert icon to data-selected-icon.
+    'hdbt-icon' => '', // Remove hdbt-icon class.
+    'target="_blank"' => '', // Remove target=_blank.
+    'data-protocol="false"' => '', // Remove false data-attributes.
+    'data-is-external="false"' => '', // Remove false data-attributes.
+    'data-is-external="true"' => '', // Remove manually added data-attribute.
+    'data-icon=' => 'data-selected-icon=', // Convert icon to selected icon.
+  ];
+
+  // Load all field configurations.
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  foreach ($field_storage->loadMultiple() as $field_config) {
+
+    // Go through each field and check for long text fields (html formatted).
+    if ($field_config->getType() === 'text_long') {
+      $field_storage_definition = $field_config->getFieldStorageDefinition();
+      $entity_type = $field_config->getTargetEntityTypeId();
+
+      /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
+      $table_mapping = $entity_type_manager->getStorage($entity_type)->getTableMapping();
+
+      // Get current field's table name and column.
+      $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
+      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+
+      // Go through our data array, treat array key as data to search for
+      // and array value as replacement. Use sql replace to replace the data.
+      foreach ($data_to_be_converted as $old => $new) {
+        $query = Drupal::database()->update($table_name);
+        $query->expression(
+          $column,
+          "REPLACE($column, :old_value, :new_value)",
+          [
+            ':old_value' => $old,
+            ':new_value' => $new,
+          ]
+        );
+        $result = $query->execute();
+      }
+    }
+  }
+}


### PR DESCRIPTION
# CKEditor link conversion [UHF-4556](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4556)
A tool to fix broken icon links made with CKEditor.

## What was done
* Created an update hook which will go through each user generated CKEditor link button with icon
   * The processor will remove target=_blank, obsolete false data attributes and will convert the data-icon to data-selected-icon

## How to install
* Install your instance with the instructions found from https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/263
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4556_ckeditor_link_conversion`
* Run `make drush-updb drush-cr`

## How to test
* Check for pages with broken button links (IE. double icons, missing icons, etc). Here's few examples:
   * https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/sosiaali-ja-terveyspalvelut
   * https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/asiakkaan-tiedot-ja-oikeudet
   * https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/hammashoito
   
