### PR TITLE
Draft: UHF-4792: Add update hook for TPR view changes for new status_extra filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "drupal/focal_point": "^1.5",
     "drupal/helfi_api_base": "*",
     "drupal/helfi_media_map": "*",
-    "drupal/helfi_tpr": "*",
+    "drupal/helfi_tpr": "^2.0.5",
     "drupal/helfi_media_formtool": "*",
     "drupal/image_style_quality": "^1.4",
     "drupal/imagecache_external": "^3.0",

--- a/helfi_features/helfi_tpr_config/config/install/views.view.service_list.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.service_list.yml
@@ -16,80 +16,23 @@ base_table: tpr_service_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Default
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: infinite_scroll
-        options:
-          items_per_page: 4
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'Load more services'
-            automatically_load_content: false
-            initially_load_all_pages: false
-      style:
-        type: default
-        options:
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: 'entity:tpr_service'
-        options:
-          relationship: none
-          view_mode: teaser
+      title: ''
       fields:
         name:
+          id: name
           table: tpr_service_field_data
           field: name
-          id: name
-          entity_type: null
-          entity_field: name
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -158,20 +101,150 @@ display:
           entity_type: tpr_service
           entity_field: name_override
           plugin_id: field
+      pager:
+        type: infinite_scroll
+        options:
+          offset: 0
+          items_per_page: 8
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load more services'
+            automatically_load_content: false
+            initially_load_all_pages: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No results'
+            format: full_html
+          tokenize: false
+      sorts:
+        name:
+          id: name
+          table: tpr_service_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name
+          exposed: false
+        name_override:
+          id: name_override
+          table: tpr_service_field_data
+          field: name_override
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: name_override
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name_override
+          exposed: false
+      arguments:
+        id:
+          id: id
+          table: tpr_service_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: id
+          plugin_id: string
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:tpr_service'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 1
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
       filters:
         content_translation_status:
-          value: '1'
+          id: content_translation_status
           table: tpr_service_field_data
           field: content_translation_status
-          plugin_id: boolean
           entity_type: tpr_service
           entity_field: content_translation_status
-          id: content_translation_status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         langcode:
           id: langcode
           table: tpr_service_field_data
@@ -179,6 +252,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_service
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -211,104 +287,69 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: tpr_service
-          entity_field: langcode
-          plugin_id: language
-      sorts:
-        name:
-          id: name
+        status_extra:
+          id: status_extra
           table: tpr_service_field_data
-          field: name
+          field: status_extra
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
+          entity_type: tpr_service
+          plugin_id: tpr_status
+          operator: '='
+          value: ''
+          group: 1
           exposed: false
           expose:
+            operator_id: ''
             label: ''
-          entity_type: tpr_service
-          entity_field: name
-          plugin_id: standard
-        name_override:
-          id: name_override
-          table: tpr_service_field_data
-          field: name_override
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:tpr_service'
+        options:
           relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: tpr_service
-          entity_field: name_override
-          plugin_id: standard
-      title: ''
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: true
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No results'
-            format: full_html
-          plugin_id: text
-      relationships: {  }
-      arguments:
-        id:
-          id: id
-          table: tpr_service_field_data
-          field: id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:tpr_service'
-            fail: 'not found'
-          validate_options:
-            operation: view
-            multiple: 1
-            access: false
-            bundles: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
-          entity_type: tpr_service
-          entity_field: id
-          plugin_id: string
       display_extenders: {  }
-      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -316,15 +357,108 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }
   block:
-    display_plugin: block
     id: block
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
+      filters:
+        status_extra:
+          id: status_extra
+          table: tpr_service_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          plugin_id: tpr_status
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: tpr_service_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -332,15 +466,15 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }
   entity_reference_1:
-    display_plugin: entity_reference
     id: entity_reference_1
     display_title: 'Entity Reference'
+    display_plugin: entity_reference
     position: 2
     display_options:
-      display_extenders: {  }
       fields:
         name_override:
           id: name_override
@@ -349,6 +483,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_service
+          entity_field: name_override
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -404,9 +541,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_service
-          entity_field: name_override
-          plugin_id: field
         id:
           id: id
           table: tpr_service_field_data
@@ -414,6 +548,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_service
+          entity_field: id
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -469,9 +606,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_service
-          entity_field: id
-          plugin_id: field
         name:
           id: name
           table: tpr_service_field_data
@@ -479,6 +613,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -534,18 +671,99 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: name
-          plugin_id: field
-      defaults:
-        fields: false
-        arguments: false
       pager:
         type: some
         options:
-          items_per_page: 40
           offset: 0
+          items_per_page: 40
       arguments: {  }
+      filters:
+        content_translation_status:
+          id: content_translation_status
+          table: tpr_service_field_data
+          field: content_translation_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: content_translation_status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: tpr_service_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: entity_reference
         options:
@@ -553,6 +771,15 @@ display:
             name_override: name_override
             id: id
             name: name
+      defaults:
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/helfi_features/helfi_tpr_config/config/install/views.view.service_units.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.service_units.yml
@@ -1,0 +1,353 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.tpr_unit.teaser_with_image
+  module:
+    - helfi_tpr
+    - user
+    - views_infinite_scroll
+id: service_units
+label: 'Service units'
+module: views
+description: 'Lists all published units that offer the service'
+tag: ''
+base_table: tpr_unit_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: ''
+      fields:
+        name:
+          id: name
+          table: tpr_unit_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: infinite_scroll
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load more service points'
+            automatically_load_content: false
+            initially_load_all_pages: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        name:
+          id: name
+          table: tpr_unit_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name
+          exposed: false
+        name_override:
+          id: name_override
+          table: tpr_unit_field_data
+          field: name_override
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: name_override
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name_override
+          exposed: false
+      arguments:
+        id:
+          id: id
+          table: tpr_service_field_data
+          field: id
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: id
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:tpr_service'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 0
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+      filters:
+        status_extra:
+          id: status_extra
+          table: tpr_unit_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          plugin_id: tpr_status
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: tpr_unit_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: 'entity:tpr_unit'
+        options:
+          relationship: none
+          view_mode: teaser_with_image
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+      relationships:
+        services_target_id:
+          id: services_target_id
+          table: tpr_unit__services
+          field: services_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'TPR - Service'
+          entity_type: tpr_unit
+          entity_field: services
+          plugin_id: standard
+          required: true
+      use_ajax: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags: {  }
+  service_units:
+    id: service_units
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      rendering_language: '***LANGUAGE_entity_translation***'
+      display_extenders:
+        metatag_display_extender: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags: {  }

