### PR TITLE
UHF-4847: Fix layout issue on group content creation form

### DIFF
--- a/helfi_features/helfi_base_config/config/update/helfi_base_config_update_9009.yml
+++ b/helfi_features/helfi_base_config/config/update/helfi_base_config_update_9009.yml
@@ -1,0 +1,10 @@
+block.block.language_switcher_admin:
+  expected_config:
+    visibility:
+      request_path:
+        pages: "/node/*\r\n/admin/content/integrations/tpr-unit/*/edit\r\n/admin/content/integrations/tpr-service/*/edit"
+  update_actions:
+    change:
+      visibility:
+        request_path:
+          pages: "/node/*\r\n/admin/content/integrations/tpr-unit/*/edit\r\n/admin/content/integrations/tpr-service/*/edit\r\n/group/*/content/create/*"

--- a/helfi_features/helfi_base_config/helfi_base_config.install
+++ b/helfi_features/helfi_base_config/helfi_base_config.install
@@ -42,6 +42,7 @@ function helfi_base_config_install($is_syncing) {
       helfi_base_config_update_9006();
       helfi_base_config_update_9007();
       helfi_base_config_update_9008();
+      helfi_base_config_update_9009();
     }
   }
 }
@@ -201,6 +202,20 @@ function helfi_base_config_update_9008() {
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_base_config', 'helfi_base_config_update_9008');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Remove language switcher from group content creation pages.
+ */
+function helfi_base_config_update_9009() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_base_config', 'helfi_base_config_update_9009');
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();


### PR DESCRIPTION
# Fix layout issue on group content creation form [UHF-4847](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4847)
Fix layout issue on group content creation from where the sidebar would go under content when adding new content to group.

## What was done
* Changed the page--group template to extend correct template and removed the language switcher from the group content creation page since it isn't available on the regular content creation page either.

## How to install
* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/125)

## How to test
* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/125)

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/125
