### PR TITLE
UHF-5283: Added new display mode for news

### DIFF
--- a/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.card_teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_display.node.news_item.card_teaser.yml
@@ -1,0 +1,71 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.card_teaser
+    - field.field.node.news_item.field_content
+    - field.field.node.news_item.field_lead_in
+    - field.field.node.news_item.field_main_image
+    - field.field.node.news_item.field_main_image_caption
+    - field.field.node.news_item.field_news_item_links_link
+    - field.field.node.news_item.field_news_item_links_title
+    - field.field.node.news_item.field_news_item_tags
+    - field.field.node.news_item.field_short_title
+    - image.style.3_2_m
+    - node.type.news_item
+  module:
+    - media
+    - user
+id: node.news_item.card_teaser
+targetEntityType: node
+bundle: news_item
+mode: card_teaser
+content:
+  field_main_image:
+    type: media_thumbnail
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: 3_2_m
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_news_item_links_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_short_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  published_at:
+    type: timestamp
+    label: hidden
+    settings:
+      date_format: long
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden:
+  field_content: true
+  field_lead_in: true
+  field_main_image_caption: true
+  field_news_item_links_link: true
+  field_news_item_tags: true
+  langcode: true
+  toc_enabled: true

--- a/helfi_features/helfi_news_item/config/install/core.entity_view_mode.node.card_teaser.yml
+++ b/helfi_features/helfi_news_item/config/install/core.entity_view_mode.node.card_teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.card_teaser
+label: 'Card Teaser'
+targetEntityType: node
+cache: true

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -207,12 +207,4 @@ function helfi_news_item_update_9009() {
   foreach ($configurations as $configuration) {
     ConfigHelper::installNewConfig($configLocation, $configuration);
   }
-  /** @var \Drupal\update_helper\Updater $updateHelper */
-  $updateHelper = \Drupal::service('update_helper.updater');
-
-  // Execute configuration update definitions with logging of success.
-  $updateHelper->executeUpdate('helfi_news_item', 'helfi_news_item_update_9009');
-
-  // Output logged messages to related channel of update execution.
-  return $updateHelper->logger()->output();
 }

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -191,3 +191,28 @@ function helfi_news_item_update_9008() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Added new display mode for news
+ */
+function helfi_news_item_update_9009() {
+  $configLocation = dirname(__FILE__) . '/config/install/';
+
+  $configurations = [
+    'core.entity_view_display.node.news_item.card_teaser',
+    'core.entity_view_mode.node.card_teaser'
+  ];
+
+  // Install new display mode for news item
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfig($configLocation, $configuration);
+  }
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_news_item', 'helfi_news_item_update_9009');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
# New card teaser for Helfi news item [UHF-5283](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5283)

Added new card teaser display mode for helfi news item

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-5283-main-news-styles`
* Run `make drush-updb drush-cr`

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/326
