### PR TITLE
Uhf 5664 popular services paragraph

### DIFF
--- a/helfi_features/helfi_frontpage/config/install/core.entity_form_display.paragraph.popular_service_item.default.yml
+++ b/helfi_features/helfi_frontpage/config/install/core.entity_form_display.paragraph.popular_service_item.default.yml
@@ -1,0 +1,34 @@
+uuid: f0c1eeab-a45b-44b6-b2b6-e21db1f5b128
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.popular_service_item.field_service_links
+    - field.field.paragraph.popular_service_item.field_service_title
+    - paragraphs.paragraphs_type.popular_service_item
+  module:
+    - link
+id: paragraph.popular_service_item.default
+targetEntityType: paragraph
+bundle: popular_service_item
+mode: default
+content:
+  field_service_links:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_service_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/helfi_features/helfi_frontpage/config/install/core.entity_form_display.paragraph.popular_services.default.yml
+++ b/helfi_features/helfi_frontpage/config/install/core.entity_form_display.paragraph.popular_services.default.yml
@@ -1,0 +1,35 @@
+uuid: 952ab331-766c-4dc7-9f84-1c79a1dbd7d0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.popular_services.field_service_items
+    - paragraphs.paragraphs_type.popular_services
+  module:
+    - paragraphs
+id: paragraph.popular_services.default
+targetEntityType: paragraph
+bundle: popular_services
+mode: default
+content:
+  field_service_items:
+    type: paragraphs
+    weight: 0
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/helfi_features/helfi_frontpage/config/install/core.entity_view_display.paragraph.popular_service_item.default.yml
+++ b/helfi_features/helfi_frontpage/config/install/core.entity_view_display.paragraph.popular_service_item.default.yml
@@ -1,0 +1,36 @@
+uuid: b9d3be18-1d4e-49c7-8ceb-918b26685b77
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.popular_service_item.field_service_links
+    - field.field.paragraph.popular_service_item.field_service_title
+    - paragraphs.paragraphs_type.popular_service_item
+  module:
+    - link
+id: paragraph.popular_service_item.default
+targetEntityType: paragraph
+bundle: popular_service_item
+mode: default
+content:
+  field_service_links:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_service_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/helfi_features/helfi_frontpage/config/install/core.entity_view_display.paragraph.popular_services.default.yml
+++ b/helfi_features/helfi_frontpage/config/install/core.entity_view_display.paragraph.popular_services.default.yml
@@ -1,0 +1,24 @@
+uuid: 332fc467-3223-424b-997e-06c2a579655a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.popular_services.field_service_items
+    - paragraphs.paragraphs_type.popular_services
+  module:
+    - entity_reference_revisions
+id: paragraph.popular_services.default
+targetEntityType: paragraph
+bundle: popular_services
+mode: default
+content:
+  field_service_items:
+    type: entity_reference_revisions_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_service_item.field_service_links.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_service_item.field_service_links.yml
@@ -1,0 +1,23 @@
+uuid: e2aaba6c-2a6c-44ca-a4c1-8e3ed6e56886
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_service_links
+    - paragraphs.paragraphs_type.popular_service_item
+  module:
+    - link
+id: paragraph.popular_service_item.field_service_links
+field_name: field_service_links
+entity_type: paragraph
+bundle: popular_service_item
+label: Links
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_service_item.field_service_title.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_service_item.field_service_title.yml
@@ -1,0 +1,19 @@
+uuid: d704b9d4-4978-476c-8b29-a5102baac98e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_service_title
+    - paragraphs.paragraphs_type.popular_service_item
+id: paragraph.popular_service_item.field_service_title
+field_name: field_service_title
+entity_type: paragraph
+bundle: popular_service_item
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_services.field_service_items.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_services.field_service_items.yml
@@ -1,5 +1,5 @@
 uuid: 1ec40238-2a0a-40bc-ace9-4a463f41ca96
