### PR TITLE
UHF-6869: Added patch to fix the WSOD in TPR unit listings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
                 "[#UHF-3631] Breadcrumb allow dashes and underscores": "https://www.drupal.org/files/issues/2020-07-23/easy_breadcrumb-allow_hyphens_underscores-3161100-2.patch"
             },
             "drupal/views_bulk_edit": {
+                "[#UHF-6869] https://www.drupal.org/project/views_bulk_edit/issues/3311552": "https://git.drupalcode.org/project/views_bulk_edit/-/merge_requests/12.patch",
                 "[#UHF-4528] Declaration must be compatible": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/20af0607626b4c9adaa52c1c9773850a5c8fec3d/patches/views_bulk_edit_tests_compatible_declaration_8.x-2.6.patch"
             }
         }


### PR DESCRIPTION
# [UHF-6869](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6869)


## What was done
* Added patch to fix the WSOD

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6869_VBE_patch -W && composer install`
* Run `make drush-cr`

## How to test
* Check that the TPR unit listing works. F.e. https://helfi-kasko.docker.so/en/childhood-and-education/admin/content/integrations/tpr-unit
