### PR TITLE
UHF-6300: Remove ctools dependencies from modules

### DIFF
--- a/helfi_features/helfi_base_config/helfi_base_config.info.yml
+++ b/helfi_features/helfi_base_config/helfi_base_config.info.yml
@@ -8,7 +8,6 @@ dependencies:
   - 'admin_toolbar_tools:admin_toolbar_tools'
   - 'config_rewrite:config_rewrite'
   - 'config_ignore:config_ignore'
-  - 'ctools:ctools'
   - 'diff:diff'
   - 'drupal:block'
   - 'drupal:config_translation'

--- a/helfi_features/helfi_gdpr_compliance/helfi_gdpr_compliance.info.yml
+++ b/helfi_features/helfi_gdpr_compliance/helfi_gdpr_compliance.info.yml
@@ -2,7 +2,6 @@ name: 'HELfi GDPR compliance'
 type: module
 core_version_requirement: '^8.9 || ^9'
 dependencies:
-  - 'ctools:ctools'
   - 'drupal:block'
   - 'eu_cookie_compliance:eu_cookie_compliance'
   - 'helfi_content:helfi_content'


### PR DESCRIPTION
# [UHF-6300](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6300)

## What was done
* Removed redundant ctools dependencies from platform config submodules.

## How to test
* Check site specific PR's for testing instructions.
* Tests fail until https://github.com/City-of-Helsinki/drupal-hdbt/pull/382 is merged and released.

## Other PRs
* Related theme PR:
  * https://github.com/City-of-Helsinki/drupal-hdbt/pull/382
* Site specific PRs:
  * https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/435
  * https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/419
  * https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/308
  * https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/204
  * https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/95
  * https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/43
  * https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/114
  * https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/113
