### PR TITLE
UHF-X: Fix not valid context error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "drupal/content_lock": "^2.2",
         "drupal/core-recommended": ">=9.3",
         "drupal/crop": "^2.1",
+        "drupal/ctools": "^3.11",
         "drupal/default_content": "^2.0.0-alpha2",
         "drupal/diff": "^1.0",
         "drupal/gin_toolbar": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "drupal/content_lock": "^2.2",
         "drupal/core-recommended": ">=9.3",
         "drupal/crop": "^2.1",
-        "drupal/ctools": "^3.11",
         "drupal/default_content": "^2.0.0-alpha2",
         "drupal/diff": "^1.0",
         "drupal/gin_toolbar": "^1.0",
@@ -62,6 +61,9 @@
         "drupal/view_unpublished": "^1.0",
         "drupal/views_bulk_edit": "^2.6",
         "drupal/views_bulk_operations": "^4.1"
+    },
+    "conflict": {
+        "drupal/ctools": "<3.11 || ^4.0.1"
     },
     "extra": {
         "patches": {


### PR DESCRIPTION
# Fix the "not valid context error"

Adds version constraints for CTools to prevent [ctools issue 3300682](https://www.drupal.org/project/ctools/issues/3300682).

## How to install
* Make sure your instance is up and running on latest dev branch.
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X-not-valid-context-error`

## How to test
* Make sure you can't install e.g. ctools version 4.0.1
    * `composer require drupal/ctools:^4.0.1`
* Make sure you can install ctools version 4.0.0
    * `composer require drupal/ctools:^4.0`
