### PR TITLE
UHF-3856: Add type & visibility sorting for announcements

### DIFF
--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -227,7 +227,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
         return 0;
       }
       // Global renders before page-specific.
-      return $visibilityA < $visibilityB ? 1 : -1;
+      return $visibilityA > $visibilityB ? 1 : -1;
     });
   }
 

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -226,8 +226,8 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
       ) {
         return 0;
       }
-      // Global renders before page-specific.
-      return $visibilityA > $visibilityB ? 1 : -1;
+      // Page-specific renders before global announcement.
+      return $visibilityA < $visibilityB ? 1 : -1;
     });
   }
 

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -205,7 +205,8 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    */
   private function doSort(array &$announcements, array $announcementTypeWeights): void {
     // Sort by type/severity.
-    usort($announcements, function ($a, $b) use ($announcementTypeWeights) {
+    usort($announcements, function (EntityInterface $a, EntityInterface $b)
+    use ($announcementTypeWeights) {
       $weightA = $announcementTypeWeights[$a->get('field_announcement_type')->value];
       $weightB = $announcementTypeWeights[$b->get('field_announcement_type')->value];
       if ($weightA === $weightB) {
@@ -216,7 +217,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
     });
 
     // Sort by visibility.
-    usort($announcements, function ($a, $b) {
+    usort($announcements, function (EntityInterface $a, EntityInterface $b) {
       $visibilityA = $this->resolveVisibilityWeight($a);
       $visibilityB = $this->resolveVisibilityWeight($b);
       // Sort visibility only within same type.

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -190,7 +190,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
     );
 
     // Map select-list values with numeric weight value.
-    $announcementTypeWeights = $this->createAnnouncementMap($types);
+    $announcementTypeWeights = $this->createAnnouncementWeightMap($types);
 
     $this->doSort($announcements, $announcementTypeWeights);
   }
@@ -204,14 +204,14 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    *   Announcement types ordered by severity.
    */
   private function doSort(array &$announcements, array $announcementTypeWeights): void {
-    // Sort by severity.
+    // Sort by type/severity.
     usort($announcements, function ($a, $b) use ($announcementTypeWeights) {
       $weightA = $announcementTypeWeights[$a->get('field_announcement_type')->value];
       $weightB = $announcementTypeWeights[$b->get('field_announcement_type')->value];
       if ($weightA === $weightB) {
         return 0;
       }
-      // Higher severity renders first.
+      // More urgent announcements render first.
       return $weightA < $weightB ? 1 : -1;
     });
 
@@ -226,7 +226,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
       ) {
         return 0;
       }
-      // More generic shows first, global renders before page-specific.
+      // Global renders before page-specific.
       return $visibilityA < $visibilityB ? 1 : -1;
     });
   }
@@ -240,7 +240,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    * @return int[]|string[]
    *   Array of announcement type keys and weights.
    */
-  private function createAnnouncementMap(array $announcementTypes): array {
+  private function createAnnouncementWeightMap(array $announcementTypes): array {
     return array_flip(array_keys($announcementTypes));
   }
 

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -177,12 +177,10 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   }
 
   /**
-   * Sort announcements by type/severity and then by visibility
+   * Sort announcements by type/severity and by visibility.
    *
    * @param array $announcements
    *   Array of nodes.
-   *
-   * @return void
    */
   private function sortAnnouncements(array &$announcements): void {
     // Get all possible values for the announcement types.
@@ -204,12 +202,10 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    *   Announcement entities.
    * @param array $announcementTypeWeights
    *   Announcement types ordered by severity.
-   *
-   * @return void
    */
-  private function doSort(array &$announcements, array $announcementTypeWeights) {
+  private function doSort(array &$announcements, array $announcementTypeWeights): void {
     // Sort by severity.
-    usort($announcements, function($a, $b) use ($announcementTypeWeights) {
+    usort($announcements, function ($a, $b) use ($announcementTypeWeights) {
       $weightA = $announcementTypeWeights[$a->get('field_announcement_type')->value];
       $weightB = $announcementTypeWeights[$b->get('field_announcement_type')->value];
       if ($weightA === $weightB) {
@@ -219,18 +215,18 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
       return $weightA < $weightB ? 1 : -1;
     });
 
-    // Sort by visibility on
-    usort($announcements, function($a, $b) {
+    // Sort by visibility.
+    usort($announcements, function ($a, $b) {
       $visibilityA = $this->resolveVisibility($a);
       $visibilityB = $this->resolveVisibility($b);
       // Sort visibility only within same type.
       if (
         $a->get('field_announcement_type')->value !== $b->get('field_announcement_type')->value ||
         $visibilityA === $visibilityB
-      ){
+      ) {
         return 0;
       }
-      // More generic shows first, global announcement renders before page-specific.
+      // More generic shows first, global renders before page-specific.
       return $visibilityA < $visibilityB ? 1 : -1;
     });
   }
@@ -242,6 +238,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    *   Should return ['notification' => 0, 'attention' => 1, 'alert' => 2].
    *
    * @return int[]|string[]
+   *   Array of announcement type keys and weights.
    */
   private function createAnnouncementMap($announcementTypes): array {
     return array_flip(array_keys($announcementTypes));
@@ -250,8 +247,11 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * Return weight by announcement visibility.
    *
-   * @param EntityInterface $announcement
+   * @param Drupal\Core\Entity\EntityInterface $announcement
+   *   Announcement entity.
+   *
    * @return int
+   *   Visibility weight.
    */
   private function resolveVisibility(EntityInterface $announcement): int {
     if (

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -217,8 +217,8 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
 
     // Sort by visibility.
     usort($announcements, function ($a, $b) {
-      $visibilityA = $this->resolveVisibility($a);
-      $visibilityB = $this->resolveVisibility($b);
+      $visibilityA = $this->resolveVisibilityWeight($a);
+      $visibilityB = $this->resolveVisibilityWeight($b);
       // Sort visibility only within same type.
       if (
         $a->get('field_announcement_type')->value !== $b->get('field_announcement_type')->value ||
@@ -245,7 +245,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   }
 
   /**
-   * Return weight by announcement visibility.
+   * Return weight for announcement visibility.
    *
    * @param Drupal\Core\Entity\EntityInterface $announcement
    *   Announcement entity.
@@ -253,7 +253,11 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    * @return int
    *   Visibility weight.
    */
-  private function resolveVisibility(EntityInterface $announcement): int {
+  private function resolveVisibilityWeight(EntityInterface $announcement): int {
+    if ($announcement->get('field_announcement_all_pages')->value == TRUE) {
+      return self::VISIBILITY_ALL_WEIGHT;
+    }
+
     if (
       !$announcement->get('field_announcement_unit_pages')->isEmpty() ||
       !$announcement->get('field_announcement_service_pages')->isEmpty()
@@ -261,7 +265,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
       return self::VISIBILITY_REGION_WEIGHT;
     }
 
-    if ($announcement->get('field_announcement_content_pages')->isEmpty()) {
+    if (!$announcement->get('field_announcement_content_pages')->isEmpty()) {
       return self::VISIBILITY_PAGE_WEIGHT;
     }
 

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -22,9 +22,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
-  const VISIBILITY_ALL_WEIGHT = 0;
-  const VISIBILITY_REGION_WEIGHT = 1;
-  const VISIBILITY_PAGE_WEIGHT = 2;
+  public const VISIBILITY_ALL_WEIGHT = 0;
+  public const VISIBILITY_REGION_WEIGHT = 1;
+  public const VISIBILITY_PAGE_WEIGHT = 2;
 
   /**
    * The current route match.
@@ -179,7 +179,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * Sort announcements by type/severity and by visibility.
    *
-   * @param array $announcements
+   * @param \Drupal\node\NodeInterface[] $announcements
    *   Array of nodes.
    */
   private function sortAnnouncements(array &$announcements): void {
@@ -198,7 +198,7 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * Execute sorting.
    *
-   * @param array $announcements
+   * @param \Drupal\node\NodeInterface[] $announcements
    *   Announcement entities.
    * @param array $announcementTypeWeights
    *   Announcement types ordered by severity.

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -205,8 +205,10 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
    */
   private function doSort(array &$announcements, array $announcementTypeWeights): void {
     // Sort by type/severity.
-    usort($announcements, function (EntityInterface $a, EntityInterface $b)
-    use ($announcementTypeWeights) {
+    usort($announcements, function (
+      EntityInterface $a,
+      EntityInterface $b
+    ) use ($announcementTypeWeights) {
       $weightA = $announcementTypeWeights[$a->get('field_announcement_type')->value];
       $weightB = $announcementTypeWeights[$b->get('field_announcement_type')->value];
       if ($weightA === $weightB) {

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -23,8 +23,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   const VISIBILITY_ALL_WEIGHT = 0;
-  const VISIBILITY_PAGE_WEIGHT = 1;
-  const VISIBILITY_REGION_WEIGHT = 2;
+  const VISIBILITY_REGION_WEIGHT = 1;
+  const VISIBILITY_PAGE_WEIGHT = 2;
 
   /**
    * The current route match.
@@ -234,13 +234,13 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
   /**
    * Create the map which is used to order the announcements by severity.
    *
-   * @param $announcementTypes
+   * @param array $announcementTypes
    *   Should return ['notification' => 0, 'attention' => 1, 'alert' => 2].
    *
    * @return int[]|string[]
    *   Array of announcement type keys and weights.
    */
-  private function createAnnouncementMap($announcementTypes): array {
+  private function createAnnouncementMap(array $announcementTypes): array {
     return array_flip(array_keys($announcementTypes));
   }
 


### PR DESCRIPTION
# Announcement sorting [UHF-3856](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3856)
Announcement blocks are now sorted by:
* Type/severity: alert, attention, notice
* Visibility: global, service/unit pages or specific page.

## What was done
Added sorting for announcement blocks. 

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-3856_announcement_sort`
* Run `make drush-updb drush-cr`

## How to test
* Select a content page to test this with
* Create a set of announcements of different types and visibilities, Pick few of these (Remember to create the announcements in random order to test the sorting properly): 
  * **global alert** announcement, **page specific alert** announcement,
  * **global attention** announcement, **service specific attention** announcement
  * **global notice** announcement, **page specific notice** announcement
* Go to a content page where you set the announcements

What you should see:
- You should see only the announcements that matches the visibility
- You should see announcements sorted by type/severity (all alerts first, then all attentions, then all notices)
- You should see announcements sorted by visibility within the type (for example: all global alerts are always rendered before any page specific alert: general announcements before page specific announcements.)

