### PR TITLE
UHF-5573: Change the default settings for news item teaser image to 3:2 aspect ratio

### DIFF
--- a/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.teaser.yml
@@ -25,7 +25,7 @@ content:
     region: content
     label: hidden
     settings:
-      view_mode: media_library
+      view_mode: image
       link: false
     third_party_settings: {  }
   field_news_item_links_title:


### PR DESCRIPTION
# Change the news teaser item to use 3:2 aspect ratio [UHF-5573](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5573)
Change the default settings for news item teaser image to 3:2 aspect ratio.

## What was done
* Change the default settings for news item teaser image to 3:2 aspect ratio.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-5573_news_item_aspect_ratio`
* Run `make drush-updb drush-cr`

## How to test
* If you create a new instance or enable the news item feature to a site where this is not available then you will get the correct aspect ratio from the start. The kasko and etusivu instances that have news items enabled have already manually been updated to use this style in the other PRs.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/27
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/168
