### PR TITLE
UHF-X Broken metatag url

### DIFF
--- a/helfi_features/helfi_content/config/override/metatag.metatag_defaults.403.yml
+++ b/helfi_features/helfi_content/config/override/metatag.metatag_defaults.403.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: '403'
+label: '403 access denied'
+tags:
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'

--- a/helfi_features/helfi_content/config/override/metatag.metatag_defaults.404.yml
+++ b/helfi_features/helfi_content/config/override/metatag.metatag_defaults.404.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: '404'
+label: '404 page not found'
+tags:
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'

--- a/helfi_features/helfi_content/config/override/metatag.metatag_defaults.front.yml
+++ b/helfi_features/helfi_content/config/override/metatag.metatag_defaults.front.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+id: front
+label: 'Front page'
+tags:
+  canonical_url: '[site:url]'
+  shortlink: '[site:url]'
+  og_image: '[node:shareable-image]'
+  twitter_cards_image: '[node:shareable-image]'

--- a/helfi_features/helfi_content/config/override/metatag.metatag_defaults.global.yml
+++ b/helfi_features/helfi_content/config/override/metatag.metatag_defaults.global.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+id: global
+label: Global
+tags:
+  canonical_url: '[current-page:url]'
+  title: '[current-page:title] | [site:page-title-suffix]'
+  twitter_cards_page_url: '[current-page:url]'
+  twitter_cards_title: '[current-page:title] | [site:page-title-suffix]'
+  twitter_cards_type: summary_large_image
+  og_image: '[site:default-og-image]'
+  twitter_cards_image: '[site:default-og-image]'

--- a/helfi_features/helfi_content/config/override/metatag.metatag_defaults.node.yml
+++ b/helfi_features/helfi_content/config/override/metatag.metatag_defaults.node.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node
+label: Content
+tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_lead_in]'
+  title: '[node:title] | [site:page-title-suffix]'
+  article_modified_time: '[node:created:html_datetime]'
+  article_published_time: '[node:created:html_datetime]'
+  og_site_name: '[site:name]'
+  og_title: '[node:title]'
+  og_updated_time: '[node:changed:html_datetime]'
+  og_url: '[current-page:url:absolute]'
+  twitter_cards_image: '[node:shareable-image]'
+  og_image: '[node:shareable-image]'

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9031.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9031.yml
@@ -1,0 +1,22 @@
+metatag.metatag_defaults.global:
+  expected_config:
+    tags:
+      image_src: '[site:base-url]/themes/custom/hdbt/src/images/og-global.png'
+  update_actions:
+    add:
+      tags:
+        og_image: '[site:default-og-image]'
+    delete:
+      tags:
+        image_src: '[site:base-url]/themes/custom/hdbt/src/images/og-global.png'
+metatag.metatag_defaults.node:
+  expected_config:
+    tags:
+      og_image_url: '[node:field_liftup_image:entity:field_media_image:og_image:url],[site:base-url]/themes/custom/hdbt/src/images/og-global.png'
+  update_actions:
+    add:
+      tags:
+        og_image: '[node:shareable-image]'
+    delete:
+      tags:
+        og_image_url: '[node:field_liftup_image:entity:field_media_image:og_image:url],/themes/contrib/hdbt/src/images/og-global.png'

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -33,6 +33,22 @@ function helfi_content_install($is_syncing) {
     helfi_content_update_9025();
     helfi_content_update_9027();
     helfi_content_update_9028();
+
+    // Override default meta tags configurations.
+    $config_location = dirname(__FILE__) . '/config/override/';
+
+    $configurations = [
+      'metatag.metatag_defaults.403',
+      'metatag.metatag_defaults.404',
+      'metatag.metatag_defaults.front',
+      'metatag.metatag_defaults.global',
+      'metatag.metatag_defaults.node',
+    ];
+
+    // Update meta tag default configurations.
+    foreach ($configurations as $configuration) {
+      ConfigHelper::updateExistingConfig($config_location, $configuration);
+    }
   }
 }
 
@@ -682,6 +698,23 @@ function helfi_content_update_9030() {
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9030');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Update broken reference to OG image.
+ */
+function helfi_content_update_9031() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9031');
+
+  // Notify users to manually update the configuration.
+  \Drupal::messenger()->addWarning('Please remove the "metatag.metatag_defaults.node.yml" og_image_url manually if the update failed.');
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();


### PR DESCRIPTION
## What was done
* Fixed broken references to obsolete URLs in configurations.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_fix_broken_metatag_url`
* Run `make drush-updb drush-cr drush-cex`

## How to test (in Kasko only)
* Check that `conf/cmi/metatag.metatag_defaults.global.yml` and `conf/cmi/metatag.metatag_defaults.node.yml` has been updated

