### PR TITLE
UHF-7417: Check cookie category before setting.

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -50,6 +50,8 @@
     }
 
     cookieSet() {
+      if (Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')) return;
+
       Drupal.eu_cookie_compliance.setAcceptedCategories([ ...Drupal.eu_cookie_compliance.getAcceptedCategories(), 'chat' ]);
     }
   }


### PR DESCRIPTION
# [UHF-7417](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7417)
<!-- What problem does this solve? -->
Chat category approval appearing twice in cookies if two chat buttons present.

## What was done
<!-- Describe what was done -->

* Checking the cookie category before setting.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git checkout dev`
    * `git pull`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7417-chat-cookie-category-duplicaiton`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works by observing the chat category is not set twice in cookie category cookie
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
