### PR TITLE
UHF-7110: Add events list paragraph to TPR units and TPR services

### DIFF
--- a/helfi_features/helfi_tpr_config/config/install/field.field.tpr_service.tpr_service.field_lower_content.yml
+++ b/helfi_features/helfi_tpr_config/config/install/field.field.tpr_service.tpr_service.field_lower_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.liftup_with_image
@@ -38,6 +39,7 @@ settings:
       banner: banner
       liftup_with_image: liftup_with_image
       from_library: from_library
+      event_list: event_list
       phasing: phasing
       remote_video: remote_video
     negate: 0
@@ -57,6 +59,9 @@ settings:
       content_cards:
         enabled: true
         weight: -23
+      event_list:
+        weight: 44
+        enabled: true
       from_library:
         enabled: true
         weight: 21

--- a/helfi_features/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_lower_content.yml
+++ b/helfi_features/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_lower_content.yml
@@ -7,6 +7,7 @@ dependencies:
     - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.event_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.liftup_with_image
@@ -38,6 +39,7 @@ settings:
       liftup_with_image: liftup_with_image
       from_library: from_library
       remote_video: remote_video
+      event_list: event_list
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -55,6 +57,9 @@ settings:
       content_cards:
         enabled: true
         weight: -23
+      event_list:
+        weight: 44
+        enabled: true
       from_library:
         enabled: true
         weight: 21

--- a/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9028.yml
+++ b/helfi_features/helfi_tpr_config/config/update/helfi_tpr_config_update_9028.yml
@@ -1,0 +1,30 @@
+field.field.tpr_service.tpr_service.field_lower_content:
+  expected_config: {  }
+  update_actions:
+    add:
+      dependencies:
+        config:
+          - paragraphs.paragraphs_type.event_list
+      settings:
+        handler_settings:
+          target_bundles:
+            event_list: event_list
+          target_bundles_drag_drop:
+            event_list:
+              weight: 44
+              enabled: true
+field.field.tpr_unit.tpr_unit.field_lower_content:
+  expected_config: {  }
+  update_actions:
+    add:
+      dependencies:
+        config:
+          - paragraphs.paragraphs_type.event_list
+      settings:
+        handler_settings:
+          target_bundles:
+            event_list: event_list
+          target_bundles_drag_drop:
+            event_list:
+              weight: 44
+              enabled: true

--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -93,7 +93,7 @@ function helfi_tpr_config_update_dependencies() {
   ];
 
   // Run helfi_tpr_config_update_9027() after helfi_content_update_9031()
-  // has been run. helfi_content_update_9032() update will install 
+  // has been run. helfi_content_update_9032() update will install
   // phasing paragraph.
   $dependencies['helfi_tpr_config'][9027] = [
     'helfi_content' => 9032,
@@ -579,6 +579,22 @@ function helfi_tpr_config_update_9027() {
 
   // Execute configuration update definitions with logging of success.
   $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9027');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Adds event list paragraph to tpr unit and tpr service lower content areas.
+ */
+function helfi_tpr_config_update_9028() {
+
+  // Enable the 'Hide sidebar navigation from this page' to unit and service.
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_tpr_config', 'helfi_tpr_config_update_9028');
 
   // Output logged messages to related channel of update execution.
   return $updateHelper->logger()->output();


### PR DESCRIPTION
# [UHF-7110](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7110)

Make it possible to add the events list paragraph to TPR units and TPR service pages lower content area.

## What was done
* Created update hook that adds the events list paragraph to TPR units and TPR service lower content area.

## How to install
* To test this feature you can use any instance. I used SOTE so maybe use some other like KYMP. Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7110_events_paragraph_to_unit_and_service`
* Run `make drush-updb drush-cr`

## How to test
* Go to any TPR unit or TPR service and you should be able to add the event list paragraph to the lower content area. Since I don't know how to get the paragraph to display anything I can only tell you to add the title and description at this point.
