### PR TITLE
UHF-X: Enable events paragraph

### DIFF
--- a/helfi_features/helfi_events/config/install/core.entity_form_display.paragraph.event_list.default.yml
+++ b/helfi_features/helfi_events/config/install/core.entity_form_display.paragraph.event_list.default.yml
@@ -26,11 +26,11 @@ content:
       placeholder_title: ''
     third_party_settings: {  }
   field_event_list_description:
-    type: string_textarea
+    type: text_textarea
     weight: 1
     region: content
     settings:
-      rows: 5
+      rows: 3
       placeholder: ''
     third_party_settings: {  }
   field_event_list_title:

--- a/helfi_features/helfi_events/config/install/core.entity_view_display.paragraph.event_list.default.yml
+++ b/helfi_features/helfi_events/config/install/core.entity_view_display.paragraph.event_list.default.yml
@@ -16,9 +16,9 @@ bundle: event_list
 mode: default
 content:
   field_event_list_description:
-    type: basic_string
+    type: text_default
     label: hidden
-    settings: {  }
+    settings: { }
     third_party_settings: {  }
     weight: 1
     region: content

--- a/helfi_features/helfi_events/config/install/field.field.paragraph.event_list.field_event_list_description.yml
+++ b/helfi_features/helfi_events/config/install/field.field.paragraph.event_list.field_event_list_description.yml
@@ -18,4 +18,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string_long
+field_type: text_long

--- a/helfi_features/helfi_events/config/install/field.storage.paragraph.field_event_list_description.yml
+++ b/helfi_features/helfi_events/config/install/field.storage.paragraph.field_event_list_description.yml
@@ -4,15 +4,15 @@ status: true
 dependencies:
   module:
     - paragraphs
+    - text
 _core:
   default_config_hash: jEfT1S05qwT11BZeMt-9_Bb4ibiWj9JULgjB1uOr0FU
 id: paragraph.field_event_list_description
 field_name: field_event_list_description
 entity_type: paragraph
-type: string_long
-settings:
-  case_sensitive: false
-module: core
+type: text_long
+settings: {  }
+module: text
 locked: false
 cardinality: 1
 translatable: true

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -248,3 +248,14 @@ function helfi_platform_config_update_9009() {
     ]);
   }
 }
+
+/**
+ * Install helfi_events.
+ */
+function helfi_platform_config_update_9010() {
+  if (!Drupal::moduleHandler()->moduleExists('helfi_events')) {
+    Drupal::service('module_installer')->install([
+      'helfi_events',
+    ]);
+  }
+}


### PR DESCRIPTION
# UHF-X: Enable events paragraph
- Change events list description field type to text_long
- Enable helfi_events

## What was done
Changed some fields configs to transform `field_event_list_description` to type `text_long`. 
Enable `helfi_events` feature via update hook.

## How to install
- Run `composer require drupal/helfi_platform_config:dev-UHF-X-enable-events-paragraph` in your instance of choice.
- Run `make drush-cr drush-updb`

## How to test
- Check that paragraph type `events` is available.
- Add or edit a landing page.
- Add a paragraph of type `events`. See that the description field is of type `text_long` (has ckeditor toolbar at the top). Fill the fields and check that the description field is rendered correctly.

