### PR TITLE
Added update hook to update hero design translations

### DIFF
--- a/helfi_features/helfi_content/config/language/fi/field.storage.paragraph.field_hero_design.yml
+++ b/helfi_features/helfi_content/config/language/fi/field.storage.paragraph.field_hero_design.yml
@@ -3,14 +3,10 @@ settings:
     -
       label: 'Ilman kuvaa, tasattu vasemmalle'
     -
-      label: 'Ilman kuvaa, tasattu keskelle'
-    -
       label: 'Kuva oikealla'
     -
       label: 'Kuva vasemmalla'
     -
       label: 'Kuva alhaalla'
-    -
-      label: Taustakuva
     -
       label: Diagonaalinen

--- a/helfi_features/helfi_content/config/language/sv/field.storage.paragraph.field_hero_design.yml
+++ b/helfi_features/helfi_content/config/language/sv/field.storage.paragraph.field_hero_design.yml
@@ -1,0 +1,12 @@
+settings:
+  allowed_values:
+    -
+      label: 'Utan bild, justerad vänster'
+    -
+      label: 'Bild justerad till höger'
+    -
+      label: 'Bild justerad till vänster'
+    -
+      label: 'Bild justerad ner'
+    -
+      label: Diagonal

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -911,3 +911,21 @@ function helfi_content_update_9035() {
     }
   }
 }
+
+
+/**
+ * Update translation for hero design
+ */
+function helfi_content_update_9036() {
+  // Handle the configuration translation update manually.
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  $configurations = [
+    'field.storage.paragraph.field_hero_design',
+  ];
+
+  // Update translations.
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
+  }
+}


### PR DESCRIPTION
## What was done
* Updated hero design translations since they were wrong
* Also added correct Swedish translations

## How to install
* Make sure your instance is up and running on latest dev branch. Test i.ex. in kymp
    * `git pull origin dev`
    * `make fresh`


## Before updating platform config
* Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/admin/structure/paragraphs_type/hero/fields/paragraph.hero.field_hero_design/translate/fi/edit and check the translations
* All of the other translations should be wrong except without image left
* Check https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/admin/structure/paragraphs_type/hero/fields/paragraph.hero.field_hero_design/translate/sv/edit
    * The translations should be in English

* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X-update-hero-translation`
* Run `make drush-updb drush-cr`

## How to test
* Check the same translations again, they should be correct now
* Check the Swedish translations, they should be correct and in Swedish now

