### PR TITLE
UHF-7008: Fixed broken Drupal core localization URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,9 @@
                 "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299). Re-rolled for hel.fi": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/83eb65d99327bf9c9c67ca4f7c1220ae3d8e2eae/patches/drupal-3163299-ajax-exposed-filters-views-block-on-same-page.patch",
                 "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch",
                 "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch",
-                "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch"
+                "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch",
+                "[#UHF-7008] Add multilingual support for caching basefield definitions (https://www.drupal.org/project/drupal/issues/3114824)": "https://www.drupal.org/files/issues/2020-02-20/3114824_2.patch",
+                "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
                 "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
                 "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299). Re-rolled for hel.fi": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/83eb65d99327bf9c9c67ca4f7c1220ae3d8e2eae/patches/drupal-3163299-ajax-exposed-filters-views-block-on-same-page.patch",
                 "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch",
-                "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch"
+                "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch",
+                "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"

--- a/helfi_features/helfi_base_config/helfi_base_config.install
+++ b/helfi_features/helfi_base_config/helfi_base_config.install
@@ -264,3 +264,13 @@ function helfi_base_config_update_9012() {
     \Drupal::messenger()->addMessage('Updated Site email address to point to drupal@hel.fi.');
   }
 }
+
+/**
+ * Fix Drupal core localization file download URLs.
+ */
+function helfi_base_config_update_9013() {
+  $keys = \Drupal::keyValue('locale.translation_status');
+  if ($keys->has('drupal')) {
+    $keys->delete('drupal');
+  }
+}

--- a/helfi_features/helfi_content/translations/fi.po
+++ b/helfi_features/helfi_content/translations/fi.po
@@ -465,6 +465,9 @@ msgstr "Oletus"
 msgid "Menu link title"
 msgstr "Valikon linkin otsikko"
 
+msgid "Meta information"
+msgstr "Metatiedot"
+
 msgid "Metatags"
 msgstr "Metatunnisteet"
 

--- a/helfi_features/helfi_tpr_config/translations/fi.po
+++ b/helfi_features/helfi_tpr_config/translations/fi.po
@@ -177,12 +177,6 @@ msgstr ""
 msgid "Lower content region"
 msgstr "Alempi sisältöalue"
 
-msgid "Meta information"
-msgstr "Metatiedot"
-
-msgid "Metatags"
-msgstr "Metatunnisteet"
-
 msgid "Next ›"
 msgstr "Seuraava ›"
 


### PR DESCRIPTION
# [UHF-7008](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7008)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed broken Drupal core localization URL
* Moved translations couple of translation from helfi_tpr_config module to helfi_content module
* Added patches to fix the base field definitions caching in multilingual fields and the rendering of admin toolbar and contextual links when browsing the admin pages in other language than English.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7008_localization -W`
* Run `make drush-updb drush-cr drush-locale-update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
* [ ] Check that the Drupal core translations get loaded without errors when running `drush locale:check; drush locale:update; drush cr`
* [ ] Log in as helfi-admin and change user language to Finnish
   * Clear caches from "Flush all caches" link and check that the translations are translated to Finnish. Note. There might be issues with the translations still - see more in here [UHF-7611](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7611)
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/93
