### PR TITLE
UHF-6169: Fixed assetpaths for leijuke js loading.

### DIFF
--- a/src/Plugin/Block/ChatLeijuke.php
+++ b/src/Plugin/Block/ChatLeijuke.php
@@ -65,6 +65,7 @@ class ChatLeijuke extends BlockBase {
     $build = [];
     $chatLibrary = [];
     $modulePath = \Drupal::service('extension.list.module')->getPath('helfi_platform_config');
+    $assetPath = \Drupal::config('helfi_proxy.settings')->get('asset_path');
 
     $librariesYml = Yaml::parseFile($modulePath . '/helfi_platform_config.libraries.yml');
 
@@ -104,7 +105,7 @@ class ChatLeijuke extends BlockBase {
               $config['chat_selection'] => [
                 'name' => $config['chat_selection'],
                 'libraries' => $chatLibrary,
-                'modulepath' => $modulePath,
+                'modulepath' => $assetPath . '/' . $modulePath,
                 'title' => $config['chat_title'] ? Xss::filter($config['chat_title']) : 'Chat',
               ],
             ],


### PR DESCRIPTION
# [UHF-6169](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6169)
Fixed assetpaths for leijuke js loading 

## What was done
* Fixed assetpaths for leijuke js loading

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6169-leijuke-js-paths`
* Run `make drush-updb drush-cr`

## How to test
* Check that the chat js loaded via leijuke from assets is loaded.

