### PR TITLE
UHF-4259 react and share block additions

### DIFF
--- a/assets/js/reactAndShareSettings.js
+++ b/assets/js/reactAndShareSettings.js
@@ -6,10 +6,15 @@
       window.rnsData = {
         apiKey: drupalSettings.reactAndShareApiKey
       };
-      var s = document.createElement('script');
-      s.src = 'https://cdn.reactandshare.com/plugin/rns.js';
 
-      document.body.appendChild(s);
+      if (drupalSettings.siteName !== undefined) {
+        window.rnsData.categories = [drupalSettings.siteName]
+      }
+
+      var scriptElement = document.createElement('script');
+      scriptElement.src = 'https://cdn.reactandshare.com/plugin/rns.js';
+
+      document.body.appendChild(scriptElement);
 
       $('.js-react-and-share__container .rns').show();
     }

--- a/src/Plugin/Block/ReactAndShare.php
+++ b/src/Plugin/Block/ReactAndShare.php
@@ -15,10 +15,17 @@ use Drupal\Core\Language\LanguageManagerInterface;
  */
 class ReactAndShare extends BlockBase {
 
+  /**
+   * Language manager
+   *
+   * @var Drupal\Core\Language\LanguageManagerInterface
+   */
   private LanguageManagerInterface $languageManager;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition)
-  {
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->languageManager = \Drupal::languageManager();
   }

--- a/src/Plugin/Block/ReactAndShare.php
+++ b/src/Plugin/Block/ReactAndShare.php
@@ -16,7 +16,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 class ReactAndShare extends BlockBase {
 
   /**
-   * Language manager
+   * Language manager.
    *
    * @var Drupal\Core\Language\LanguageManagerInterface
    */

--- a/src/Plugin/Block/ReactAndShare.php
+++ b/src/Plugin/Block/ReactAndShare.php
@@ -27,8 +27,9 @@ class ReactAndShare extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    $language = \Drupal::languageManager()->getCurrentLanguage();
-    $langcode = $language->getId();
+    $langcode = $this->languageManager
+      ->getCurrentLanguage()
+      ->getId();
 
     if (!$apikey = getenv('REACT_AND_SHARE_APIKEY_' . strtoupper($langcode))) {
       return [];

--- a/src/Plugin/Block/ReactAndShare.php
+++ b/src/Plugin/Block/ReactAndShare.php
@@ -3,6 +3,7 @@
 namespace Drupal\helfi_platform_config\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Language\LanguageManagerInterface;
 
 /**
  * Provides a 'ReactAndShare' block.
@@ -13,6 +14,14 @@ use Drupal\Core\Block\BlockBase;
  * )
  */
 class ReactAndShare extends BlockBase {
+
+  private LanguageManagerInterface $languageManager;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition)
+  {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->languageManager = \Drupal::languageManager();
+  }
 
   /**
    * {@inheritdoc}
@@ -26,13 +35,19 @@ class ReactAndShare extends BlockBase {
     }
 
     $library = ['helfi_platform_config/react_and_share'];
+    $sitename = $this->languageManager
+      ->getLanguageConfigOverride('fi', 'system.site')
+      ->get('name');
 
     $build['react_and_share'] = [
       '#theme' => 'react_and_share',
       '#title' => t('React and Share'),
       '#attached' => [
         'library' => $library,
-        'drupalSettings' => ['reactAndShareApiKey' => $apikey],
+        'drupalSettings' => [
+          'reactAndShareApiKey' => $apikey,
+          'siteName' => $sitename,
+        ],
       ],
     ];
 


### PR DESCRIPTION
# React and share block additions [UHF-4259](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4259)
Added finnish site name as rns initial request's category parameter

## What was done
* Added finnish sitename to drupalSettings for javascript to use
* Added sitename as rns request parameter

## How to install
* Make sure you have rns key set in local.settings.php in order to test in local (if not, ask for it)
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4259_rns_block_additions`
* Run `make drush-cr`

## How to test
* Open browser's network tab
* Go to any page with rns block set to it (any content page)
  * Make sure to reload without cache so the new javascript is loaded
* After the page has loaded, find the initial rns request  from network tab, check the request's payload
  * There should be c[]: 'Sivuston nimi suomeksi' in the payload (the request should be the one sent to `data.reactandshare.com/track.gif....`)
