### PR TITLE
UHF-4815: Update Gin toolbar version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/crop": "^2.1",
         "drupal/default_content": "^2.0.0-alpha1",
         "drupal/diff": "^1.0",
-        "drupal/gin_toolbar": "1.0-beta20",
+        "drupal/gin_toolbar": "^1.0",
         "drupal/editoria11y": "^1.0",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/easy_breadcrumb": "^2.0",


### PR DESCRIPTION
# Update Gin theme and Gin toolbar [UHF-4815](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4815)

Gin theme got new beta version during spring and it had multiple design changes. These changed didn't apply out of the box to HDBT Admin theme.

## What was done
* Fixed the position of node preview tools container.

Check instructions from https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/135