-langcode: fi
+langcode: en
 status: true
 dependencies:
   config:

--- a/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_services.field_service_items.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.field.paragraph.popular_services.field_service_items.yml
@@ -1,0 +1,97 @@
+uuid: 1ec40238-2a0a-40bc-ace9-4a463f41ca96
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_service_items
+    - paragraphs.paragraphs_type.popular_service_item
+    - paragraphs.paragraphs_type.popular_services
+  module:
+    - entity_reference_revisions
+id: paragraph.popular_services.field_service_items
+field_name: field_service_items
+entity_type: paragraph
+bundle: popular_services
+label: 'Service items'
+description: 'Service items to showcase.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      popular_service_item: popular_service_item
+    negate: 0
+    target_bundles_drag_drop:
+      accordion:
+        weight: 24
+        enabled: false
+      accordion_item:
+        weight: 25
+        enabled: false
+      banner:
+        weight: 26
+        enabled: false
+      chart:
+        weight: 27
+        enabled: false
+      columns:
+        weight: 28
+        enabled: false
+      contact_card:
+        weight: 29
+        enabled: false
+      contact_card_listing:
+        weight: 30
+        enabled: false
+      content_cards:
+        weight: 31
+        enabled: false
+      content_liftup:
+        weight: 32
+        enabled: false
+      from_library:
+        weight: 33
+        enabled: false
+      gallery:
+        weight: 34
+        enabled: false
+      gallery_slide:
+        weight: 35
+        enabled: false
+      hero:
+        weight: 36
+        enabled: false
+      image:
+        weight: 37
+        enabled: false
+      liftup_with_image:
+        weight: 38
+        enabled: false
+      list_of_links:
+        weight: 39
+        enabled: false
+      list_of_links_item:
+        weight: 40
+        enabled: false
+      popular_service_item:
+        weight: 42
+        enabled: true
+      popular_services:
+        weight: 41
+        enabled: false
+      remote_video:
+        weight: 43
+        enabled: false
+      sidebar_text:
+        weight: 44
+        enabled: false
+      social_media_link:
+        weight: 45
+        enabled: false
+      text:
+        weight: 46
+        enabled: false
+field_type: entity_reference_revisions

--- a/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_items.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_items.yml
@@ -1,5 +1,5 @@
 uuid: b10aed68-8b0a-4b42-9f8e-a57376b9016e
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_items.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_items.yml
@@ -1,0 +1,20 @@
+uuid: b10aed68-8b0a-4b42-9f8e-a57376b9016e
+langcode: fi
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_service_items
+field_name: field_service_items
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 4
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_links.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_links.yml
@@ -1,0 +1,19 @@
+uuid: 50f624b3-9d79-48bb-9758-6b248c9daf80
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_service_links
+field_name: field_service_links
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 3
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_title.yml
+++ b/helfi_features/helfi_frontpage/config/install/field.storage.paragraph.field_service_title.yml
@@ -1,0 +1,21 @@
+uuid: 43367029-120a-4022-88c9-d2e176f1e26b
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_service_title
+field_name: field_service_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_frontpage/config/install/paragraphs.paragraphs_type.popular_service_item.yml
+++ b/helfi_features/helfi_frontpage/config/install/paragraphs.paragraphs_type.popular_service_item.yml
@@ -1,0 +1,10 @@
+uuid: 53d8337f-6a18-49a8-bae2-c25346795aab
+langcode: en
+status: true
+dependencies: {  }
+id: popular_service_item
+label: 'Popular service item'
+icon_uuid: null
+icon_default: null
+description: 'Showcase popular service.'
+behavior_plugins: {  }

--- a/helfi_features/helfi_frontpage/config/install/paragraphs.paragraphs_type.popular_services.yml
+++ b/helfi_features/helfi_frontpage/config/install/paragraphs.paragraphs_type.popular_services.yml
@@ -1,0 +1,10 @@
+uuid: cf0ee520-44c1-4537-8a55-d77a178fd79c
+langcode: en
+status: true
+dependencies: {  }
+id: popular_services
+label: 'Popular services'
+icon_uuid: null
+icon_default: null
+description: 'Showcase popular services'
+behavior_plugins: {  }

