### PR TITLE
UHF-5939: News list paragraph "all news" link

### DIFF
--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\entity\BundleFieldDefinition;
 use Drupal\helfi_news_feed\Entity\NewsFeedParagraph;
 use Drupal\paragraphs\ParagraphInterface;
@@ -126,4 +127,36 @@ function helfi_news_feed_entity_bundle_info_alter(array &$bundles) : void {
   if (isset($bundles['paragraph']['news_list'])) {
     $bundles['paragraph']['news_list']['class'] = NewsFeedParagraph::class;
   }
+}
+
+/**
+ * Implements hook_preprocess_paragraph().
+ */
+function helfi_news_feed_preprocess_paragraph__news_list(&$variables) {
+  // Get current language ID.
+  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+  // Get the "Etusivu" instance using the environment resolver.
+  $instance_name = \Drupal\helfi_api_base\Environment\Project::ETUSIVU;
+  $resolver = \Drupal::service('helfi_api_base.environment_resolver');
+  $environment = $resolver->getEnvironment($instance_name, getenv('APP_ENV'));
+
+  $environment_url = $environment->getUrl($language);
+
+  // Set the news archive path based on language.
+  switch ($language) {
+    case 'fi':
+    default:
+      $news_path = '/uutiset';
+      break;
+    case 'sv':
+      $news_path = '/nyheter';
+      break;
+    case 'en':
+      $news_path = '/news';
+      break;
+  }
+
+  // Assign the URL variable to the template.
+  $variables['news_archive_url'] = $environment_url . $news_path;
 }

--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -11,7 +11,6 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Url;
 use Drupal\entity\BundleFieldDefinition;
 use Drupal\helfi_news_feed\Entity\NewsFeedParagraph;
 use Drupal\paragraphs\ParagraphInterface;

--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -135,7 +135,7 @@ function helfi_news_feed_preprocess_paragraph__news_list(&$variables) {
   // Get current language ID.
   $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-  // Get the "Etusivu" instance using the environment resolver.
+  // Get the correct "Etusivu" instance environment URL.
   $instance_name = \Drupal\helfi_api_base\Environment\Project::ETUSIVU;
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
   $environment = $resolver->getEnvironment($instance_name, getenv('APP_ENV'));


### PR DESCRIPTION
## [UHF-5939: News list paragraphin "Katso kaikki uutiset" linkki](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5939)

### What has been done:

Added a "See all the news" link on the "News list" paragraph. The link points to the news archive page on the matching environment (local, test, production) of the Etusivu instance.

### How to install:
- Set up any instance (implemented on KYMP)
- Get this branch of the helfi_platform_config module:
  - `composer require drupal/helfi_platform_config:dev-UHF-5939_news_list_paragraph_all_news_link`
- Get the matching branch of the HDBT theme:
  - `composer require drupal/hdbt:dev-UHF-5939_news_list_paragraph_all_news_link`
- Import translations and clear cache:
  - `make shell`
  - `drush locale:check; drush locale:update; drush cr`  

### How to test:
- Add the "News list" paragraph on any page and see if the link exist and points to the correct instance/environment
- Create language versions of the page and see that the link text changes accordingly

### Other PR's:
- https://github.com/City-of-Helsinki/drupal-hdbt/pull/352