### PR TITLE
UHF-4810: Open chat from a separate button

### DIFF
--- a/assets/js/genesys_neuvonta.js
+++ b/assets/js/genesys_neuvonta.js
@@ -7,6 +7,12 @@
 
   Drupal.behaviors.genesys_chat = {
     attach: function (context, settings) {
+      // Open chat from an external button.
+      $('#openChat').click(function(e) {
+        e.preventDefault();
+        $("#chatButtonStart").click();
+      });
+
       var helFiChatPageUrl = document.location.href;
       helFiChatPageUrl = helFiChatPageUrl.toLowerCase();
       var helfiChat_lang = document.documentElement.lang;


### PR DESCRIPTION
# Neuvonnan chattien käynnistys erillisestä nappulasta etusivuilla [UHF-4810](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4810)

## What was done
* A JavaScript snippet was added that enables the opening of the Genesys chat widget by clicking on an element with a certain ID (`#openChat`).

## How to install
* Set up any instance
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4810_neuvonta_genesys_button`
* Run `make drush-cr`

## How to test
* Create a content page of any type and set the `Genesys (Neuvonta)` chat block to be visible on that page
* Add an element (for example a link) with `id="openChat"` on that page
* Click on the element and see how the chat widget opens
