### PR TITLE
Locked Gin toolbar module version to 1.0-beta20.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "drupal/crop": "^2.1",
     "drupal/default_content": "^2.0.0-alpha1",
     "drupal/diff": "^1.0",
-    "drupal/gin_toolbar": "^1.0@beta",
+    "drupal/gin_toolbar": "1.0-beta20",
     "drupal/entity_usage": "^2.0@beta",
     "drupal/easy_breadcrumb": "^2.0",
     "drupal/elasticsearch_connector": "^7.0@alpha",


### PR DESCRIPTION
# Lock Gin toolbar module version to 1.0@beta20.
Locked gin theme to 1.0-beta20 as it needs some TLC before updating to latest version.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_gin_toolbar_lock -W`
* Run `make drush-updb drush-cr`

## How to test
* Check your instance composer.lock for drupal/gin_toolbar and make sure it's 1.0-beta20

