### PR TITLE
Update patch for default_content 2.0.0-alpha2

### DIFF
--- a/modules/helfi_test_content/README.md
+++ b/modules/helfi_test_content/README.md
@@ -18,7 +18,7 @@ drush en -y helfi_test_content
 When the module is already enabled and the content should be re-imported, it can be done with following drush command.
 
 ```
-drush dcim helfi_test_content --update-existing && drush dcim helfi_tpr_test_content --update-existing
+drush dcim helfi_test_content && drush dcim helfi_tpr_test_content
 ```
 
 ## How to export the test content

--- a/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch
+++ b/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch
@@ -1,0 +1,276 @@
+diff --git a/composer.json b/composer.json
+index 4c6b3fd..cc81c83 100644
+--- a/composer.json
++++ b/composer.json
+@@ -9,6 +9,7 @@
+   },
+   "require-dev": {
+     "drupal/paragraphs": "^1",
++    "drush/drush": "^11",
+     "drupal/hal": " ^9 || ^1 || ^2"
+   },
+   "extra": {
+diff --git a/drush.services.yml b/drush.services.yml
+index 441ae0c..a02bba6 100644
+--- a/drush.services.yml
++++ b/drush.services.yml
+@@ -1,6 +1,6 @@
+ services:
+   default_content.commands:
+-    class: \Drupal\default_content\Commands\DefaultContentCommands
+-    arguments: ['@default_content.exporter']
++    class: Drupal\default_content\Commands\DefaultContentCommands
++    arguments: ['@default_content.exporter', '@default_content.importer', '%container.modules%']
+     tags:
+       - { name: drush.command }
+diff --git a/src/Commands/DefaultContentCommands.php b/src/Commands/DefaultContentCommands.php
+index d9c6da4..ef36be3 100644
+--- a/src/Commands/DefaultContentCommands.php
++++ b/src/Commands/DefaultContentCommands.php
+@@ -2,13 +2,13 @@
+ 
+ namespace Drupal\default_content\Commands;
+ 
++use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+ use Drupal\default_content\ExporterInterface;
++use Drupal\default_content\ImporterInterface;
+ use Drush\Commands\DrushCommands;
+ 
+ /**
+- * Class DefaultContentCommands.
+- *
+- * @package Drupal\default_content
++ * Provides Drush commands for 'Default content' module.
+  */
+ class DefaultContentCommands extends DrushCommands {
+ 
+@@ -20,13 +20,34 @@ class DefaultContentCommands extends DrushCommands {
+   protected $defaultContentExporter;
+ 
+   /**
+-   * SimplesitemapController constructor.
++   * The default content importer.
++   *
++   * @var \Drupal\default_content\ImporterInterface
++   */
++  protected $defaultContentImporter;
++
++  /**
++   * A full list of installed modules plus the active profile.
++   *
++   * @var string[]
++   */
++  protected $installedExtensions;
++
++  /**
++   * DefaultContentCommands constructor.
+    *
+    * @param \Drupal\default_content\ExporterInterface $default_content_exporter
+    *   The default content exporter.
++   * @param \Drupal\default_content\ImporterInterface $default_content_importer
++   *   The default content importer.
++   * @param array[] $installed_modules
++   *   Installed modules list from the 'container.modules' container parameter.
+    */
+-  public function __construct(ExporterInterface $default_content_exporter) {
++  public function __construct(ExporterInterface $default_content_exporter, ImporterInterface $default_content_importer, array $installed_modules) {
++    parent::__construct();
+     $this->defaultContentExporter = $default_content_exporter;
++    $this->defaultContentImporter = $default_content_importer;
++    $this->installedExtensions = array_keys($installed_modules);
+   }
+ 
+   /**
+@@ -85,10 +106,71 @@ class DefaultContentCommands extends DrushCommands {
+    * @aliases dcem
+    */
+   public function contentExportModule($module) {
++    $this->checkExtensions([$module]);
+     $module_folder = \Drupal::moduleHandler()
+       ->getModule($module)
+       ->getPath() . '/content';
+     $this->defaultContentExporter->exportModuleContent($module, $module_folder);
+   }
+ 
++  /**
++   * Imports default content from installed modules or active profile.
++   *
++   * @param string[] $extensions
++   *   Space-delimited list of module which may contain also the active profile.
++   *
++   * @option update Updates existing entities with values from import
++   *
++   * @usage drush default-content:import
++   *   Imports default content from all installed modules, including the active
++   *   profile.
++   * @usage drush dcim my_module other_module custom_profile
++   *   Imports default content from <info>my_module</info>,
++   *   <info>other_module<info> modules and <info>custom_profile<info> active
++   *   profile.
++   * @usage drush default-content:import my_module --no-update
++   *   Imports only new default content from <info>my_module</info> module.
++   *
++   * @command default-content:import
++   * @aliases dcim
++   */
++  public function import(array $extensions, array $options = ['update' => TRUE]): void {
++    $count = 0;
++    $import_from_extensions = [];
++    foreach ($this->checkExtensions($extensions) as $extension) {
++      if ($extension_count = count($this->defaultContentImporter->importContent($extension, $options['update']))) {
++        $import_from_extensions[] = $extension;
++        $count += $extension_count;
++      }
++    }
++    if ($count) {
++      $this->logger()->notice(new PluralTranslatableMarkup($count, '1 entity imported from @modules', '@count entities imported from @modules', [
++        '@modules' => implode(', ', $import_from_extensions),
++      ]));
++      return;
++    }
++    $this->logger()->warning(dt('No content has been imported.'));
++  }
++
++  /**
++   * Checks and returns a list of extension given the user input.
++   *
++   * @param array $extensions
++   *   An array of modules and/or the active profile.
++   *
++   * @return array
++   *   A list of modules and/or the active profile.
++   */
++  protected function checkExtensions(array $extensions): array {
++    if (!$extensions) {
++      return $this->installedExtensions;
++    }
++
++    if ($invalid_extensions = array_diff($extensions, $this->installedExtensions)) {
++      throw new \InvalidArgumentException(sprintf('Invalid modules or profile passed: %s', implode(', ', $invalid_extensions)));
++    }
++
++    return $extensions;
++  }
++
+ }
+diff --git a/src/Importer.php b/src/Importer.php
+index 27fedaf..7ca9986 100644
+--- a/src/Importer.php
++++ b/src/Importer.php
+@@ -149,11 +149,12 @@ class Importer implements ImporterInterface {
+   /**
+    * {@inheritdoc}
+    */
+-  public function importContent($module) {
++  public function importContent(string $module, bool $update_existing = FALSE) {
+     $created = [];
+     $folder = \Drupal::service('extension.list.module')->getPath($module) . "/content";
+ 
+     if (file_exists($folder)) {
++      /** @var \Drupal\user\UserInterface $root_user */
+       $root_user = $this->entityTypeManager->getStorage('user')->load(1);
+       $this->accountSwitcher->switchTo($root_user);
+       $file_map = [];
+@@ -251,10 +252,13 @@ class Importer implements ImporterInterface {
+             $entity = $this->serializer->deserialize($contents, $class, 'hal_json', ['request_method' => 'POST']);
+           }
+           else {
+-            $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents));
++            $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents), $update_existing);
++          }
++
++          if (!$entity->isNew() && !$update_existing) {
++            continue;
+           }
+ 
+-          $entity->enforceIsNew(TRUE);
+           // Ensure that the entity is not owned by the anonymous user.
+           if ($entity instanceof EntityOwnerInterface && empty($entity->getOwnerId())) {
+             $entity->setOwner($root_user);
+diff --git a/src/ImporterInterface.php b/src/ImporterInterface.php
+index 0d300a3..abbeb90 100644
+--- a/src/ImporterInterface.php
++++ b/src/ImporterInterface.php
+@@ -12,10 +12,13 @@ interface ImporterInterface {
+    *
+    * @param string $module
+    *   The module to create the default content from.
++   * @param bool $update_existing
++   *   Whether to update an already existing entity with the imported values.
++   *   Defaults to FALSE.
+    *
+    * @return \Drupal\Core\Entity\EntityInterface[]
+    *   An array of created entities keyed by their UUIDs.
+    */
+-  public function importContent($module);
++  public function importContent(string $module, bool $update_existing = FALSE);
+ 
+ }
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index 4d5a932..1024b95 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -150,7 +150,7 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+   /**
+    * {@inheritdoc}
+    */
+-  public function denormalize(array $data) {
++  public function denormalize(array $data, bool $update_existing = FALSE) {
+     if (!isset($data['_meta']['entity_type'])) {
+       throw new UnexpectedValueException('The entity type metadata must be specified.');
+     }
+@@ -178,8 +178,21 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+       $values[$entity_type->getKey('langcode')] = $data['_meta']['default_langcode'];
+     }
+ 
++    // Load the entity by UUID and check if it exists.
++    $entity = $this->entityTypeManager->getStorage($entity_type->id())->loadByProperties(['uuid' => $values['uuid']]);
+     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+-    $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++    if (!empty($entity)) {
++      if (!$update_existing) {
++        // Do not override the existing entity.
++        return reset($entity);
++      }
++      $entity = reset($entity);
++    }
++    else {
++      $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++      $entity->enforceIsNew(TRUE);
++    }
++
+     foreach ($data['default'] as $field_name => $values) {
+       $this->setFieldValues($entity, $field_name, $values);
+     }
+diff --git a/src/Normalizer/ContentEntityNormalizerInterface.php b/src/Normalizer/ContentEntityNormalizerInterface.php
+index fa78b79..1587248 100644
+--- a/src/Normalizer/ContentEntityNormalizerInterface.php
++++ b/src/Normalizer/ContentEntityNormalizerInterface.php
+@@ -27,10 +27,13 @@ interface ContentEntityNormalizerInterface {
+    *
+    * @param array $data
+    *   The normalized data.
++   * @param bool $update_existing
++   *   Whether to update an already existing entity with the imported values.
++   *   Defaults to FALSE.
+    *
+    * @return \Drupal\Core\Entity\ContentEntityInterface
+    *   The denormalized content entity.
+    */
+-  public function denormalize(array $data);
++  public function denormalize(array $data, bool $update_existing = FALSE);
+ 
+ }
+diff --git a/tests/src/Functional/DefaultContentTest.php b/tests/src/Functional/DefaultContentTest.php
+index cea7bdd..4ac9aa5 100644
+--- a/tests/src/Functional/DefaultContentTest.php
++++ b/tests/src/Functional/DefaultContentTest.php
+@@ -102,7 +102,7 @@ class DefaultContentTest extends BrowserTestBase {
+     $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadMultiple();
+     $term = reset($terms);
+     $this->assertNotEmpty($term);
+-    $this->assertEquals($term->name->value, 'A tag');
++    $this->assertEquals($term->label(), 'A tag');
+     $term_id = $node->field_tags->target_id;
+     $this->assertNotEmpty($term_id);
+   }


### PR DESCRIPTION
# Fix outdated patch file for default_content module

Added a new patch for default_content module based on the [latest changes](https://www.drupal.org/project/default_content/issues/2640734#comment-14638943) at issue 2640734. An update for the patch is needed after the default_content module got updated to version 2.0.0-alpha2.

After this is merged to main branch, then the actually patch is changed from composer.json file to point to the raw github file.

## How to install
* Make sure you have some local development site running.
* Use the new patch.
  * It might be easiest to test by temporarily changing the current patch from `vendor/composer/installed.json` to:
```
"drupal/default_content": {
    "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/UHF-X-default-content-patch-fix/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"
},
```
* Run `composer update drupal/default_content`

## How to test
* Check that the above `composer update` command was succesful. The patch was applied to the default_content module 2.0.0-alpha2.
* Enable the _HELfi Platform test content_ module.
* This will create the default content.
* Run `drush dcim helfi_test_content` and check that it updates the default content.
