### PR TITLE
UHF-5289: Changes to allowed paragraphs in news, removed image from t…

### DIFF
--- a/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.tiny_teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.tiny_teaser.yml
@@ -11,51 +11,41 @@ dependencies:
     - field.field.node.news_item.field_news_item_links_title
     - field.field.node.news_item.field_news_item_tags
     - field.field.node.news_item.field_short_title
-    - image.style.tiny_square_image
     - node.type.news_item
   module:
-    - media
     - user
 id: node.news_item.tiny_teaser
 targetEntityType: node
 bundle: news_item
 mode: tiny_teaser
 content:
-  field_main_image:
-    type: media_thumbnail
-    weight: 1
-    label: hidden
-    settings:
-      image_style: tiny_square_image
-      image_link: ''
-    third_party_settings: {  }
-    region: content
   field_short_title:
-    weight: 2
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
   links:
-    weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   published_at:
     type: timestamp
-    weight: 3
-    region: content
     label: hidden
     settings:
       date_format: publication_date_format
       custom_date_format: ''
       timezone: ''
     third_party_settings: {  }
+    weight: 2
+    region: content
 hidden:
   field_content: true
   field_lead_in: true
+  field_main_image: true
   field_main_image_caption: true
   field_news_item_links_link: true
   field_news_item_links_title: true

--- a/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_content.yml
+++ b/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_content.yml
@@ -4,8 +4,9 @@ dependencies:
   config:
     - field.storage.node.field_content
     - node.type.news_item
-    - paragraphs.paragraphs_type.gallery
+    - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
   module:
@@ -23,12 +24,13 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 0
     target_bundles:
       text: text
       image: image
-      gallery: gallery
       remote_video: remote_video
+      banner: banner
+      list_of_links: list_of_links
+    negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: -24
@@ -38,7 +40,7 @@ settings:
         enabled: false
       banner:
         weight: -36
-        enabled: false
+        enabled: true
       columns:
         weight: -26
         enabled: false
@@ -52,8 +54,8 @@ settings:
         weight: -32
         enabled: false
       gallery:
-        enabled: true
         weight: -39
+        enabled: false
       gallery_slide:
         weight: -31
         enabled: false
@@ -61,33 +63,24 @@ settings:
         weight: -30
         enabled: false
       image:
-        enabled: true
         weight: -40
+        enabled: true
       liftup_with_image:
         weight: -29
         enabled: false
       list_of_links:
         weight: -28
-        enabled: false
+        enabled: true
       list_of_links_item:
         weight: -27
         enabled: false
-      map:
-        weight: -25
-        enabled: false
       remote_video:
-        enabled: true
         weight: -38
-      service_list:
-        weight: -23
-        enabled: false
+        enabled: true
       sidebar_text:
         weight: -34
         enabled: false
       text:
-        enabled: true
         weight: -41
-      unit_search:
-        weight: -22
-        enabled: false
+        enabled: true
 field_type: entity_reference_revisions

--- a/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_content.yml
+++ b/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_content.yml
@@ -6,7 +6,6 @@ dependencies:
     - node.type.news_item
     - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.image
-    - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.remote_video
     - paragraphs.paragraphs_type.text
   module:
@@ -29,7 +28,6 @@ settings:
       image: image
       remote_video: remote_video
       banner: banner
-      list_of_links: list_of_links
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -70,7 +68,7 @@ settings:
         enabled: false
       list_of_links:
         weight: -28
-        enabled: true
+        enabled: false
       list_of_links_item:
         weight: -27
         enabled: false

--- a/helfi_features/helfi_news_item/config/language/fi/views.view.news.yml
+++ b/helfi_features/helfi_news_item/config/language/fi/views.view.news.yml
@@ -1,0 +1,15 @@
+display:
+  latest_news:
+    display_options:
+      title: 'Uusimmat uutiset'
+    display_title: 'Uusimmat uutiset'
+  default:
+    display_options:
+      fields:
+        view_node:
+          text: näkymä
+      title: 'Uusimmat uutiset'
+      arguments:
+        nid:
+          exception:
+            title: Kaikki

--- a/helfi_features/helfi_news_item/config/language/sv/views.view.news.yml
+++ b/helfi_features/helfi_news_item/config/language/sv/views.view.news.yml
@@ -1,0 +1,13 @@
+display:
+  default:
+    display_options:
+      fields:
+        view_node:
+          text: visa
+      title: 'Senaste nyheterna'
+      arguments:
+        nid:
+          exception:
+            title: Alla
+  latest_news:
+    display_title: 'Senaste nyheterna'

