### PR TITLE
Fix translations for `North Sami`

### DIFF
--- a/translations/new/fi.po
+++ b/translations/new/fi.po
@@ -453,7 +453,7 @@ msgstr "Tämä sisältö on nyt lukittu. Sisältö pysyy lukittuna vaikka siirty
 msgid "This content is being edited by the user @name and is therefore locked to prevent other users changes. This lock is in place since @date."
 msgstr "Käyttäjä @name muokkaa tätä sisältöä, ja siksi se on lukittu. Sisältö on lukittu @date hetkestä lähtien."
 
-msgid "Northern Sami"
+msgid "North Sami"
 msgstr "Pohjoissaame"
 
 msgid "Round-the-clock care"

--- a/translations/new/sv.po
+++ b/translations/new/sv.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 
-msgid "Northern Sami"
+msgid "North Sami"
 msgstr "Nordsamiska"
 
 msgid "Round-the-clock care"


### PR DESCRIPTION
Fix translations for North Sami after text change.
Check instructions from https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/144.