### PR TITLE
Fix leijuke loading multiple times sometimes.

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -8,9 +8,17 @@
 
       for (const chat_selection in leijukeData) {
         const adapter = getAdapter(chat_selection);
+        if (!adapter) return;
 
         setTimeout(() => {
+          // Only load any leijuke once, in case of ajax triggers.
+          if (leijukeData[chat_selection].initialized) {
+            console.warn(`Already initialized ${chat_selection}!`);
+            return;
+          }
+
           new Leijuke(leijukeData[chat_selection], new EuCookieManager, adapter);
+          drupalSettings.leijuke_data[chat_selection].initialized = true;
         });
       }
     }
@@ -29,6 +37,7 @@
     if (chatSelection.indexOf('kuura') != -1) {
       return new KuuraAdapter;
     }
+    console.warn(`No adapter found for ${chatSelection}!`);
   }
 
   class EuCookieManager {


### PR DESCRIPTION
# Leijuke init check
Fix leijuke loading multiple times sometimes

## What was done
* Loading debounce

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X-leijuke-init-fix`
* Run `make drush-updb drush-cr`

## How to test
* Check the leijuke doesn't load multple instances if ajax triggered e.g. terveysasema search in https://www.hel.fi/fi/test-sosiaali-ja-terveyspalvelut/terveydenhoito/terveysasemat

## Other PRs
* 
