### PR TITLE
UHF-6960: Front page tasks

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -15,6 +15,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\helfi_api_base\Environment\Project;
 
 /**
  * Helper function to enable paragraph type for given entity/bundle/field combination.
@@ -179,29 +180,25 @@ function helfi_platform_config_system_breadcrumb_alter(
   if ($route_match->getRouteObject()?->getOption('_admin_route')) {
     return;
   }
-  // @todo Replace this with Etusivu instance once it's live.
-  $list = [
-    'en' => [
-      'text' => 'Frontpage',
-      'url' => 'https://www.hel.fi/helsinki/en',
-    ],
-    'fi' => [
-      'text' => 'Etusivu',
-      'url' => 'https://www.hel.fi/helsinki/fi',
-    ],
-    'sv' => [
-      'text' => 'Framsida',
-      'url' => 'https://www.hel.fi/helsinki/sv',
-    ],
-  ];
+
+  /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolver $resolver */
+  $resolver = \Drupal::service('helfi_api_base.environment_resolver');
+  $activeEnvironment = $resolver->getActiveEnvironment()->getEnvironmentName();
+  $environment = $resolver->getEnvironment(Project::ETUSIVU, $activeEnvironment);
   $currentLanguage = Drupal::languageManager()
     ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
     ->getId();
 
-  $link = $list[$currentLanguage] ?? $list['en'];
+  // Revert to English path, if current language path is not found.
+  try {
+    $url = $environment->getUrl($currentLanguage);
+  }
+  catch (\Exception $e) {
+    $url = $environment->getUrl('en');
+  }
 
   $links = $breadcrumb->getLinks();
-  array_unshift($links, Link::fromTextAndUrl($link['text'], Url::fromUri($link['url'])));
+  array_unshift($links, Link::fromTextAndUrl(t('Front page'), Url::fromUri($url)));
 
   // Include front page in breadcrumb if it's the only item.
   if (count($links) === 1 && Drupal::service('path.matcher')->isFrontPage()) {

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -197,6 +197,9 @@ function helfi_platform_config_system_breadcrumb_alter(
     $url = $environment->getUrl('en');
   }
 
+  // @todo We need a better way to deal with local docker.so urls.
+  $url = str_replace(['http://', ':8080'], ['https://', ''], $url);
+
   $links = $breadcrumb->getLinks();
   array_unshift($links, Link::fromTextAndUrl(t('Front page'), Url::fromUri($url)));
 

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -197,9 +197,6 @@ function helfi_platform_config_system_breadcrumb_alter(
     $url = $environment->getUrl('en');
   }
 
-  // @todo We need a better way to deal with local docker.so urls.
-  $url = str_replace(['http://', ':8080'], ['https://', ''], $url);
-
   $links = $breadcrumb->getLinks();
   array_unshift($links, Link::fromTextAndUrl(t('Front page'), Url::fromUri($url)));
 

--- a/tests/src/Functional/BreadcrumbTest.php
+++ b/tests/src/Functional/BreadcrumbTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_platform_config\Functional;
 
+use Drupal\helfi_api_base\Environment\EnvironmentResolver;
+use Drupal\helfi_api_base\Environment\Project;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -25,6 +27,7 @@ class BreadcrumbTest extends BrowserTestBase {
    */
   protected static $modules = [
     'language',
+    'locale',
     'content_translation',
     'node',
     'block',
@@ -55,6 +58,10 @@ class BreadcrumbTest extends BrowserTestBase {
     $this->config('language.negotiation')
       ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
       ->save();
+    $this->config('helfi_api_base.environment_resolver.settings')
+      ->set(EnvironmentResolver::ENVIRONMENT_NAME_KEY, 'local')
+      ->set(EnvironmentResolver::PROJECT_NAME_KEY, Project::ASUMINEN)
+      ->save();
 
     NodeType::create([
       'type' => 'page',
@@ -81,14 +88,14 @@ class BreadcrumbTest extends BrowserTestBase {
    */
   public function testBreadcrumb() : void {
     // Make sure first item is always link to hel.fi Etusivu instance.
-    foreach (['en' => 'Front page', 'sv' => 'Framsida', 'fi' => 'Etusivu'] as $language => $title) {
+    foreach (['en', 'sv', 'fi'] as $language) {
       $this->drupalGet('/' . $language);
       $parts = $this->getBreadcrumbParts();
-      $this->assertEquals($title, $parts[0]['text']);
+      $this->assertEquals(t('Front page'), $parts[0]['text']);
 
       $this->drupalGet('/' . $language . '/node/' . $this->node->id());
       $parts = $this->getBreadcrumbParts();
-      $this->assertEquals($title, $parts[0]['text']);
+      $this->assertEquals(t('Front page'), $parts[0]['text']);
     }
   }
 

--- a/tests/src/Functional/BreadcrumbTest.php
+++ b/tests/src/Functional/BreadcrumbTest.php
@@ -81,7 +81,7 @@ class BreadcrumbTest extends BrowserTestBase {
    */
   public function testBreadcrumb() : void {
     // Make sure first item is always link to hel.fi Etusivu instance.
-    foreach (['en' => 'Frontpage', 'sv' => 'Framsida', 'fi' => 'Etusivu'] as $language => $title) {
+    foreach (['en' => 'Front page', 'sv' => 'Framsida', 'fi' => 'Etusivu'] as $language => $title) {
       $this->drupalGet('/' . $language);
       $parts = $this->getBreadcrumbParts();
       $this->assertEquals($title, $parts[0]['text']);

--- a/translations/override/fi.po
+++ b/translations/override/fi.po
@@ -45,6 +45,9 @@ msgstr ""
 "Kenttään asetaan sivuston perusosoitteen jälkeinen osa, "
 "esimerkiksi \"/kaupunkisymposium\"."
 
+msgid "Front page"
+msgstr "Etusivu"
+
 # Pathauto
 msgid "Automatic alias"
 msgstr "Osoitealias käytössä"

--- a/translations/override/sv.po
+++ b/translations/override/sv.po
@@ -26,3 +26,5 @@ msgctxt "PHP date format"
 msgid "l, F j, Y - H:i"
 msgstr "j.n.Y - H:i"
 
+msgid "Front page"
+msgstr "Framsida"


### PR DESCRIPTION
# [UHF-6960](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6960)

## What was done
* Replaced breadcrumb creation with Etusivu instance instead of hardcoded values.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6960_front_page_tasks`
* Run `make drush-updb drush-cr`

## How to test
* Check that the breadcrumb "Front page" link points to correct environment

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/447
* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/16