--- a/helfi_features/helfi_tpr_config/config/install/views.view.unit_search.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.unit_search.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.teaser_with_image
-    - taxonomy.vocabulary.neighbourhoods
   module:
     - address
     - helfi_tpr

--- a/helfi_features/helfi_tpr_config/config/install/views.view.unit_search.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.unit_search.yml
@@ -3,9 +3,11 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.tpr_unit.teaser_with_image
+    - taxonomy.vocabulary.neighbourhoods
   module:
     - address
     - helfi_tpr
+    - taxonomy
     - user
     - views_infinite_scroll
 id: unit_search
@@ -17,80 +19,23 @@ base_table: tpr_unit_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Default
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Käytä
-          reset_button: false
-          reset_button_label: Palauta
-          exposed_sorts_label: Lajittele
-          expose_sort_order: true
-          sort_asc_label: Nousevasti
-          sort_desc_label: Laskevasti
-      pager:
-        type: infinite_scroll
-        options:
-          items_per_page: 5
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          views_infinite_scroll:
-            button_text: 'Load more results'
-            automatically_load_content: false
-            initially_load_all_pages: false
-      style:
-        type: default
-        options:
-          row_class: ''
-          default_row_class: true
-          uses_fields: true
-      row:
-        type: 'entity:tpr_unit'
-        options:
-          relationship: none
-          view_mode: teaser_with_image
+      title: ''
       fields:
         name:
+          id: name
           table: tpr_unit_field_data
           field: name
-          id: name
-          entity_type: null
-          entity_field: name
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -135,7 +80,7 @@ display:
           click_sort_column: value
           type: string
           settings: {  }
-          group_column: value
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -152,6 +97,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: address
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -196,7 +144,7 @@ display:
           click_sort_column: langcode
           type: address_default
           settings: {  }
-          group_column: ''
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -206,9 +154,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_unit
-          entity_field: address
-          plugin_id: field
         address__address_line1:
           id: address__address_line1
           table: tpr_unit_field_data
@@ -216,6 +161,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: address
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -260,7 +208,7 @@ display:
           click_sort_column: langcode
           type: address_default
           settings: {  }
-          group_column: ''
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -270,9 +218,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_unit
-          entity_field: address
-          plugin_id: field
         address__address_line2:
           id: address__address_line2
           table: tpr_unit_field_data
@@ -280,6 +225,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: address
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -324,7 +272,7 @@ display:
           click_sort_column: langcode
           type: address_default
           settings: {  }
-          group_column: ''
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -334,9 +282,267 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        id:
+          id: id
+          table: tpr_unit_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: tpr_unit
-          entity_field: address
+          entity_field: id
           plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: entity_id
+          group_columns:
+            entity_id: entity_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name_1:
+          id: name_1
+          table: taxonomy_term_field_data
+          field: name
+          relationship: field_districts
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: entity_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      pager:
+        type: infinite_scroll
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load more results'
+            automatically_load_content: false
+            initially_load_all_pages: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Käytä
+          reset_button: false
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          expose_sort_order: true
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No results'
+            format: full_html
+          tokenize: false
+      sorts:
+        name:
+          id: name
+          table: tpr_unit_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name
+          exposed: false
+        name_override:
+          id: name_override
+          table: tpr_unit_field_data
+          field: name_override
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: name_override
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name_override
+          exposed: false
+      arguments:
+        id:
+          id: id
+          table: tpr_unit_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: id
+          plugin_id: string
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:tpr_unit'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 1
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
       filters:
         combine:
           id: combine
@@ -345,6 +551,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: combine
           operator: allwords
           value: ''
           group: 1
@@ -387,16 +594,18 @@ display:
             address__postal_code: address__postal_code
             address__address_line1: address__address_line1
             address__address_line2: address__address_line2
-          plugin_id: combine
-        content_translation_status:
-          id: content_translation_status
+            name_1: name_1
+        status_extra:
+          id: status_extra
           table: tpr_unit_field_data
-          field: content_translation_status
+          field: status_extra
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          plugin_id: tpr_status
           operator: '='
-          value: '1'
+          value: ''
           group: 1
           exposed: false
           expose:
@@ -425,9 +634,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: tpr_unit
-          entity_field: content_translation_status
-          plugin_id: boolean
         langcode:
           id: langcode
           table: tpr_unit_field_data
@@ -435,6 +641,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -467,103 +676,177 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        provided_languages_value:
+          id: provided_languages_value
+          table: tpr_unit__provided_languages
+          field: provided_languages_value
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: tpr_unit
+          entity_field: provided_languages
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: provided_languages_value_op
+            label: 'Provided languages'
+            description: null
+            use_operator: false
+            operator: provided_languages_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: provided_languages_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: null
+          is_grouped: true
+          group_info:
+            label: ''
+            description: ''
+            identifier: provided_languages_value
+            optional: true
+            widget: select
+            multiple: true
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Show heath stations that provide service in Swedish'
+                operator: '='
+                value: sv
+        field_districts_target_id:
+          id: field_districts_target_id
+          table: tpr_unit__field_districts
+          field: field_districts_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: empty
+          value: {  }
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: neighbourhoods
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        langcode_1:
+          id: langcode_1
+          table: taxonomy_term_field_data
+          field: langcode
+          relationship: field_districts
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
           entity_field: langcode
           plugin_id: language
