### PR TITLE
UHF-4092 News item medium teaser

### DIFF
--- a/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.medium_teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.medium_teaser.yml
@@ -1,0 +1,61 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.medium_teaser
+    - field.field.node.news_item.field_content
+    - field.field.node.news_item.field_lead_in
+    - field.field.node.news_item.field_main_image
+    - field.field.node.news_item.field_main_image_caption
+    - field.field.node.news_item.field_news_item_links_link
+    - field.field.node.news_item.field_news_item_links_title
+    - field.field.node.news_item.field_news_item_tags
+    - field.field.node.news_item.field_short_title
+    - node.type.news_item
+  module:
+    - user
+id: node.news_item.medium_teaser
+targetEntityType: node
+bundle: news_item
+mode: medium_teaser
+content:
+  field_news_item_links_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_short_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  published_at:
+    type: timestamp
+    label: hidden
+    settings:
+      date_format: publication_date_format
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
+hidden:
+  field_content: true
+  field_lead_in: true
+  field_main_image: true
+  field_main_image_caption: true
+  field_news_item_links_link: true
+  field_news_item_tags: true
+  langcode: true
+  toc_enabled: true

--- a/helfi_features/helfi_news_item/config/install/core.entity_view_mode.node.medium_teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_mode.node.medium_teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.medium_teaser
+label: 'Medium Teaser'
+targetEntityType: node
+cache: true

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -114,3 +114,20 @@ function helfi_news_item_update_9005() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Add medium-teaser display for news items.
+ */
+function helfi_news_item_update_9006() {
+  $configLocation = dirname(__FILE__) . '/config/install/';
+
+  $configurations = [
+    'core.entity_view_mode.node.medium_teaser',
+    'core.entity_view_display.node.news_item.medium_teaser',
+  ];
+
+  // Install configurations and translations.
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($configLocation, $configuration);
+  }
+}

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -128,6 +128,6 @@ function helfi_news_item_update_9006() {
 
   // Install configurations and translations.
   foreach ($configurations as $configuration) {
-    ConfigHelper::installNewConfigTranslation($configLocation, $configuration);
+    ConfigHelper::installNewConfig($configLocation, $configuration);
   }
 }


### PR DESCRIPTION
# Group news archive and adding medium teaser for news item [UHF-4092](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4092)
While working on the group news archive task we needed a new display for news item that will be used on other instances as well so added one.

## What was done
* New display for news item called medium teaser was added.

## How to install
* Test this using the HALLINTO instance since it is the only one beside KASKO to have news item feature on.
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4092_news_item_medium_teaser`
* Run `make drush-updb drush-cr`

## How to test
* Log into the site and make sure that under the news items Manage display (/admin/structure/types/manage/news_item/display) there is "Medium Teaser" tab. 

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/147
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/297