--- a/helfi_features/helfi_frontpage/config/language/fi/field.field.paragraph.popular_services.field_service_items.yml
+++ b/helfi_features/helfi_frontpage/config/language/fi/field.field.paragraph.popular_services.field_service_items.yml
@@ -1,0 +1,2 @@
+label: Palvelut
+description: 'Palvelut, joita esitellään.'

--- a/helfi_features/helfi_frontpage/config/language/fi/paragraphs.paragraphs_type.popular_service_item.yml
+++ b/helfi_features/helfi_frontpage/config/language/fi/paragraphs.paragraphs_type.popular_service_item.yml
@@ -1,0 +1,2 @@
+label: 'Suosittu palvelu'
+description: 'Esittele suosittua palvelua.'

--- a/helfi_features/helfi_frontpage/config/language/fi/paragraphs.paragraphs_type.popular_services.yml
+++ b/helfi_features/helfi_frontpage/config/language/fi/paragraphs.paragraphs_type.popular_services.yml
@@ -1,0 +1,2 @@
+label: 'Suositut palvelut '
+description: 'Esittele suosittuja palveluita.'

--- a/helfi_features/helfi_frontpage/config/update/helfi_frontpage_update_9001.yml
+++ b/helfi_features/helfi_frontpage/config/update/helfi_frontpage_update_9001.yml
@@ -1,0 +1,12 @@
+field.field.node.landing_page.field_content:
+  expected_config: {  }
+  update_actions:
+    add:
+      settings:
+        handler_settings:
+          target_bundles:
+            popular_services: popular_services
+          target_bundles_drag_drop:
+            popular_services:
+              enabled: true
+              weight: 42

--- a/helfi_features/helfi_frontpage/helfi_frontpage.info.yml
+++ b/helfi_features/helfi_frontpage/helfi_frontpage.info.yml
@@ -1,0 +1,16 @@
+name: 'HELfi Frontpage'
+type: module
+core_version_requirement: '^8.9 || ^9'
+dependencies:
+  - 'drupal:ckeditor'
+  - 'drupal:content_translation'
+  - 'drupal:editor'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:text'
+  - 'helfi_platform_config:helfi_platform_config'
+  - 'paragraphs:paragraphs'
+  - 'update_helper:update_helper'
+package: HELfi
+'interface translation project': helfi_frontpage
+'interface translation server pattern': modules/contrib/helfi_platform_config/helfi_features/helfi_frontpage/translations/%language.po

--- a/helfi_features/helfi_frontpage/helfi_frontpage.install
+++ b/helfi_features/helfi_frontpage/helfi_frontpage.install
@@ -1,11 +1,13 @@
 <?php
 
-declare(strict_types = 1);
-
 /**
  * @file
- * Contains install functions for HELfi Frontpage module
+ * Contains install functions for HELfi Frontpage module.
  */
+
+declare(strict_types = 1);
+
+use Drupal\helfi_platform_config\ConfigHelper;
 
 /**
  * Implements hook_install().
@@ -24,6 +26,19 @@ function helfi_frontpage_install($is_syncing) {
 function helfi_frontpage_update_9001() {
   /** @var \Drupal\update_helper\Updater $updateHelper */
   $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Install config translations.
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  $configurations = [
+    'paragraphs.paragraphs_type.popular_service_item',
+    'paragraphs.paragraphs_type.popular_services',
+    'field.field.paragraph.popular_services.field_service_items',
+  ];
+
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
+  }
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_frontpage', 'helfi_frontpage_update_9001');