-      sorts:
-        name:
-          id: name
-          table: tpr_unit_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 2
           exposed: false
           expose:
+            operator_id: ''
             label: ''
-          entity_type: tpr_unit
-          entity_field: name
-          plugin_id: standard
-        name_override:
-          id: name_override
-          table: tpr_unit_field_data
-          field: name_override
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+      row:
+        type: 'entity:tpr_unit'
+        options:
+          relationship: none
+          view_mode: teaser_with_image
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        field_districts:
+          id: field_districts
+          table: tpr_unit__field_districts
+          field: field_districts
           relationship: none
           group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: tpr_unit
-          entity_field: name_override
+          admin_label: 'field_districts: Taxonomy term'
           plugin_id: standard
-      title: ''
+          required: false
+      use_ajax: true
+      group_by: true
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No results'
-            format: full_html
-          plugin_id: text
-      relationships: {  }
-      arguments:
-        id:
-          id: id
-          table: tpr_unit_field_data
-          field: id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:tpr_unit'
-            fail: 'not found'
-          validate_options:
-            operation: view
-            multiple: 1
-            access: false
-            bundles: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: true
-          entity_type: tpr_unit
-          entity_field: id
-          plugin_id: string
       display_extenders: {  }
-      use_ajax: true
     cache_metadata:
       max-age: -1
       contexts:
@@ -571,16 +854,18 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }
   block:
-    display_plugin: block
     id: block
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       rendering_language: '***LANGUAGE_entity_translation***'
+      display_extenders:
+        metatag_display_extender: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -588,15 +873,15 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags: {  }
   entity_reference:
-    display_plugin: entity_reference
     id: entity_reference
     display_title: 'Entity Reference'
+    display_plugin: entity_reference
     position: 2
     display_options:
-      display_extenders: {  }
       fields:
         name_override:
           id: name_override
@@ -605,6 +890,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: name_override
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -660,9 +948,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_unit
-          entity_field: name_override
-          plugin_id: field
         id:
           id: id
           table: tpr_unit_field_data
@@ -670,6 +955,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: id
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -725,9 +1013,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: tpr_unit
-          entity_field: id
-          plugin_id: field
         name:
           id: name
           table: tpr_unit_field_data
@@ -735,6 +1020,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -790,14 +1078,12 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: name
-          plugin_id: field
-      defaults:
-        fields: false
-        filters: false
-        filter_groups: false
-        arguments: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 40
+      arguments: {  }
       filters:
         content_translation_status:
           id: content_translation_status
@@ -806,6 +1092,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: content_translation_status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -836,9 +1125,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: tpr_unit
-          entity_field: content_translation_status
-          plugin_id: boolean
         langcode:
           id: langcode
           table: tpr_unit_field_data
@@ -846,6 +1132,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: tpr_unit
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -878,14 +1167,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: tpr_unit
-          entity_field: langcode
-          plugin_id: language
       filter_groups:
         operator: AND
         groups:
           1: AND
-      arguments: {  }
       style:
         type: entity_reference
         options:
@@ -893,11 +1178,15 @@ display:
             name: name
             id: id
             name_override: name_override
