### PR TITLE
UHF-6993: Revert cookie policy version via update.

### DIFF
--- a/helfi_features/helfi_gdpr_compliance/config/update/helfi_gdpr_compliance_update_9013.yml
+++ b/helfi_features/helfi_gdpr_compliance/config/update/helfi_gdpr_compliance_update_9013.yml
@@ -1,0 +1,5 @@
+eu_cookie_compliance.settings:
+  expected_config: { }
+  update_actions:
+    change:
+      cookie_policy_version: 1.0.0

--- a/helfi_features/helfi_gdpr_compliance/helfi_gdpr_compliance.install
+++ b/helfi_features/helfi_gdpr_compliance/helfi_gdpr_compliance.install
@@ -332,3 +332,17 @@ function helfi_gdpr_compliance_update_9012() {
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();
 }
+
+/**
+ * Revert cookie policy version because it breaks.
+ */
+function helfi_gdpr_compliance_update_9013() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_gdpr_compliance', 'helfi_gdpr_compliance_update_9013');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
# [UHF-6993](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6993)
The installed version of eu_cookie_compliance has a bug that breaks the version changes and our proxy setup makes it worse. 

## What was done
* Reverts cookie policy version change in update 9012 via update 9013.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6993-revert-cookie-policy-version`
* Run `make drush-updb drush-cr`

## How to test
* Inspect the cookie_agreed_version and check the cookie banner can be dismissed.

## Other PRs
* 