--- a/helfi_features/helfi_frontpage/helfi_frontpage.install
+++ b/helfi_features/helfi_frontpage/helfi_frontpage.install
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @file
+ * Contains install functions for HELfi Frontpage module
+ */
+
+/**
+ * Implements hook_install().
+ */
+function helfi_frontpage_install($is_syncing) {
+  // Do not perform following steps if the module is being installed as part
+  // of a configuration import.
+  if (!$is_syncing && Drupal::moduleHandler()->moduleExists('update_helper')) {
+    helfi_frontpage_update_9001();
+  }
+}
+
+/**
+ * Update landing page content field to include popular services paragraph.
+ */
+function helfi_frontpage_update_9001() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_frontpage', 'helfi_frontpage_update_9001');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}

--- a/helfi_features/helfi_frontpage/helfi_frontpage.module
+++ b/helfi_features/helfi_frontpage/helfi_frontpage.module
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Module functions for HELfi Frontpage module.
+ */
+
 declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityTypeInterface;

--- a/helfi_features/helfi_frontpage/helfi_frontpage.module
+++ b/helfi_features/helfi_frontpage/helfi_frontpage.module
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Implements hook_entity_bundle_field_info_alter().
+ */
+function helfi_frontpage_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
+  if ($bundle === 'popular_services' && isset($fields['field_service_items'])) {
+    $fields['field_service_items']->addConstraint('MinimumCount', ['count' => 2]);
+  }
+}

--- a/helfi_features/helfi_frontpage/src/Plugin/Validation/Constraint/MinimumCount.php
+++ b/helfi_features/helfi_frontpage/src/Plugin/Validation/Constraint/MinimumCount.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_frontpage\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that the field has a minimum amount of values.
+ *
+ * @Constraint(
+ *   id = "MinimumCount",
+ *   label = @Translation("Minimum count", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class MinimumCount extends Constraint {
+  /**
+   * The minimum count of values for the field.
+   *
+   * @var int
+   */
+  public $count;
+  /**
+   * Validation message when validation fails.
+   *
+   * @var int
+   */
+  public $tooFewValues = 'Field %field expects at least %count values';
+
+}

--- a/helfi_features/helfi_frontpage/src/Plugin/Validation/Constraint/MinimumCountValidator.php
+++ b/helfi_features/helfi_frontpage/src/Plugin/Validation/Constraint/MinimumCountValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_frontpage\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates that field has a minimum count of values.
+ */
+class MinimumCountValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($items, $constraint) {
+    if ($items->count() < $constraint->count) {
+      $this->context->addViolation($constraint->tooFewValues, [
+        '%field' => $items->getFieldDefinition()->getLabel(),
+        '%count' => $constraint->count,
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
# Popular services [UHF-5664](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5664)
Added functionality to showcase services via a paragraph.

Sketch: https://share.goabstract.com/ca21840a-654f-4386-a828-93dd3759040d?collectionLayerId=daadaaf5-3cdc-4f85-b23b-b6ff6db8f9f2&mode=design

## What was done
- Added new feature module `helfi_frontpage` (some frontpage components are to be global)
- Added new paragraph types: `popular_services` & `popular_service_items`
- Added update hook to enable `popular_services` in landing pages

## How to install
- Checkout branch in your instance of choice. Run `composer require drupal/helfi_platform_config:dev-UHF-5664-popular-services-paragraph drupal/hdbt:dev-UHF-5664-popular-serivces-paragraph` (yep, the HDBT branch is typo'd)
- Run `drush cr; drush en helfi_frontpage`
- Run `drush locale:check && drush locale:update` 

## How to test
- Check `/fi/admin/structure/paragraphs_type` and see that `popular_services` & `popular_service_items` paragraphs are enabled
- Add or edit a landing page. You should be able to add a `popular_services` paragraph to content-field.
  - You should not be able save the node if you have less than 2 popular service items added 
- View the landing page. The paragraph style should match the sketch.

## Other PRs
https://github.com/City-of-Helsinki/drupal-hdbt/pull/327