-      pager:
-        type: some
-        options:
-          items_per_page: 40
-          offset: 0
+      defaults:
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      relationships: {  }
+      display_extenders:
+        metatag_display_extender: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/helfi_features/helfi_tpr_config/config/install/views.view.unit_services.yml
+++ b/helfi_features/helfi_tpr_config/config/install/views.view.unit_services.yml
@@ -1,0 +1,340 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.tpr_service.teaser
+  module:
+    - helfi_tpr
+    - user
+    - views_infinite_scroll
+id: unit_services
+label: 'Unit services'
+module: views
+description: 'Lists all published services attached to a unit'
+tag: ''
+base_table: tpr_unit_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: ''
+      fields:
+        rendered_entity:
+          id: rendered_entity
+          table: tpr_service
+          field: rendered_entity
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          plugin_id: rendered_entity
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: teaser
+      pager:
+        type: infinite_scroll
+        options:
+          offset: 0
+          items_per_page: 8
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          views_infinite_scroll:
+            button_text: 'Load more services'
+            automatically_load_content: false
+            initially_load_all_pages: false
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        name:
+          id: name
+          table: tpr_service_field_data
+          field: name
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name
+          exposed: false
+        name_override:
+          id: name_override
+          table: tpr_service_field_data
+          field: name_override
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: name_override
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: name_override
+          exposed: false
+      arguments:
+        id:
+          id: id
+          table: tpr_unit_field_data
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_unit
+          entity_field: id
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:tpr_unit'
+            fail: 'not found'
+          validate_options:
+            bundles: {  }
+            access: false
+            operation: view
+            multiple: 0
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+      filters:
+        status_extra:
+          id: status_extra
+          table: tpr_service_field_data
+          field: status_extra
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          plugin_id: tpr_status
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: tpr_service_field_data
+          field: langcode
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
+      relationships:
+        services_target_id:
+          id: services_target_id
+          table: tpr_unit__services
+          field: services_target_id
+          relationship: none
+          group_type: group
+          admin_label: 'TPR - Service'
+          entity_type: tpr_unit
+          entity_field: services
+          plugin_id: standard
+          required: true
+      use_ajax: true
+      group_by: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.tpr_service.tpr_service.default'
+        - 'config:core.entity_view_display.tpr_service.tpr_service.teaser'
+  unit_services:
+    id: unit_services
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      rendering_language: '***LANGUAGE_entity_translation***'
+      display_extenders:
+        metatag_display_extender: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - user.permissions
+      tags:
+        - 'config:core.entity_view_display.tpr_service.tpr_service.default'
+        - 'config:core.entity_view_display.tpr_service.tpr_service.teaser'

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
@@ -1,0 +1,1088 @@
+views.view.service_units:
+  expected_config:
+    display:
+      default:
+        display_options:
+          filters:
+            content_translation_status:
+              admin_label: ''
+              entity_field: content_translation_status
+              entity_type: tpr_unit
+              expose:
+                description: ''
+                identifier: ''
+                label: ''
+                multiple: false
+                operator: ''
+                operator_id: ''
+                operator_limit_selection: false
+                operator_list: {  }
+                remember: false
+                remember_roles:
+                  authenticated: authenticated
+                required: false
+                use_operator: false
+              exposed: false
+              field: content_translation_status
+              group: 1
+              group_info:
+                default_group: All
+                default_group_multiple: {  }
+                description: ''
+                group_items: {  }
+                identifier: ''
+                label: ''
+                multiple: false
+                optional: true
+                remember: false
+                widget: select
+              group_type: group
+              id: content_translation_status
+              is_grouped: false
+              operator: '='
+              plugin_id: boolean
+              relationship: none
+              table: tpr_unit_field_data
+              value: '1'
+          pager:
+            options:
+              items_per_page: 8
+          row:
+            options:
+              view_mode: teaser
+        display_title: Master
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              content_translation_status:
+                admin_label: ''
+                entity_field: content_translation_status
+                entity_type: tpr_unit
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: content_translation_status
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: content_translation_status
+                is_grouped: false
+                operator: '='
+                plugin_id: boolean
+                relationship: none
+                table: tpr_unit_field_data
+                value: '1'
+    add:
+      display:
+        default:
+          cache_metadata:
+            contexts:
+              - user
+          display_options:
+            filter_groups:
+              groups:
+                1: AND
+              operator: AND
+            filters:
+              status_extra:
+                admin_label: ''
+                entity_type: tpr_unit
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: status_extra
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: status_extra
+                is_grouped: false
+                operator: '='
+                plugin_id: tpr_status
+                relationship: none
+                table: tpr_unit_field_data
+                value: ''
+            sorts:
+              name:
+                expose:
+                  field_identifier: name
+              name_override:
+                expose:
+                  field_identifier: name_override
+        service_units:
+          cache_metadata:
+            contexts:
+              - user
+    change:
+      display:
+        default:
+          display_options:
+            pager:
+              options:
+                items_per_page: 5
+            row:
+              options:
+                view_mode: teaser_with_image
+          display_title: Default
+views.view.unit_services:
+  expected_config:
+    display:
+      default:
+        display_options:
+          filters:
+            content_translation_status:
+              admin_label: ''
+              entity_field: content_translation_status
+              entity_type: tpr_service
+              expose:
+                description: ''
+                identifier: ''
+                label: ''
+                multiple: false
+                operator: ''
+                operator_id: ''
+                operator_limit_selection: false
+                operator_list: {  }
+                remember: false
+                remember_roles:
+                  authenticated: authenticated
+                required: false
+                use_operator: false
+              exposed: false
+              field: content_translation_status
+              group: 1
+              group_info:
+                default_group: All
+                default_group_multiple: {  }
+                description: ''
+                group_items: {  }
+                identifier: ''
+                label: ''
+                multiple: false
+                optional: true
+                remember: false
+                widget: select
+              group_type: group
+              id: content_translation_status
+              is_grouped: false
+              operator: '='
+              plugin_id: boolean
+              relationship: services_target_id
+              table: tpr_service_field_data
+              value: '1'
+          pager:
+            options:
+              items_per_page: 4
+        display_title: Master
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              content_translation_status:
+                admin_label: ''
+                entity_field: content_translation_status
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: content_translation_status
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: content_translation_status
+                is_grouped: false
+                operator: '='
+                plugin_id: boolean
+                relationship: services_target_id
+                table: tpr_service_field_data
+                value: '1'
+    add:
+      display:
+        default:
+          cache_metadata:
+            contexts:
+              - user
+          display_options:
+            filter_groups:
+              groups:
+                1: AND
+              operator: AND
+            filters:
+              status_extra:
+                admin_label: ''
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: status_extra
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: status_extra
+                is_grouped: false
+                operator: '='
+                plugin_id: tpr_status
+                relationship: services_target_id
+                table: tpr_service_field_data
+                value: ''
+            sorts:
+              name:
+                expose:
+                  field_identifier: name
+              name_override:
+                expose:
+                  field_identifier: name_override
+        unit_services:
+          cache_metadata:
+            contexts:
+              - user
+    change:
+      display:
+        default:
+          display_options:
+            pager:
+              options:
+                items_per_page: 8
+          display_title: Default
+views.view.service_list:
+  expected_config:
+    display:
+      block:
+        display_options:
+          display_extenders: {  }
+      default:
+        display_options:
+          pager:
+            options:
+              items_per_page: 4
+      entity_reference_1:
+        display_options:
+          display_extenders: {  }
+  update_actions:
+    add:
+      display:
+        block:
+          cache_metadata:
+            contexts:
+              - user
+        default:
+          cache_metadata:
+            contexts:
+              - user
+          display_options:
+            filters:
+              status_extra:
+                admin_label: ''
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: status_extra
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: status_extra
+                is_grouped: false
+                operator: '='
+                plugin_id: tpr_status
+                relationship: none
+                table: tpr_service_field_data
+                value: ''
+            sorts:
+              name:
+                expose:
+                  field_identifier: name
+              name_override:
+                expose:
+                  field_identifier: name_override
+        entity_reference_1:
+          display_options:
+            filter_groups:
+              groups:
+                1: AND
+              operator: AND
+            filters:
+              content_translation_status:
+                admin_label: ''
+                entity_field: content_translation_status
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: content_translation_status
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: content_translation_status
+                is_grouped: false
+                operator: '='
+                plugin_id: boolean
+                relationship: none
+                table: tpr_service_field_data
+                value: '1'
+              langcode:
+                admin_label: ''
+                entity_field: langcode
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  reduce: false
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: langcode
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: langcode
+                is_grouped: false
+                operator: in
+                plugin_id: language
+                relationship: none
+                table: tpr_service_field_data
+                value:
+                  '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+    change:
+      display:
+        block:
+          display_options:
+            defaults:
+              filter_groups: false
+              filters: false
+            display_extenders:
+              metatag_display_extender:
+                metatags: {  }
+                tokenize: false
+            filter_groups:
+              groups:
+                1: AND
+              operator: AND
+            filters:
+              langcode:
+                admin_label: ''
+                entity_field: langcode
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  reduce: false
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: langcode
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: langcode
+                is_grouped: false
+                operator: in
+                plugin_id: language
+                relationship: none
+                table: tpr_service_field_data
+                value:
+                  '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+              status_extra:
+                admin_label: ''
+                entity_type: tpr_service
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: status_extra
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: status_extra
+                is_grouped: false
+                operator: '='
+                plugin_id: tpr_status
+                relationship: none
+                table: tpr_service_field_data
+                value: ''
+        default:
+          display_options:
+            pager:
+              options:
+                items_per_page: 8
+        entity_reference_1:
+          display_options:
+            defaults:
+              filter_groups: false
+              filters: false
+            display_extenders:
+              metatag_display_extender:
+                metatags: {  }
+                tokenize: false
+views.view.unit_search:
+  expected_config:
+    display:
+      block:
+        display_options:
+          display_extenders: {  }
+      default:
+        display_options:
+          fields:
+            address__address_line1:
+              group_column: ''
+            address__address_line2:
+              group_column: ''
+            address__postal_code:
+              group_column: ''
+            name:
+              group_column: value
+          filters:
+            content_translation_status:
+              admin_label: ''
+              entity_field: content_translation_status
+              entity_type: tpr_unit
+              expose:
+                description: ''
+                identifier: ''
+                label: ''
+                multiple: false
+                operator: ''
+                operator_id: ''
+                operator_limit_selection: false
+                operator_list: {  }
+                remember: false
+                remember_roles:
+                  authenticated: authenticated
+                required: false
+                use_operator: false
+              exposed: false
+              field: content_translation_status
+              group: 1
+              group_info:
+                default_group: All
+                default_group_multiple: {  }
+                description: ''
+                group_items: {  }
+                identifier: ''
+                label: ''
+                multiple: false
+                optional: true
+                remember: false
+                widget: select
+              group_type: group
+              id: content_translation_status
+              is_grouped: false
+              operator: '='
+              plugin_id: boolean
+              relationship: none
+              table: tpr_unit_field_data
+              value: '1'
+          relationships: {  }
+      entity_reference:
+        display_options:
+          display_extenders: {  }
+  update_actions:
+    delete:
+      display:
+        default:
+          display_options:
+            filters:
+              content_translation_status:
+                admin_label: ''
+                entity_field: content_translation_status
+                entity_type: tpr_unit
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: content_translation_status
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: content_translation_status
+                is_grouped: false
+                operator: '='
+                plugin_id: boolean
+                relationship: none
+                table: tpr_unit_field_data
+                value: '1'
+    add:
+      display:
+        block:
+          cache_metadata:
+            contexts:
+              - user
+        default:
+          cache_metadata:
+            contexts:
+              - user
+          display_options:
+            fields:
+              id:
+                admin_label: ''
+                alter:
+                  absolute: false
+                  alt: ''
+                  alter_text: false
+                  ellipsis: true
+                  external: false
+                  html: false
+                  link_class: ''
+                  make_link: false
+                  max_length: 0
+                  more_link: false
+                  more_link_path: ''
+                  more_link_text: ''
+                  nl2br: false
+                  path: ''
+                  path_case: none
+                  prefix: ''
+                  preserve_tags: ''
+                  rel: ''
+                  replace_spaces: false
+                  strip_tags: false
+                  suffix: ''
+                  target: ''
+                  text: ''
+                  trim: false
+                  trim_whitespace: false
+                  word_boundary: true
+                click_sort_column: value
+                delta_first_last: false
+                delta_limit: 0
+                delta_offset: 0
+                delta_reversed: false
+                element_class: ''
+                element_default_classes: true
+                element_label_class: ''
+                element_label_colon: false
+                element_label_type: ''
+                element_type: ''
+                element_wrapper_class: ''
+                element_wrapper_type: ''
+                empty: ''
+                empty_zero: false
+                entity_field: id
+                entity_type: tpr_unit
+                exclude: true
+                field: id
+                field_api_classes: false
+                group_column: entity_id
+                group_columns:
+                  entity_id: entity_id
+                group_rows: true
+                group_type: group
+                hide_alter_empty: true
+                hide_empty: false
+                id: id
+                label: ''
+                multi_type: separator
+                plugin_id: field
+                relationship: none
+                separator: ', '
+                settings:
+                  link_to_entity: false
+                table: tpr_unit_field_data
+                type: string
+              name_1:
+                admin_label: ''
+                alter:
+                  absolute: false
+                  alt: ''
+                  alter_text: false
+                  ellipsis: true
+                  external: false
+                  html: false
+                  link_class: ''
+                  make_link: false
+                  max_length: 0
+                  more_link: false
+                  more_link_path: ''
+                  more_link_text: ''
+                  nl2br: false
+                  path: ''
+                  path_case: none
+                  prefix: ''
+                  preserve_tags: ''
+                  rel: ''
+                  replace_spaces: false
+                  strip_tags: false
+                  suffix: ''
+                  target: ''
+                  text: ''
+                  trim: false
+                  trim_whitespace: false
+                  word_boundary: true
+                click_sort_column: value
+                convert_spaces: false
+                delta_first_last: false
+                delta_limit: 0
+                delta_offset: 0
+                delta_reversed: false
+                element_class: ''
+                element_default_classes: true
+                element_label_class: ''
+                element_label_colon: false
+                element_label_type: ''
+                element_type: ''
+                element_wrapper_class: ''
+                element_wrapper_type: ''
+                empty: ''
+                empty_zero: false
+                entity_field: name
+                entity_type: taxonomy_term
+                exclude: true
+                field: name
+                field_api_classes: false
+                group_column: entity_id
+                group_columns: {  }
+                group_rows: true
+                group_type: group
+                hide_alter_empty: true
+                hide_empty: false
+                id: name_1
+                label: ''
+                multi_type: separator
+                plugin_id: term_name
+                relationship: field_districts
+                separator: ', '
+                settings:
+                  link_to_entity: false
+                table: taxonomy_term_field_data
+                type: string
+            filter_groups:
+              groups:
+                1: AND
+                2: OR
+              operator: AND
+            filters:
+              combine:
+                fields:
+                  name_1: name_1
+              langcode_1:
+                admin_label: ''
+                entity_field: langcode
+                entity_type: taxonomy_term
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  reduce: false
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: langcode
+                group: 2
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: langcode_1
+                is_grouped: false
+                operator: in
+                plugin_id: language
+                relationship: field_districts
+                table: taxonomy_term_field_data
+                value:
+                  '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+              provided_languages_value:
+                admin_label: ''
+                entity_field: provided_languages
+                entity_type: tpr_unit
+                expose:
+                  description: null
+                  identifier: provided_languages_value
+                  label: 'Provided languages'
+                  multiple: false
+                  operator: provided_languages_value_op
+                  operator_id: provided_languages_value_op
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  placeholder: null
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: true
+                field: provided_languages_value
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items:
+                    1:
+                      operator: '='
+                      title: 'Show heath stations that provide service in Swedish'
+                      value: sv
+                  identifier: provided_languages_value
+                  label: ''
+                  multiple: true
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: provided_languages_value
+                is_grouped: true
+                operator: '='
+                plugin_id: string
+                relationship: none
+                table: tpr_unit__provided_languages
+                value: ''
+              status_extra:
+                admin_label: ''
+                entity_type: tpr_unit
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: status_extra
+                group: 1
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                id: status_extra
+                is_grouped: false
+                operator: '='
+                plugin_id: tpr_status
+                relationship: none
+                table: tpr_unit_field_data
+                value: ''
+            group_by: true
+            sorts:
+              name:
+                expose:
+                  field_identifier: name
+              name_override:
+                expose:
+                  field_identifier: name_override
+        entity_reference:
+          display_options:
+            relationships: {  }
+    change:
+      display:
+        block:
+          display_options:
+            display_extenders:
+              metatag_display_extender: {  }
+        default:
+          display_options:
+            fields:
+              address__address_line1:
+                group_column: entity_id
+              address__address_line2:
+                group_column: entity_id
+              address__postal_code:
+                group_column: entity_id
+              name:
+                group_column: entity_id
+            filters:
+              field_districts_target_id:
+                admin_label: ''
+                error_message: true
+                expose:
+                  description: ''
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  operator: ''
+                  operator_id: ''
+                  operator_limit_selection: false
+                  operator_list: {  }
+                  reduce: false
+                  remember: false
+                  remember_roles:
+                    authenticated: authenticated
+                  required: false
+                  use_operator: false
+                exposed: false
+                field: field_districts_target_id
+                group: 2
+                group_info:
+                  default_group: All
+                  default_group_multiple: {  }
+                  description: ''
+                  group_items: {  }
+                  identifier: ''
+                  label: ''
+                  multiple: false
+                  optional: true
+                  remember: false
+                  widget: select
+                group_type: group
+                hierarchy: false
+                id: field_districts_target_id
+                is_grouped: false
+                limit: true
+                operator: empty
+                plugin_id: taxonomy_index_tid
+                reduce_duplicates: false
+                relationship: none
+                table: tpr_unit__field_districts
+                type: select
+                value: {  }
+                vid: neighbourhoods
+            relationships:
+              field_districts:
+                admin_label: 'field_districts: Taxonomy term'
+                field: field_districts
+                group_type: group
+                id: field_districts
+                plugin_id: standard
+                relationship: none
+                required: false
+                table: tpr_unit__field_districts
+        entity_reference:
+          display_options:
+            defaults:
+              relationships: false
+            display_extenders:
+              metatag_display_extender: {  }

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
@@ -1,56 +1,5 @@
 views.view.service_units:
-  expected_config:
-    display:
-      default:
-        display_options:
-          filters:
-            content_translation_status:
-              admin_label: ''
-              entity_field: content_translation_status
-              entity_type: tpr_unit
-              expose:
-                description: ''
-                identifier: ''
-                label: ''
-                multiple: false
-                operator: ''
-                operator_id: ''
-                operator_limit_selection: false
-                operator_list: {  }
-                remember: false
-                remember_roles:
-                  authenticated: authenticated
-                required: false
-                use_operator: false
-              exposed: false
-              field: content_translation_status
-              group: 1
-              group_info:
-                default_group: All
-                default_group_multiple: {  }
-                description: ''
-                group_items: {  }
-                identifier: ''
-                label: ''
-                multiple: false
-                optional: true
-                remember: false
-                widget: select
-              group_type: group
-              id: content_translation_status
-              is_grouped: false
-              operator: '='
-              plugin_id: boolean
-              relationship: none
-              table: tpr_unit_field_data
-              value: '1'
-          pager:
-            options:
-              items_per_page: 8
-          row:
-            options:
-              view_mode: teaser
-        display_title: Master
+  expected_config: {}
   update_actions:
     delete:
       display:
@@ -171,55 +120,7 @@ views.view.service_units:
                 view_mode: teaser_with_image
           display_title: Default
 views.view.unit_services:
