### PR TITLE
UHF-7615: Removed patch which hides untranslated menu links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
                 "[#UHF-4553] Fix unlock content button redirect": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/82081691e4a6d05b3716052d5fff46a04027bdc3/patches/content-lock-uhf-4553.patch"
             },
             "drupal/core": {
+                "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
                 "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
                 "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299). Re-rolled for hel.fi": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/83eb65d99327bf9c9c67ca4f7c1220ae3d8e2eae/patches/drupal-3163299-ajax-exposed-filters-views-block-on-same-page.patch",
                 "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/matomo_reports": "^1.1",
         "drupal/media_entity_file_replace": "^1.0",
         "drupal/media_entity_soundcloud": "^3.0.0",
-        "drupal/menu_block_current_language": "^1.5",
+        "drupal/menu_block_current_language": "^2.0",
         "drupal/menu_link_attributes": "^1.2",
         "drupal/metatag": "^1.16",
         "drupal/oembed_providers": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,6 @@
                 "[#UHF-4553] Fix unlock content button redirect": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/82081691e4a6d05b3716052d5fff46a04027bdc3/patches/content-lock-uhf-4553.patch"
             },
             "drupal/core": {
-                "[#UHF-181] Hide untranslated menu links": "https://www.drupal.org/files/issues/2021-03-05/3091246-allow-menu-tree-manipulators-alter-12-1.patch",
                 "[#UHF-920] Token for base URL (https://www.drupal.org/project/drupal/issues/1088112).": "https://www.drupal.org/files/issues/2020-10-06/1088112-63.patch",
                 "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299). Re-rolled for hel.fi": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/83eb65d99327bf9c9c67ca4f7c1220ae3d8e2eae/patches/drupal-3163299-ajax-exposed-filters-views-block-on-same-page.patch",
                 "[#UHF-3087] Non-published menu links as parent (https://www.drupal.org/project/drupal/issues/2807629)": "https://www.drupal.org/files/issues/2021-07-09/2807629-45.patch",

--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -1,6 +1,8 @@
 services:
   helfi_platform_config.menu_language_filter:
     class: Drupal\helfi_platform_config\Menu\FilterByLanguage
+    arguments:
+      - '@router.admin_context'
     tags:
       - { name: event_subscriber }
 

--- a/src/Menu/FilterByLanguage.php
+++ b/src/Menu/FilterByLanguage.php
@@ -20,7 +20,7 @@ final class FilterByLanguage implements EventSubscriberInterface {
    *
    * @var string[]
    */
-  protected $menuNames = [
+  protected array $menuNames = [
     'branding-navigation',
     'footer-bottom-navigation',
     'footer-top-navigation',
@@ -40,12 +40,16 @@ final class FilterByLanguage implements EventSubscriberInterface {
   }
 
   /**
-   * Responds to MenuLinkTreeEvents::ALTER_MANUPULATORS event.
+   * Responds to MenuLinkTreeEvents::ALTER_MANIPULATORS event.
    *
    * @param \Drupal\Core\Menu\MenuLinkTreeManipulatorsAlterEvent $event
    *   The event to subscribe to.
    */
   public function filter(MenuLinkTreeManipulatorsAlterEvent $event) : void {
+    // Drush defaults to site's default language. In our case, finnish.
+    // This causes '::filterLanguages' manipulator to set AccessResultForbidden
+    // to all non-finnish links when run via Drush.
+    // @see UHF-7615.
     if (!$this->adminContext->isAdminRoute()) {
       return;
     }

--- a/src/Menu/FilterByLanguage.php
+++ b/src/Menu/FilterByLanguage.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\helfi_platform_config\Menu;
 
 use Drupal\Core\Menu\MenuLinkTreeManipulatorsAlterEvent;
+use Drupal\Core\Routing\AdminContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -30,12 +31,24 @@ final class FilterByLanguage implements EventSubscriberInterface {
   ];
 
   /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Routing\AdminContext $adminContext
+   *   The admin context service.
+   */
+  public function __construct(private AdminContext $adminContext) {
+  }
+
+  /**
    * Responds to MenuLinkTreeEvents::ALTER_MANUPULATORS event.
    *
    * @param \Drupal\Core\Menu\MenuLinkTreeManipulatorsAlterEvent $event
    *   The event to subscribe to.
    */
   public function filter(MenuLinkTreeManipulatorsAlterEvent $event) : void {
+    if (!$this->adminContext->isAdminRoute()) {
+      return;
+    }
     $manipulators = &$event->getManipulators();
 
     $menuName = NULL;


### PR DESCRIPTION
# [UHF-7615](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7615)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed patch which hides untranslated menu links as all of our menu blocks use either custom menu tree manipulators or menu_block_current_language blocks.

