### PR TITLE
UHF-3631 breadcrumb

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,6 @@
   },
   "extra": {
     "patches": {
-      "drupal/allowed_formats": {
-        "Post update hook fails when config is already updated (https://www.drupal.org/project/allowed_formats/issues/3261891)": "https://www.drupal.org/files/issues/2022-02-01/3261891-2.patch"
-      },
       "drupal/content_lock": {
         "[#UHF-4553] Fix unlock content button redirect": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/82081691e4a6d05b3716052d5fff46a04027bdc3/patches/content-lock-uhf-4553.patch"
       },
@@ -96,7 +93,7 @@
         "[#UHF-3268] Support for field group translations": "https://www.drupal.org/files/issues/2021-11-22/field_group_fix-translations_label_description-3111107-31.patch"
       },
       "drupal/easy_breadcrumb": {
-        "[UHF-3631] Breadcrumb allow dashes and underscores": "https://www.drupal.org/files/issues/2021-05-11/easy_breadcrumb-allow-hyphen_and_underscore-3161100-19.patch"
+        "[#UHF-3631] Breadcrumb allow dashes and underscores": "https://www.drupal.org/files/issues/2020-07-23/easy_breadcrumb-allow_hyphens_underscores-3161100-2.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,9 @@
       },
       "drupal/field_group": {
         "[#UHF-3268] Support for field group translations": "https://www.drupal.org/files/issues/2021-11-22/field_group_fix-translations_label_description-3111107-31.patch"
+      },
+      "drupal/easy_breadcrumb": {
+        "[UHF-3631] Breadcrumb allow dashes and underscores": "https://www.drupal.org/files/issues/2021-05-11/easy_breadcrumb-allow-hyphen_and_underscore-3161100-19.patch"
       }
     }
   }


### PR DESCRIPTION
#  breadcrumb fix [UHF-3631](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3631)
You should use Sote to test since sote frontpage has dash in its /fi frontpages name. Breadcrumb module stripped dashes from the breadcrumb. Also, the front page name was shown twice in the breadcrumb.

## What was done
* Added a patch which solves the problem

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-3631_breadcrumb -W`
* Run `make drush-updb drush-cr`

## How to test
* If you use Sote: Go to finnish front page and see the breadcrumb
* If other cases, find or create a page which has dash in it's name

Go to the page and you should see breadcrumb with dashes, front page name should be seen only once
What to expect in Sote frontpage: Etusivu > Sosiaali- ja terveyspalvelut