-  expected_config:
-    display:
-      default:
-        display_options:
-          filters:
-            content_translation_status:
-              admin_label: ''
-              entity_field: content_translation_status
-              entity_type: tpr_service
-              expose:
-                description: ''
-                identifier: ''
-                label: ''
-                multiple: false
-                operator: ''
-                operator_id: ''
-                operator_limit_selection: false
-                operator_list: {  }
-                remember: false
-                remember_roles:
-                  authenticated: authenticated
-                required: false
-                use_operator: false
-              exposed: false
-              field: content_translation_status
-              group: 1
-              group_info:
-                default_group: All
-                default_group_multiple: {  }
-                description: ''
-                group_items: {  }
-                identifier: ''
-                label: ''
-                multiple: false
-                optional: true
-                remember: false
-                widget: select
-              group_type: group
-              id: content_translation_status
-              is_grouped: false
-              operator: '='
-              plugin_id: boolean
-              relationship: services_target_id
-              table: tpr_service_field_data
-              value: '1'
-          pager:
-            options:
-              items_per_page: 4
-        display_title: Master
+  expected_config: {}
   update_actions:
     delete:
       display:
@@ -328,28 +229,8 @@ views.view.unit_services:
           cache_metadata:
             contexts:
               - user
-    change:
-      display:
-        default:
-          display_options:
-            pager:
-              options:
-                items_per_page: 8
-          display_title: Default
 views.view.service_list:
