### PR TITLE
UHF-6075 custom content type metatag

### DIFF
--- a/helfi_features/helfi_content/helfi_content.module
+++ b/helfi_features/helfi_content/helfi_content.module
@@ -15,7 +15,7 @@ function helfi_content_page_attachments_alter(array &$attachments) {
   }
 
   $entities = array_filter(
-    iterator_to_array(\Drupal::routeMatch()->getParameters()),
+    \Drupal::routeMatch()->getParameters()->all(),
     function($param) {
       return $param instanceof \Drupal\Core\Entity\EntityInterface;
     }

--- a/helfi_features/helfi_content/helfi_content.module
+++ b/helfi_features/helfi_content/helfi_content.module
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_content_page_attachments_alter(array &$attachments) {
+  // Set custom content type metatag on all content pages.
+  if (empty($attachments['#attached']['html_head'])) {
+    return;
+  }
+
+  $entities = array_filter(
+    iterator_to_array(\Drupal::routeMatch()->getParameters()),
+    function($param) {
+      return ($param instanceof \Drupal\Core\Entity\EntityInterface && method_exists($param, 'getType'));
+    }
+  );
+
+  $entity = !empty($entities) ? reset($entities) : NULL;
+  if ($entity) {
+    $tag_name = 'helfi_content_type';
+    $helfi_content_type = [
+      '#tag' => 'meta',
+      '#attributes' => [
+        'name' => $tag_name,
+        'content' => $entity->getType(),
+      ],
+    ];
+    $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
+  }
+}

--- a/helfi_features/helfi_content/helfi_content.module
+++ b/helfi_features/helfi_content/helfi_content.module
@@ -17,18 +17,20 @@ function helfi_content_page_attachments_alter(array &$attachments) {
   $entities = array_filter(
     iterator_to_array(\Drupal::routeMatch()->getParameters()),
     function($param) {
-      return ($param instanceof \Drupal\Core\Entity\EntityInterface && method_exists($param, 'getType'));
+      return $param instanceof \Drupal\Core\Entity\EntityInterface;
     }
   );
 
   $entity = !empty($entities) ? reset($entities) : NULL;
   if ($entity) {
     $tag_name = 'helfi_content_type';
+
+    $type = method_exists($entity, 'getType') ? $entity->getType() : $entity->getEntityTypeId();
     $helfi_content_type = [
       '#tag' => 'meta',
       '#attributes' => [
         'name' => $tag_name,
-        'content' => $entity->getType(),
+        'content' => $type,
       ],
     ];
     $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];

--- a/helfi_features/helfi_content/helfi_content.module
+++ b/helfi_features/helfi_content/helfi_content.module
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * @file
+ * Contains HELfi content alterations.
+ */
+
+/**
  * Implements hook_page_attachments_alter().
  */
 function helfi_content_page_attachments_alter(array &$attachments) {

--- a/helfi_features/helfi_content/helfi_content.module
+++ b/helfi_features/helfi_content/helfi_content.module
@@ -25,12 +25,11 @@ function helfi_content_page_attachments_alter(array &$attachments) {
   if ($entity) {
     $tag_name = 'helfi_content_type';
 
-    $type = method_exists($entity, 'getType') ? $entity->getType() : $entity->getEntityTypeId();
     $helfi_content_type = [
       '#tag' => 'meta',
       '#attributes' => [
         'name' => $tag_name,
-        'content' => $type,
+        'content' => $entity->bundle(),
       ],
     ];
     $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -197,6 +197,37 @@ function helfi_platform_config_preprocess_breadcrumb(&$variables) {
 }
 
 /**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_platform_config_page_attachments_alter(array &$attachments) {
+  // Set custom content type metatag on all content pages.
+  if (!empty($attachments['#attached']['html_head'])) {
+    $entity = NULL;
+    $tag_name = 'helfi_content_type';
+    foreach (\Drupal::routeMatch()->getParameters() as $param) {
+      if ($param instanceof \Drupal\Core\Entity\EntityInterface) {
+        $entity = $param;
+        break;
+      }
+    }
+
+    if (
+      $entity &&
+      $type = $entity->getType()
+    ) {
+      $helfi_content_type = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => $tag_name,
+          'content' => $type,
+        ],
+      ];
+      $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
+    }
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK().
  */
 function helfi_platform_config_preprocess_react_and_share(&$variables) {

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -201,29 +201,29 @@ function helfi_platform_config_preprocess_breadcrumb(&$variables) {
  */
 function helfi_platform_config_page_attachments_alter(array &$attachments) {
   // Set custom content type metatag on all content pages.
-  if (!empty($attachments['#attached']['html_head'])) {
-    $entity = NULL;
-    $tag_name = 'helfi_content_type';
-    foreach (\Drupal::routeMatch()->getParameters() as $param) {
-      if ($param instanceof \Drupal\Core\Entity\EntityInterface) {
-        $entity = $param;
-        break;
-      }
-    }
+  if (empty($attachments['#attached']['html_head'])) {
+    return;
+  }
 
-    if (
-      $entity &&
-      $type = $entity->getType()
-    ) {
-      $helfi_content_type = [
-        '#tag' => 'meta',
-        '#attributes' => [
-          'name' => $tag_name,
-          'content' => $type,
-        ],
-      ];
-      $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
+  $entities = array_filter(
+    iterator_to_array(\Drupal::routeMatch()->getParameters()),
+    function($param) {
+      return ($param instanceof \Drupal\Core\Entity\EntityInterface && method_exists($param, 'getType'));
     }
+  );
+
+  $entity = !empty($entities) ? reset($entities) : NULL;
+  if ($entity) {
+    $type = $entity->getType();
+    $tag_name = 'helfi_content_type';
+    $helfi_content_type = [
+      '#tag' => 'meta',
+      '#attributes' => [
+        'name' => $tag_name,
+        'content' => $type,
+      ],
+    ];
+    $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
   }
 }
 

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -197,37 +197,6 @@ function helfi_platform_config_preprocess_breadcrumb(&$variables) {
 }
 
 /**
- * Implements hook_page_attachments_alter().
- */
-function helfi_platform_config_page_attachments_alter(array &$attachments) {
-  // Set custom content type metatag on all content pages.
-  if (empty($attachments['#attached']['html_head'])) {
-    return;
-  }
-
-  $entities = array_filter(
-    iterator_to_array(\Drupal::routeMatch()->getParameters()),
-    function($param) {
-      return ($param instanceof \Drupal\Core\Entity\EntityInterface && method_exists($param, 'getType'));
-    }
-  );
-
-  $entity = !empty($entities) ? reset($entities) : NULL;
-  if ($entity) {
-    $type = $entity->getType();
-    $tag_name = 'helfi_content_type';
-    $helfi_content_type = [
-      '#tag' => 'meta',
-      '#attributes' => [
-        'name' => $tag_name,
-        'content' => $type,
-      ],
-    ];
-    $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
-  }
-}
-
-/**
  * Implements hook_preprocess_HOOK().
  */
 function helfi_platform_config_preprocess_react_and_share(&$variables) {


### PR DESCRIPTION
# Contenttype metatag [UHF-6075](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6075)
Added content type metatag to all possible content types.

## What was done
* Added content type metatag to all possible content types.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6075_custom_content_type_metatag`
* Run `make drush-updb drush-cr`

## How to test
* Go to any content page
  * test with different kind of content: nodes, tpr-entities, job_listings and whatnot
* inspect the page, check the content of head tag
   * You should see something like `<meta name="helfi_content_type" content="whatever_content_you_lookin">`

