### PR TITLE
UHF-7350: News item translations

### DIFF
--- a/helfi_features/helfi_news_item/config/language/fi/field.field.node.news_item.field_news_groups.yml
+++ b/helfi_features/helfi_news_item/config/language/fi/field.field.node.news_item.field_news_groups.yml
@@ -1,0 +1,1 @@
+label: 'Kohderyhmät'

--- a/helfi_features/helfi_news_item/config/language/fi/field.field.node.news_item.field_news_neighbourhoods.yml
+++ b/helfi_features/helfi_news_item/config/language/fi/field.field.node.news_item.field_news_neighbourhoods.yml
@@ -1,0 +1,1 @@
+label: 'Kaupunginosat'

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -223,3 +223,20 @@ function helfi_news_item_update_9010() {
     ConfigHelper::installNewConfig($config_optional, 'core.date_format.publication_date_format');
   }
 }
+
+/**
+ * Add translations for the news item groups and neighbourhoods.
+ */
+function helfi_news_item_update_9011() {
+  $config_location = dirname(__FILE__) . '/config/language/';
+  $configurations = [
+    'field.field.node.news_item.field_news_groups',
+    'field.field.node.news_item.field_news_neighbourhoods',
+  ];
+
+  // Install new url pattern for News items and update News item promoted
+  // to front page field default value.
+  foreach ($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($config_location, $configuration);
+  }
+}


### PR DESCRIPTION
# [UHF-7350](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7350)

## What was done
* Added translations for the news item tags and update hook for updating them.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7350_news_item_translations`
* Run `make drush-updb drush-cr`

## How to test
* Log in and choose Finnish language for the user administration pages language
* Clear the caches from the drop (Flush all caches)
* Go to create news item and check that the news item tags are translated to Finnish, like so: 
![image](https://user-images.githubusercontent.com/1712902/200330970-9d8fc8fb-c577-41d5-bd78-cb8a157e2854.png)