-  expected_config:
-    display:
-      block:
-        display_options:
-          display_extenders: {  }
-      default:
-        display_options:
-          pager:
-            options:
-              items_per_page: 4
-      entity_reference_1:
-        display_options:
-          display_extenders: {  }
+  expected_config: {}
   update_actions:
     add:
       display:
@@ -610,67 +491,7 @@ views.view.service_list:
                 metatags: {  }
                 tokenize: false
 views.view.unit_search:
-  expected_config:
-    display:
-      block:
-        display_options:
-          display_extenders: {  }
-      default:
-        display_options:
-          fields:
-            address__address_line1:
-              group_column: ''
-            address__address_line2:
-              group_column: ''
-            address__postal_code:
-              group_column: ''
-            name:
-              group_column: value
-          filters:
-            content_translation_status:
-              admin_label: ''
-              entity_field: content_translation_status
-              entity_type: tpr_unit
-              expose:
-                description: ''
-                identifier: ''
-                label: ''
-                multiple: false
-                operator: ''
-                operator_id: ''
-                operator_limit_selection: false
-                operator_list: {  }
-                remember: false
-                remember_roles:
-                  authenticated: authenticated
-                required: false
-                use_operator: false
-              exposed: false
-              field: content_translation_status
-              group: 1
-              group_info:
-                default_group: All
-                default_group_multiple: {  }
-                description: ''
-                group_items: {  }
-                identifier: ''
-                label: ''
-                multiple: false
-                optional: true
-                remember: false
-                widget: select
-              group_type: group
-              id: content_translation_status
-              is_grouped: false
-              operator: '='
-              plugin_id: boolean
-              relationship: none
-              table: tpr_unit_field_data
-              value: '1'
-          relationships: {  }
-      entity_reference:
-        display_options:
-          display_extenders: {  }
+  expected_config: {}
   update_actions:
     delete:
       display:
@@ -1007,82 +828,3 @@ views.view.unit_search:
         entity_reference:
           display_options:
             relationships: {  }
-    change:
-      display:
-        block:
-          display_options:
-            display_extenders:
-              metatag_display_extender: {  }
-        default:
-          display_options:
-            fields:
-              address__address_line1:
-                group_column: entity_id
-              address__address_line2:
-                group_column: entity_id
-              address__postal_code:
-                group_column: entity_id
-              name:
-                group_column: entity_id
-            filters:
-              field_districts_target_id:
-                admin_label: ''
-                error_message: true
-                expose:
-                  description: ''
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  operator: ''
-                  operator_id: ''
-                  operator_limit_selection: false
-                  operator_list: {  }
-                  reduce: false
-                  remember: false
-                  remember_roles:
-                    authenticated: authenticated
-                  required: false
-                  use_operator: false
-                exposed: false
-                field: field_districts_target_id
-                group: 2
-                group_info:
-                  default_group: All
-                  default_group_multiple: {  }
-                  description: ''
-                  group_items: {  }
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  optional: true
-                  remember: false
-                  widget: select
-                group_type: group
-                hierarchy: false
-                id: field_districts_target_id
-                is_grouped: false
-                limit: true
-                operator: empty
-                plugin_id: taxonomy_index_tid
-                reduce_duplicates: false
-                relationship: none
-                table: tpr_unit__field_districts
-                type: select
-                value: {  }
-                vid: neighbourhoods
-            relationships:
-              field_districts:
-                admin_label: 'field_districts: Taxonomy term'
-                field: field_districts
-                group_type: group
-                id: field_districts
-                plugin_id: standard
-                relationship: none
-                required: false
-                table: tpr_unit__field_districts
-        entity_reference:
-          display_options:
-            defaults:
-              relationships: false
-            display_extenders:
-              metatag_display_extender: {  }

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9023.yml
@@ -6,46 +6,7 @@ views.view.service_units:
         default:
           display_options:
             filters:
-              content_translation_status:
-                admin_label: ''
-                entity_field: content_translation_status
-                entity_type: tpr_unit
-                expose:
-                  description: ''
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  operator: ''
-                  operator_id: ''
-                  operator_limit_selection: false
-                  operator_list: {  }
-                  remember: false
-                  remember_roles:
-                    authenticated: authenticated
-                  required: false
-                  use_operator: false
-                exposed: false
-                field: content_translation_status
-                group: 1
-                group_info:
-                  default_group: All
-                  default_group_multiple: {  }
-                  description: ''
-                  group_items: {  }
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  optional: true
-                  remember: false
-                  widget: select
-                group_type: group
-                id: content_translation_status
-                is_grouped: false
-                operator: '='
-                plugin_id: boolean
-                relationship: none
-                table: tpr_unit_field_data
-                value: '1'
+              content_translation_status: {}
     add:
       display:
         default:
@@ -53,10 +14,6 @@ views.view.service_units:
             contexts:
               - user
           display_options:
-            filter_groups:
-              groups:
-                1: AND
-              operator: AND
             filters:
               status_extra:
                 admin_label: ''
@@ -97,28 +54,6 @@ views.view.service_units:
                 relationship: none
                 table: tpr_unit_field_data
                 value: ''
-            sorts:
-              name:
-                expose:
-                  field_identifier: name
-              name_override:
-                expose:
-                  field_identifier: name_override
-        service_units:
-          cache_metadata:
-            contexts:
-              - user
-    change:
-      display:
-        default:
-          display_options:
-            pager:
-              options:
-                items_per_page: 5
-            row:
-              options:
-                view_mode: teaser_with_image
-          display_title: Default
 views.view.unit_services:
   expected_config: {}
   update_actions:
@@ -127,46 +62,7 @@ views.view.unit_services:
         default:
           display_options:
             filters:
-              content_translation_status:
-                admin_label: ''
-                entity_field: content_translation_status
-                entity_type: tpr_service
-                expose:
-                  description: ''
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  operator: ''
-                  operator_id: ''
-                  operator_limit_selection: false
-                  operator_list: {  }
-                  remember: false
-                  remember_roles:
-                    authenticated: authenticated
-                  required: false
-                  use_operator: false
-                exposed: false
-                field: content_translation_status
-                group: 1
-                group_info:
-                  default_group: All
-                  default_group_multiple: {  }
-                  description: ''
-                  group_items: {  }
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  optional: true
-                  remember: false
-                  widget: select
-                group_type: group
-                id: content_translation_status
-                is_grouped: false
-                operator: '='
-                plugin_id: boolean
-                relationship: services_target_id
-                table: tpr_service_field_data
-                value: '1'
+              content_translation_status: {}
     add:
       display:
         default:
@@ -218,17 +114,6 @@ views.view.unit_services:
                 relationship: services_target_id
                 table: tpr_service_field_data
                 value: ''
-            sorts:
-              name:
-                expose:
-                  field_identifier: name
-              name_override:
-                expose:
-                  field_identifier: name_override
-        unit_services:
-          cache_metadata:
-            contexts:
-              - user
 views.view.service_list:
   expected_config: {}
   update_actions:
@@ -283,13 +168,6 @@ views.view.service_list:
                 relationship: none
                 table: tpr_service_field_data
                 value: ''
-            sorts:
-              name:
-                expose:
-                  field_identifier: name
-              name_override:
-                expose:
-                  field_identifier: name_override
         entity_reference_1:
           display_options:
             filter_groups:
@@ -386,10 +264,6 @@ views.view.service_list:
             defaults:
               filter_groups: false
               filters: false
-            display_extenders:
-              metatag_display_extender:
-                metatags: {  }
-                tokenize: false
             filter_groups:
               groups:
                 1: AND
@@ -476,20 +350,11 @@ views.view.service_list:
                 relationship: none
                 table: tpr_service_field_data
                 value: ''
-        default:
-          display_options:
-            pager:
-              options:
-                items_per_page: 8
         entity_reference_1:
           display_options:
             defaults:
               filter_groups: false
               filters: false
-            display_extenders:
-              metatag_display_extender:
-                metatags: {  }
-                tokenize: false
 views.view.unit_search:
   expected_config: {}
   update_actions:
@@ -498,46 +363,7 @@ views.view.unit_search:
         default:
           display_options:
             filters:
-              content_translation_status:
-                admin_label: ''
-                entity_field: content_translation_status
-                entity_type: tpr_unit
-                expose:
-                  description: ''
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  operator: ''
-                  operator_id: ''
-                  operator_limit_selection: false
-                  operator_list: {  }
-                  remember: false
-                  remember_roles:
-                    authenticated: authenticated
-                  required: false
-                  use_operator: false
-                exposed: false
-                field: content_translation_status
-                group: 1
-                group_info:
-                  default_group: All
-                  default_group_multiple: {  }
-                  description: ''
-                  group_items: {  }
-                  identifier: ''
-                  label: ''
-                  multiple: false
-                  optional: true
-                  remember: false
-                  widget: select
-                group_type: group
-                id: content_translation_status
-                is_grouped: false
-                operator: '='
-                plugin_id: boolean
-                relationship: none
-                table: tpr_unit_field_data
-                value: '1'
+              content_translation_status: {}
     add:
       display:
         block:

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -451,3 +451,17 @@ function helfi_tpr_config_update_9022() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Use new status_extra filter on end user facing views.
+ */
+function helfi_tpr_config_update_9023() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9023');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
# Config for status_extra filter for TPR entities [UHF-4792](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4792)
Takes new custom views filter into use on TPR entity views.

## What was done
- Moves TPR views from helfi_tpr module to helfi_tpr_config
- Updates end user facing views with new filter, which displays entities if they are published OR the user has permission to view unpublished entities

## How to install
* Make sure your instance (for example, SOTE) is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Login to the site and open the following views so you can compare the changes and see if any filters / fields are missing after the updates:
  * /admin/structure/views/view/unit_services
  * /admin/structure/views/view/service_units
  * /admin/structure/views/view/service_list
  * admin/structure/views/view/unit_search
* Update the Helfi TPR module to the latest release:
  * `composer require "drupal/helfi_tpr:^2.0.5"`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4792-tpr-views-config`
* Run `make drush-updb drush-cr`

## How to test
* Check the previously opened views:
  * The default / block displays should have the new "TPR - [Entity name]: Julkaisutila tai ylläpitokäyttäjä." filter enabled and the the "TPR - [Entity name]: Käännöksen tila" should be missing.
  * For the entity reference displays the "Käännöksen tila" filter should still be present and not replaced with the new filter.
  * See if any fields or filters are missing or any configuration options got broken