### PR TITLE
UHF-5699: Move event link inside title

### DIFF
--- a/helfi_features/helfi_events/assets/js/eventList.js
+++ b/helfi_features/helfi_events/assets/js/eventList.js
@@ -35,7 +35,7 @@
         const eventElement = $(`
           <div class="event-list__event">
             <div class="event-list__image-container">
-              <div class="event-list__tags event-list__tags--mobile" role="Region" aria-label="${eventKeywords}">
+              <div class="event-list__tags event-list__tags--mobile" role="region" aria-label="${eventKeywords}">
               </div>
             </div>
             <div class="event-list__content-container">
@@ -43,21 +43,18 @@
                 <a class="event-list__event-link" href="${drupalSettings.helfi_events.baseUrl}/events/${event.id}" aria-label="(${externalLink})"></a>
               </h3>
               <div class="event__content event__content--date">
-                <div class="event__date">
-                  ${startDate.toLocaleDateString('fi-FI')}, ${at}
-                  ${startDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
-                  -
-                  ${endDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
-                </div>
+                ${startDate.toLocaleDateString('fi-FI')}, ${at}
+                ${startDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
+                -
+                ${endDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
               </div>
-              <div class="event__content event__content--location">
-                <div class="event__location"></div>
-              </div>
+              <div class="event__content event__content--location"></div>
               <div class="event__lower-container">
-                <div class="event-list__tags event-list__tags--desktop role="Region" aria-label="${eventKeywords}">
+                <div class="event-list__tags event-list__tags--desktop" role="region" aria-label="${eventKeywords}">
                 </div>
-                <span class="event-list__event-link-indicator">
-                </span>
+                <div class="event-list__indicator-container">
+                  <span class="event-list__event-link-indicator"></span>
+                </div>
               </div>
             </div>
           </div>
@@ -80,14 +77,27 @@
 
         // Use first image or fallback to placeholder if no images present
         const imageUrl = (event.images.length && event.images[0].url) ? event.images[0].url : null;
-        const imageAlt = imageUrl && event.images[0].alt_text ? event.images[0].alt_text : eventName.textContent.trim();
-        const imageElement = imageUrl ?
-          `<img class="event-list__event-image" alt="${imageAlt}" src="${event.images[0].url}"></img>` :
-          $(drupalSettings.helfi_events.imagePlaceholder).addClass('event-list__event-image');
+
+        let imageElement;
+        if(imageUrl) {
+          imageElement = $(`<img class="event-list__event-image" src="${event.images[0].url}" />`);
+
+          // Get image alt text from response or use event name.
+          const imageAlt = imageUrl && event.images[0].alt_text ? event.images[0].alt_text : eventName.textContent.trim();
+          imageElement.attr('alt', imageAlt);
+
+          // If image has photographer data, add it as data-attribute.
+          if(event.images[0].photographer_name) {
+            imageElement.attr('data-photographer', event.images[0].photographer_name);
+          }
+        }
+        else {
+          imageElement = $(drupalSettings.helfi_events.imagePlaceholder).addClass('event-list__event-image');
+        }
         $(eventElement).find('.event-list__image-container').append(imageElement);
 
         const location = `${event.location.name[currentLanguage]}${event.location.street_address ? ', ' + event.location.street_address[currentLanguage] : ''}`;
-        $(eventElement).find('.event__location').append(document.createTextNode(location))
+        $(eventElement).find('.event__content--location').append(document.createTextNode(location))
 
         return eventElement;
       });

--- a/helfi_features/helfi_events/assets/js/eventList.js
+++ b/helfi_features/helfi_events/assets/js/eventList.js
@@ -34,13 +34,15 @@
         // Base element for event, wihout text elements from api
         const eventElement = $(`
           <div class="event-list__event">
-            <a class="event-list__events-container" href="${drupalSettings.helfi_events.baseUrl}/events/${event.id}" aria-label="(${externalLink})">
+            <div class="event-list__events-container">
               <div class="event-list__image-container">
                 <div class="event-list__tags event-list__tags--mobile" role="Region" aria-label="${eventKeywords}">
                 </div>
               </div>
               <div class="event-list__content-container">
-                <h3 class="event-list__event-name"></h3>
+                <h3 class="event-list__event-name">
+                  <a class="event-list__event-link" href="${drupalSettings.helfi_events.baseUrl}/events/${event.id}" aria-label="(${externalLink})"></a>
+                </h3>
                 <div class="event__content event__content--date">
                   <div class="event__date">
                     ${startDate.toLocaleDateString('fi-FI')}, ${at}
@@ -55,11 +57,11 @@
                 <div class="event__lower-container">
                   <div class="event-list__tags event-list__tags--desktop role="Region" aria-label="${eventKeywords}">
                   </div>
-                  <span class="link__type link__type--external event-list__event-link-indicator">
+                  <span class="event-list__event-link-indicator">
                   </span>
                 </div>
               </div>
-            </a>
+            </div>
           </div>
         `);
 
@@ -76,7 +78,7 @@
         }
 
         const eventName = document.createTextNode(event.name[currentLanguage]);
-        $(eventElement).find('.event-list__event-name').append(eventName);
+        $(eventElement).find('.event-list__event-link').append(eventName);
 
         // Use first image or fallback to placeholder if no images present
         const imageUrl = (event.images.length && event.images[0].url) ? event.images[0].url : null;

--- a/helfi_features/helfi_events/assets/js/eventList.js
+++ b/helfi_features/helfi_events/assets/js/eventList.js
@@ -34,32 +34,30 @@
         // Base element for event, wihout text elements from api
         const eventElement = $(`
           <div class="event-list__event">
-            <div class="event-list__events-container">
-              <div class="event-list__image-container">
-                <div class="event-list__tags event-list__tags--mobile" role="Region" aria-label="${eventKeywords}">
+            <div class="event-list__image-container">
+              <div class="event-list__tags event-list__tags--mobile" role="Region" aria-label="${eventKeywords}">
+              </div>
+            </div>
+            <div class="event-list__content-container">
+              <h3 class="event-list__event-name">
+                <a class="event-list__event-link" href="${drupalSettings.helfi_events.baseUrl}/events/${event.id}" aria-label="(${externalLink})"></a>
+              </h3>
+              <div class="event__content event__content--date">
+                <div class="event__date">
+                  ${startDate.toLocaleDateString('fi-FI')}, ${at}
+                  ${startDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
+                  -
+                  ${endDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
                 </div>
               </div>
-              <div class="event-list__content-container">
-                <h3 class="event-list__event-name">
-                  <a class="event-list__event-link" href="${drupalSettings.helfi_events.baseUrl}/events/${event.id}" aria-label="(${externalLink})"></a>
-                </h3>
-                <div class="event__content event__content--date">
-                  <div class="event__date">
-                    ${startDate.toLocaleDateString('fi-FI')}, ${at}
-                    ${startDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
-                    -
-                    ${endDate.toLocaleTimeString('fi-FI', {hour: '2-digit', minute: '2-digit'})}
-                  </div>
+              <div class="event__content event__content--location">
+                <div class="event__location"></div>
+              </div>
+              <div class="event__lower-container">
+                <div class="event-list__tags event-list__tags--desktop role="Region" aria-label="${eventKeywords}">
                 </div>
-                <div class="event__content event__content--location">
-                  <div class="event__location"></div>
-                </div>
-                <div class="event__lower-container">
-                  <div class="event-list__tags event-list__tags--desktop role="Region" aria-label="${eventKeywords}">
-                  </div>
-                  <span class="event-list__event-link-indicator">
-                  </span>
-                </div>
+                <span class="event-list__event-link-indicator">
+                </span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# [UHF-5699: Events paragraph accessibility fix](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5699)
Event link is used as a container, which messes with screen readers. Move it inside title element.

## What was done
* Moved a-element inside title
* Made style changes to HDBT project to make the whole element clickable

## How to install
* In an instance of your choice, run `composer require drupal/helfi_platform_config:dev-UHF-5699-events-accessibility-fix drupal/hdbt:dev-UHF-5699-events-accessibility-fix`
* Clear cache `drush cr`

## How to test
* Edit or create either a landing- or standard page. Add a paragraph of type `Events`. Fill the fields.
* View the page. Link to the event should be located inside the event title, but the whole event item should be clickable.

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/345
