### PR TITLE
UHF-X Allowed formats post update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
   },
   "extra": {
     "patches": {
+      "drupal/allowed_formats": {
+        "Post update hook fails when config is already updated (https://www.drupal.org/project/allowed_formats/issues/3261891)": "https://www.drupal.org/files/issues/2022-02-01/3261891-2.patch"
+      },
       "drupal/content_lock": {
         "[#UHF-4553] Fix unlock content button redirect": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/82081691e4a6d05b3716052d5fff46a04027bdc3/patches/content-lock-uhf-4553.patch"
       },


### PR DESCRIPTION
# Allowed formats post update
Applied patch for the Allowed formats module. Will fix post update issues.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_allowed_formats_post_update`
* Run `make drush-updb`

## How to test
* Check that patch gets applied and drush updb works without complaints
