### PR TITLE
UHF-5668: Hid the toc title field and added translation for the new d…

### DIFF
--- a/helfi_features/helfi_toc/helfi_toc.module
+++ b/helfi_features/helfi_toc/helfi_toc.module
@@ -87,10 +87,10 @@ function helfi_toc_apply_form_theme(array &$form) {
   // Control Table of contents title field visibility via checkbox states.
   if (in_array($form['#form_id'], $whitelisted_forms)) {
     $form['toc_enabled']['#access'] = TRUE;
-    $form['toc_title']['#access'] = TRUE;
+    $form['toc_title']['#access'] = FALSE;
     $form['toc_title']['#states'] = [
       'visible' => [
-        ':input[name="toc_enabled[value]"]' => ['checked' => TRUE],
+        ':input[name="toc_enabled[value]"]' => ['checked' => FALSE],
       ],
     ];
   }
@@ -117,7 +117,7 @@ function helfi_toc_preprocess_field__toc_enabled(&$variables) {
 
   if ($entity instanceof ContentEntityInterface) {
     $variables['toc_enabled'] = (bool) $entity->get('toc_enabled')->value;
-    $variables['toc_title'] = $entity->get('toc_title')->value;
+    $variables['toc_title'] = t('On this page');
     $variables['#attached']['library'][] = 'helfi_toc/table_of_contents';
   }
 }

--- a/helfi_features/helfi_toc/translations/fi.po
+++ b/helfi_features/helfi_toc/translations/fi.po
@@ -12,3 +12,6 @@ msgstr "Sisällysluettelon otsikko"
 
 msgid "Loading table of contents"
 msgstr "Ladataan sisällysluetteloa"
+
+msgid "On this page"
+msgstr "Tällä sivulla"

--- a/helfi_features/helfi_toc/translations/sv.po
+++ b/helfi_features/helfi_toc/translations/sv.po
@@ -12,3 +12,6 @@ msgstr "Innehållsförteckningens titel"
 
 msgid "Loading table of contents"
 msgstr "Laddar innehållsförteckningen"
+
+msgid "On this page"
+msgstr "På den här sidan"


### PR DESCRIPTION
# [UHF-5668](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

## What was done
* Hides the toc title field from node form

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-5668-hide-toc-title-field`
* Update translations `drush locale:check` and `drush locale:update`
* Run `make drush-cr`

## How to test
* Create a standard page and check that table of contents is visible on the page
* In the form, there shouldn't be the title field visible anymore
* Save node and check that the table of contents has new default value as title `Tällä sivulla, On this page, På den här sidan`

## Other info
The field was only hidden from the form and not deleted completely in case it is wanted back