--- a/helfi_features/helfi_news_item/config/optional/block.block.views_block__news_latest_news.yml
+++ b/helfi_features/helfi_news_item/config/optional/block.block.views_block__news_latest_news.yml
@@ -4,28 +4,28 @@ dependencies:
   config:
     - views.view.news
   module:
-    - ctools
+    - node
     - views
   theme:
     - hdbt
 id: views_block__news_latest_news
 theme: hdbt
-region: sidebar_first
-weight: -10
+region: sidebar_second
+weight: -11
 provider: null
 plugin: 'views_block:news-latest_news'
 settings:
   id: 'views_block:news-latest_news'
   label: 'Latest news'
-  provider: views
   label_display: visible
+  provider: views
   views_label: 'Latest news'
   items_per_page: none
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
-    bundles:
-      news_item: news_item
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      news_item: news_item

--- a/helfi_features/helfi_news_item/config/optional/views.view.news.yml
+++ b/helfi_features/helfi_news_item/config/optional/views.view.news.yml
@@ -9,7 +9,7 @@ dependencies:
     - node
     - user
 id: news
-label: News
+label: 'Platform news'
 module: views
 description: ''
 tag: ''

--- a/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9008.yml
+++ b/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9008.yml
@@ -1,0 +1,82 @@
+core.entity_view_display.node.news_item.tiny_teaser:
+  expected_config:
+    content:
+      field_main_image:
+        label: hidden
+        region: content
+        settings:
+          image_link: ''
+          image_style: tiny_square_image
+        third_party_settings: {  }
+        type: media_thumbnail
+        weight: 1
+      field_short_title:
+        weight: 2
+      published_at:
+        weight: 3
+  update_actions:
+    delete:
+      content:
+        field_main_image:
+          label: hidden
+          region: content
+          settings:
+            image_link: ''
+            image_style: tiny_square_image
+          third_party_settings: {  }
+          type: media_thumbnail
+          weight: 1
+    add:
+      hidden:
+        field_main_image: true
+    change:
+      content:
+        field_short_title:
+          weight: 1
+        published_at:
+          weight: 2
+field.field.node.news_item.field_content:
+  expected_config:
+    settings:
+      handler_settings:
+        target_bundles:
+          gallery: gallery
+        target_bundles_drag_drop:
+          banner:
+            enabled: false
+          gallery:
+            enabled: true
+          list_of_links:
+            enabled: false
+  update_actions:
+    add:
+      settings:
+        handler_settings:
+          target_bundles:
+            list_of_links: list_of_links
+    change:
+      settings:
+        handler_settings:
+          target_bundles:
+            banner: banner
+          target_bundles_drag_drop:
+            banner:
+              enabled: true
+            gallery:
+              enabled: false
+            list_of_links:
+              enabled: true
+block.block.views_block__news_latest_news:
+  expected_config:
+    region: sidebar_first
+    weight: -10
+  update_actions:
+    change:
+      region: sidebar_second
+      weight: -11
+views.view.news:
+  expected_config:
+    label: News
+  update_actions:
+    change:
+      label: 'Platform News'

--- a/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9008.yml
+++ b/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9008.yml
@@ -46,14 +46,7 @@ field.field.node.news_item.field_content:
             enabled: false
           gallery:
             enabled: true
-          list_of_links:
-            enabled: false
   update_actions:
-    add:
-      settings:
-        handler_settings:
-          target_bundles:
-            list_of_links: list_of_links
     change:
       settings:
         handler_settings:
@@ -64,8 +57,6 @@ field.field.node.news_item.field_content:
               enabled: true
             gallery:
               enabled: false
-            list_of_links:
-              enabled: true
 block.block.views_block__news_latest_news:
   expected_config:
     region: sidebar_first

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -172,3 +172,22 @@ function helfi_news_item_update_9007() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Changes to allowed paragraphs, removed image from tiny teaser and updated translations.
+ */
+function helfi_news_item_update_9008() {
+  // Handle the configuration translation update manually.
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  ConfigHelper::installNewConfigTranslation($configTranslationLocation, 'views.view.news');
+
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_news_item', 'helfi_news_item_update_9008');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
# News configs [UHF-5289](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5289)
A longer description of the task

## What was done
* Removed image from tiny teaser
* Added new paragraph to the news node (list of links and banner)
* Added translations

## How to test
* See the pr to front-pages instance

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/32
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/313
