### PR TITLE
UHF-X env value fix

### DIFF
--- a/helfi_features/helfi_news_feed/helfi_news_feed.install
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.install
@@ -136,7 +136,7 @@ function helfi_news_feed_update_9002(&$sandbox = NULL) {
 }
 
 /**
- * Hides title and description labels and adds date format
+ * Hides title and description labels and adds date format.
  */
 function helfi_news_feed_update_9003() {
   /** @var \Drupal\update_helper\Updater $updateHelper */
@@ -150,7 +150,7 @@ function helfi_news_feed_update_9003() {
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('core.date_format.publication_date_format');
 
-  //Install date format required for new item
+  // Install date format required for new item.
   if (empty($config->getRawData())) {
     ConfigHelper::installNewConfig($config_optional, 'core.date_format.publication_date_format');
   }

--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -147,18 +147,18 @@ function helfi_news_feed_entity_bundle_info_alter(array &$bundles) : void {
  * Implements hook_preprocess_paragraph().
  */
 function helfi_news_feed_preprocess_paragraph__news_list(&$variables) {
-  // Get current language ID.
-  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-  // Get the correct "Etusivu" instance environment URL.
-  $instance_name = Project::ETUSIVU;
+  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
-  $environment = $resolver->getEnvironment($instance_name, getenv('APP_ENV'));
+  $environment = \Drupal::configFactory()
+    ->get('helfi_news_feed.settings')
+    ->get('source_environment') ?: 'prod';
+  $environment = $resolver->getEnvironment(Project::ETUSIVU, $environment);
 
-  $environment_url = $environment->getUrl($language);
+  $environment_url = $environment->getUrl($language_id);
 
   // Set the news archive path based on language.
-  switch ($language) {
+  switch ($language_id) {
     case 'fi':
     default:
       $news_path = '/uutiset';
@@ -177,23 +177,27 @@ function helfi_news_feed_preprocess_paragraph__news_list(&$variables) {
   $variables['news_archive_url'] = $environment_url . $news_path;
 }
 
-function helfi_news_feed_preprocess_external_entity(&$variables) {
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_news_feed_preprocess_external_entity__helfi_news__medium_teaser(&$variables) {
   $entity = $variables['external_entity'];
+  if ($entity->getEntityType()->id() !== 'helfi_news') {
+    return;
+  }
 
-
-  // Get current language ID.
-  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
-  // Get the correct "Etusivu" instance environment URL.
-  $instance_name = \Drupal\helfi_api_base\Environment\Project::ETUSIVU;
+  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
-  $environment = $resolver->getEnvironment($instance_name, getenv('APP_ENV'));
+  $environment = \Drupal::configFactory()
+    ->get('helfi_news_feed.settings')
+    ->get('source_environment') ?: 'prod';
 
-  $environment_url = $environment->getUrl($language);
+  $environment_url = $resolver->getEnvironment(Project::ETUSIVU, $environment)
+    ->getUrl($language_id);
 
   $variables['node_url'] = $environment_url . $entity->node_url->value;
   $variables['published_at'] = strtotime($entity->published_at->value);
- 
+
   if($entity->short_title->value)
     $variables['short_title'] =  $entity->short_title->value;
   else {

--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -197,10 +197,5 @@ function helfi_news_feed_preprocess_external_entity__helfi_news__medium_teaser(&
 
   $variables['node_url'] = $environment_url . $entity->node_url->value;
   $variables['published_at'] = strtotime($entity->published_at->value);
-
-  if($entity->short_title->value)
-    $variables['short_title'] =  $entity->short_title->value;
-  else {
-    $variables['short_title'] =  $entity->title->value;
-  }
+  $variables['short_title'] = $entity->short_title->value ?? $entity->title->value;
 }

--- a/helfi_features/helfi_news_feed/src/Entity/NewsFeedParagraph.php
+++ b/helfi_features/helfi_news_feed/src/Entity/NewsFeedParagraph.php
@@ -34,7 +34,7 @@ final class NewsFeedParagraph extends Paragraph {
    *   An array of tags.
    */
   public function getTags() : array {
-    return $this->get('field_helfi_news_tags')->value ?? [];
+    return $this->get('field_helfi_news_tags')->getValue() ?? [];
   }
 
   /**
@@ -44,7 +44,7 @@ final class NewsFeedParagraph extends Paragraph {
    *   Anb array of groups.
    */
   public function getGroups() : array {
-    return $this->get('field_helfi_news_groups')->value ?? [];
+    return $this->get('field_helfi_news_groups')->getValue() ?? [];
   }
 
   /**
@@ -54,7 +54,7 @@ final class NewsFeedParagraph extends Paragraph {
    *   An array of neighbourhoods.
    */
   public function getNeighbourhoods() : array {
-    return $this->get('field_helfi_news_neighbourhoods')->value ?? [];
+    return $this->get('field_helfi_news_neighbourhoods')->getValue() ?? [];
   }
 
   /**

--- a/helfi_features/helfi_news_feed/src/HelfiExternalEntityBase.php
+++ b/helfi_features/helfi_news_feed/src/HelfiExternalEntityBase.php
@@ -104,17 +104,18 @@ abstract class HelfiExternalEntityBase extends ExternalEntityStorageClientBase {
           $start = NULL,
           $length = NULL
   ) : array {
+    $prepared = [];
 
     foreach ($parameters as $param) {
       ['field' => $field, 'value' => $values, 'operator' => $operator] = $param;
       if ($field == 'id') {
         $storage = \Drupal::entityTypeManager()->getStorage($this->getPluginId());
         $data = $storage->loadMultiple($values);
-        $prepared = [];
+
         foreach ($data as $value) {
           $prepared[$value->id()] = [
             'id' => $value->id(),
-            'title' => $value->title->value
+            'title' => $value->title->value,
           ];
         }
       }
@@ -123,7 +124,7 @@ abstract class HelfiExternalEntityBase extends ExternalEntityStorageClientBase {
         $this->query['filter[name-filter][condition][value]'] = $values;
         $this->query['filter[name-filter][condition][operator]'] = $operator;
         $data = $this->request($this->endpoint, $this->query);
-        $prepared = [];
+
         foreach ($data as $value) {
           $prepared[$value["id"]] = $value;
         }

--- a/helfi_features/helfi_news_feed/src/HelfiExternalEntityBase.php
+++ b/helfi_features/helfi_news_feed/src/HelfiExternalEntityBase.php
@@ -5,7 +5,6 @@ namespace Drupal\helfi_news_feed;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\external_entities\ExternalEntityInterface;
-use Drupal\external_entities\ExternalEntityStorage;
 use Drupal\external_entities\StorageClient\ExternalEntityStorageClientBase;
 use Drupal\helfi_api_base\Environment\Environment;
 use Drupal\helfi_api_base\Environment\Project;
@@ -113,7 +112,10 @@ abstract class HelfiExternalEntityBase extends ExternalEntityStorageClientBase {
         $data = $storage->loadMultiple($values);
         $prepared = [];
         foreach ($data as $value) {
-          $prepared[$value->id()] = ['id' => $value->id(), 'title' =>  $value->title->value];
+          $prepared[$value->id()] = [
+            'id' => $value->id(),
+            'title' => $value->title->value
+          ];
         }
       }
       else {

--- a/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -130,11 +130,13 @@ final class News extends ExternalEntityStorageClientBase {
       return [];
     }
     $query = [
-      sprintf('filter[%s.name][operator]', $name) => 'IN',
+      sprintf('filter[taxonomy_term--news_%s][condition][operator]', $name) => 'IN',
     ];
+    $query[sprintf('filter[taxonomy_term--news_%s][condition][path]', $name)] = "field_news_$name.id";
+
     // Filter by multiple terms using 'OR' condition.
     foreach ($terms as $key => $value) {
-      $query[sprintf('filter[%s.name][value][%d]', $name, $key)] = $value;
+      $query[sprintf('filter[taxonomy_term--news_%s][condition][value][%d]', $name, $key)] = $value['target_id'];
     }
     return $query;
   }
@@ -209,16 +211,12 @@ final class News extends ExternalEntityStorageClientBase {
       }
     }
 
-    // @todo Lancode missing from parameters for some reason.
-    $language = $this->languageManager
-      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
-      ->getId();
-    $query = [
-      'filter[langcode]' => $language,
-    ];
-
+    // If filter is missing language set it manually.
     if (!isset($query['filter[langcode]'])) {
-      throw new \InvalidArgumentException('Missing required "langcode" filter.');
+      $language = $this->languageManager
+        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getId();
+      $query['filter[langcode]'] = $language;
     }
     return $this->request($query, $query['filter[langcode]']);
   }

--- a/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -209,6 +209,14 @@ final class News extends ExternalEntityStorageClientBase {
       }
     }
 
+    // @todo Lancode missing from parameters for some reason.
+    $language = $this->languageManager
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
+    $query = [
+      'filter[langcode]' => $language
+    ];
+
     if (!isset($query['filter[langcode]'])) {
       throw new \InvalidArgumentException('Missing required "langcode" filter.');
     }

--- a/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -214,7 +214,7 @@ final class News extends ExternalEntityStorageClientBase {
       ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
       ->getId();
     $query = [
-      'filter[langcode]' => $language
+      'filter[langcode]' => $language,
     ];
 
     if (!isset($query['filter[langcode]'])) {

--- a/helfi_features/helfi_news_feed/tests/src/Kernel/NewsFeedParagraphTest.php
+++ b/helfi_features/helfi_news_feed/tests/src/Kernel/NewsFeedParagraphTest.php
@@ -41,7 +41,12 @@ class NewsFeedParagraphTest extends KernelTestBase {
    */
   public function testBundleClass() : void {
     $storage = $this->getExternalEntityStorage();
-    $neighbourhood = $storage->create(['type' => 'helfi_news_neighbourhoods']);
+    $neighbourhood_uuid = '12345678-1234-1234-1234-12345678';
+    $neighbourhood = $storage->create([
+      'type' => 'helfi_news_neighbourhoods',
+      'id' => $neighbourhood_uuid,
+      'title' => 'Neighbourhood',
+    ]);
 
     $paragraph = Paragraph::create([
       'type' => 'news_list',
@@ -51,9 +56,9 @@ class NewsFeedParagraphTest extends KernelTestBase {
       'field_news_list_description' => 'test description',
     ]);
     $paragraph->save();
+
     $this->assertInstanceOf(NewsFeedParagraph::class, $paragraph);
-    // @todo Fix tests for the external entities, returns always empty array.
-    $this->assertEquals([], $paragraph->getNeighbourhoods());
+    $this->assertEquals([['target_id' => $neighbourhood_uuid]], $paragraph->getNeighbourhoods());
     $this->assertEquals(22, $paragraph->getLimit());
     $this->assertEquals('test title', $paragraph->getTitle());
     $this->assertEquals('test description', $paragraph->getDescription());


### PR DESCRIPTION
# ENV VALUE FIX 
Getenv won't work with environmentResolver since test-environment has APP_ENV=testing and in environmentResolver mapping "test". This causes code to break on test environment.

## What was done
* Replaced getenv with config file value
* (Bonus fix to news taxonomy autocomplete)

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_env_value_fix`
* Run `make drush-updb drush-cr`

