### PR TITLE
UHF-7195 News feed

### DIFF
--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -929,3 +929,13 @@ function helfi_content_update_9036() {
     ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
   }
 }
+
+/**
+ * Reinstall publication date format.
+ */
+function helfi_content_update_9037() {
+  ConfigHelper::installNewConfig(
+    dirname(__FILE__) . '/config/optional/',
+    'core.date_format.publication_date_format'
+  );
+}

--- a/helfi_features/helfi_news_feed/helfi_news_feed.module
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.module
@@ -63,7 +63,7 @@ function helfi_news_feed_paragraph_view(
       $query->condition($name, $value, 'IN');
     }
 
-    $query->sort('created', 'DESC');
+    $query->sort('published_at', 'DESC');
 
     $ids = $query->execute();
     $entities = $storage->loadMultiple(array_keys($ids));

--- a/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -132,7 +132,9 @@ final class News extends ExternalEntityStorageClientBase {
     $query = [
       sprintf('filter[taxonomy_term--news_%s][condition][operator]', $name) => 'IN',
     ];
-    $query[sprintf('filter[taxonomy_term--news_%s][condition][path]', $name)] = "field_news_$name.id";
+    $query[sprintf('filter[taxonomy_term--news_%s][condition][path]', $name)] = $name === 'tags'
+      ? "field_news_item_$name.id"
+      : "field_news_$name.id";
 
     // Filter by multiple terms using 'OR' condition.
     foreach ($terms as $key => $value) {
@@ -196,10 +198,10 @@ final class News extends ExternalEntityStorageClientBase {
     foreach ($sorts as $sort) {
       ['field' => $field, 'direction' => $direction] = $sort;
       $match = match ($field) {
-        'created' => function (string $direction) : array {
+        'published_at' => function (string $direction) : array {
           return [
-            'sort[created][path]' => 'created',
-            'sort[created][direction]' => $direction,
+            'sort[published_at][path]' => 'published_at',
+            'sort[published_at][direction]' => $direction,
           ];
         },
       };


### PR DESCRIPTION
#[UHF-7195](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7195)

## What was done
* Added update hook to reinstall the publication date format if it's missing.
* Switched news feed sorting to sort based on published_at value. 
* Fixed mismatched naming convention for news item tags field.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7195_news_feed`
* Run `make drush-updb drush-cr`

## How to test
* 

## Other PRs
* 
