### PR TITLE
UHF-6824: Breadcrumb fixes

### DIFF
--- a/config/schema/helfi_platform_config.schema.yml
+++ b/config/schema/helfi_platform_config.schema.yml
@@ -1,0 +1,7 @@
+block.settings.chat_leijuke:
+  type: block_settings
+  label: 'Example configurable text block configuration'
+  mapping:
+    chat_title:
+      type: text
+      label: 'Chat title'

--- a/config/schema/helfi_platform_config.schema.yml
+++ b/config/schema/helfi_platform_config.schema.yml
@@ -1,7 +1,0 @@
-block.settings.chat_leijuke:
-  type: block_settings
-  label: 'Example configurable text block configuration'
-  mapping:
-    chat_title:
-      type: text
-      label: 'Chat title'

--- a/helfi_features/helfi_base_config/config/install/helfi_base_config.breadcrumb.yml
+++ b/helfi_features/helfi_base_config/config/install/helfi_base_config.breadcrumb.yml
@@ -1,5 +1,0 @@
-langcode: en
-breadcrumb_base_links:
-  -
-    text: ''
-    url: ''

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -259,3 +259,30 @@ function helfi_platform_config_update_9010() {
     ]);
   }
 }
+
+/**
+ * Remove unused base config breadcrumb config.
+ */
+function helfi_platform_config_update_9011() : void {
+  $config = Drupal::configFactory()->getEditable('helfi_base_config.breadcrumb');
+
+  if (!$config) {
+    return;
+  }
+  $config->delete();
+}
+
+/**
+ * Ignore system.site:page.front configuration.
+ */
+function helfi_platform_config_update_9012() : void {
+  if (!Drupal::moduleHandler()->moduleExists('config_ignore')) {
+    return;
+  }
+  $config = Drupal::configFactory()->getEditable('config_ignore.settings');
+  $ignored = $config->get('ignored_config_entities') ?? [];
+
+  $ignored[] = 'system.site:page.front';
+  $config->set('ignored_config_entities', $ignored)
+    ->save();
+}

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -203,6 +203,17 @@ function helfi_platform_config_system_breadcrumb_alter(
   $links = $breadcrumb->getLinks();
   array_unshift($links, Link::fromTextAndUrl($link['text'], Url::fromUri($link['url'])));
 
+  // Include front page in breadcrumb if it's the only item.
+  if (count($links) === 1 && Drupal::service('path.matcher')->isFrontPage()) {
+    $entities = array_filter($route_match->getParameters()->all(), function ($value) {
+      return $value instanceof EntityInterface;
+    });
+
+    if ($entity = reset($entities)) {
+      $links[] = Link::createFromRoute($entity->label(), '<none>');
+    }
+  }
+
   // We have to recreate entire breadcrumb trail here, because breadcrumb
   // class forbids setting links after they've been set once.
   // @see \Drupal\Core\Breadcrumb\Breadcrumb::setLinks().

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -6,10 +6,13 @@
  */
 
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Render\BubbleableMetadata;
 
@@ -29,10 +32,10 @@ use Drupal\Core\Render\BubbleableMetadata;
  */
 function helfi_platform_config_enable_paragraph_fields(string $entityType, string $bundle, array $fields, string $paragraphType) : void {
   /** @var \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager */
-  $entityFieldManager = \Drupal::service('entity_field.manager');
+  $entityFieldManager = Drupal::service('entity_field.manager');
 
   if (!$definitions = $entityFieldManager->getFieldDefinitions($entityType, $bundle)) {
-    throw new \InvalidArgumentException(
+    throw new InvalidArgumentException(
       sprintf('Failed to load field definition for %s, %s', $entityType, $bundle)
     );
   }
@@ -42,7 +45,7 @@ function helfi_platform_config_enable_paragraph_fields(string $entityType, strin
 
   foreach ($definitions as $field) {
     if (!str_contains($field->getSetting('handler'), 'paragraph')) {
-      throw new \InvalidArgumentException(
+      throw new InvalidArgumentException(
         sprintf('"%s" field is not a valid paragraph reference', $field->getName()),
       );
     }
@@ -67,7 +70,7 @@ function helfi_platform_config_node_view_alter(array &$build, EntityInterface $e
   // Replace node title on nodes with the visible title field.
   // @todo Needs work on caches, wrong title is displayed if user visits content listing.
   if ($entity->hasField('field_unit_visible_title')) {
-    $entity->set('title', \Drupal::token()->replace((string) $entity->get('field_unit_visible_title')->value));
+    $entity->set('title', Drupal::token()->replace((string) $entity->get('field_unit_visible_title')->value));
   }
 }
 
@@ -76,7 +79,7 @@ function helfi_platform_config_node_view_alter(array &$build, EntityInterface $e
  */
 function helfi_platform_config_module_implements_alter(&$implementations, $hook) {
   if ($hook == 'modules_installed') {
-    $moduleHandler = \Drupal::service('module_handler');
+    $moduleHandler = Drupal::service('module_handler');
     if ($moduleHandler->moduleExists('locale')) {
       unset($implementations['locale']);
     }
@@ -87,7 +90,7 @@ function helfi_platform_config_module_implements_alter(&$implementations, $hook)
  * Implements hook_modules_installed().
  */
 function helfi_platform_config_modules_installed() {
-  $moduleHandler = \Drupal::service('module_handler');
+  $moduleHandler = Drupal::service('module_handler');
   if ($moduleHandler->moduleExists('locale')) {
     locale_system_set_config_langcodes();
   }
@@ -165,35 +168,51 @@ function helfi_platform_config_tokens(
 }
 
 /**
- * Implements hook__preprocess_HOOK().
+ * Implements hook_system_breadcrumb_alter().
  */
-function helfi_platform_config_preprocess_breadcrumb(&$variables) {
-  $config = \Drupal::config('helfi_base_config.breadcrumb');
-  if ($config && !$config->get('breadcrumb_base_links')) {
+function helfi_platform_config_system_breadcrumb_alter(
+  Breadcrumb &$breadcrumb,
+  RouteMatchInterface $route_match,
+  array $context
+) {
+  // Skip admin routes.
+  if ($route_match->getRouteObject()?->getOption('_admin_route')) {
     return;
   }
+  // @todo Replace this with Etusivu instance once it's live.
+  $list = [
+    'en' => [
+      'text' => 'Frontpage',
+      'url' => 'https://www.hel.fi/helsinki/en',
+    ],
+    'fi' => [
+      'text' => 'Etusivu',
+      'url' => 'https://www.hel.fi/helsinki/fi',
+    ],
+    'sv' => [
+      'text' => 'Framsida',
+      'url' => 'https://www.hel.fi/helsinki/sv',
+    ],
+  ];
+  $currentLanguage = Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
 
-  foreach (array_reverse($config->get('breadcrumb_base_links')) as $crumb) {
-    if (empty($crumb['text']) || !filter_var($crumb['url'], FILTER_VALIDATE_URL)) {
-      continue;
-    }
-    array_unshift(
-      $variables['links'],
-      Link::fromTextAndUrl(
-        $crumb['text'],
-        UrlHelper::isExternal($crumb['url'])
-          ? Url::fromUri($crumb['url'])
-          : Url::fromUserInput($crumb['url'])
-      )
-    );
-    array_unshift(
-      $variables['breadcrumb'],
-      [
-        'text' => $crumb['text'],
-        'url' => $crumb['url'],
-      ]
-    );
-  }
+  $link = $list[$currentLanguage] ?? $list['en'];
+
+  $links = $breadcrumb->getLinks();
+  array_unshift($links, Link::fromTextAndUrl($link['text'], Url::fromUri($link['url'])));
+
+  // We have to recreate entire breadcrumb trail here, because breadcrumb
+  // class forbids setting links after they've been set once.
+  // @see \Drupal\Core\Breadcrumb\Breadcrumb::setLinks().
+  $newBreadcrumb = new Breadcrumb();
+  $newBreadcrumb->setLinks($links);
+  // Merge cacheable metadata.
+  $newBreadcrumb->addCacheTags($breadcrumb->getCacheTags())
+    ->addCacheContexts($breadcrumb->getCacheContexts());
+
+  $breadcrumb = $newBreadcrumb;
 }
 
 /**

--- a/tests/src/Functional/BreadcrumbTest.php
+++ b/tests/src/Functional/BreadcrumbTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_platform_config\Functional;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+
+/**
+ * Tests breadcrumb.
+ *
+ * @group helfi_platform_config
+ */
+class BreadcrumbTest extends BrowserTestBase {
+
+  use AssertBreadcrumbTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'language',
+    'content_translation',
+    'node',
+    'block',
+    'helfi_platform_config',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * The node.
+   *
+   * @var \Drupal\node\NodeInterface|null
+   */
+  protected ?NodeInterface $node;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() : void {
+    parent::setUp();
+
+    foreach (['fi', 'sv'] as $langcode) {
+      ConfigurableLanguage::createFromLangcode($langcode)->save();
+    }
+    $this->config('language.negotiation')
+      ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
+      ->save();
+
+    NodeType::create([
+      'type' => 'page',
+    ])->save();
+
+    $this->drupalPlaceBlock('system_breadcrumb_block', [
+      'region' => 'content',
+      'theme' => $this->defaultTheme,
+    ]);
+
+    $this->node = Node::create(['type' => 'page', 'title' => 'Title en']);
+    $this->node->save();
+
+    foreach (['fi', 'sv'] as $language) {
+      $this->node->addTranslation($language, [
+        'title' => 'Title ' . $language,
+      ]);
+    }
+    $this->node->save();
+  }
+
+  /**
+   * Tests that breadcrumb link is added.
+   */
+  public function testBreadcrumb() : void {
+    // Make sure first item is always link to hel.fi Etusivu instance.
+    foreach (['en' => 'Frontpage', 'sv' => 'Framsida', 'fi' => 'Etusivu'] as $language => $title) {
+      $this->drupalGet('/' . $language);
+      $parts = $this->getBreadcrumbParts();
+      $this->assertEquals($title, $parts[0]['text']);
+
+      $this->drupalGet('/' . $language . '/node/' . $this->node->id());
+      $parts = $this->getBreadcrumbParts();
+      $this->assertEquals($title, $parts[0]['text']);
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-6824](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6824)

## What was done
- Fixed breadcrumb when there is only one item visible
- Removed `helfi_base_config.breadcrumb` configuration in favor of hardcoded link to hel.fi front page 
- Added `system.site:page.front` to ignored configuration

## How to install
- Make sure your instance is up and running on latest dev branch.
  - `git pull origin dev`
  - `make fresh`
- Update the Helfi Platform config
- `composer require drupal/helfi_platform_config:dev-UHF-6824-breadcrumb-fixes`
- Run `make drush-updb drush-cr`

## How to test
- Change default front page (Configuration -> Basic site settings) to whatever `/front` path gets redirected to and make sure "double" URL is removed
  - For example `/en/urban-environment-and-traffic/urban-environment-and-traffic` should become `/en/urban-environment-and-traffic`
- Make sure the old URL still works and gets redirected to new front page
- Make sure the issue Ilkka described in UHF-6824 is fixed