### PR TITLE
UHF-7419: Accessibility changes to chat button

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -463,7 +463,6 @@
       leijukeTitle.classList.add('visually-hidden');
       leijukeTitle.innerHTML = Drupal.t('Chat', {}, { context: 'Floating chat title' });
       leijukeWrapper.append(leijukeTitle);
-      
 
       let leijukeInstance = document.createElement('button');
       leijukeInstance.id = this.static.selector;

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -454,12 +454,18 @@
     initWrapper() {
       let leijukeWrapper = document.getElementById('chat-leijuke-wrapper');
       if (!leijukeWrapper) {
-        leijukeWrapper = document.createElement('div');
+        leijukeWrapper = document.createElement('aside');
         leijukeWrapper.id = 'chat-leijuke-wrapper';
         document.body.append(leijukeWrapper)
       }
 
-      let leijukeInstance = document.createElement('div');
+      let leijukeTitle = document.createElement('h2');
+      leijukeTitle.classList.add('visually-hidden');
+      leijukeTitle.innerHTML = Drupal.t('Chat', {}, { context: 'Floating chat title' });
+      leijukeWrapper.append(leijukeTitle);
+      
+
+      let leijukeInstance = document.createElement('button');
       leijukeInstance.id = this.static.selector;
       leijukeInstance.classList.add('chat-leijuke')
       leijukeWrapper.append(leijukeInstance);

--- a/translations/new/fi.po
+++ b/translations/new/fi.po
@@ -473,3 +473,7 @@ msgstr "Osapäiväryhmä"
 
 msgid "Start a chat"
 msgstr "Aloita chat"
+
+msgctxt "Floating chat title"
+msgid "Chat"
+msgstr "Chat"

--- a/translations/new/sv.po
+++ b/translations/new/sv.po
@@ -26,3 +26,7 @@ msgstr "Halvdagsgrupp"
 
 msgid "Start a chat"
 msgstr "Starta chatten"
+
+msgctxt "Floating chat title"
+msgid "Chat"
+msgstr "Chatt"


### PR DESCRIPTION
# [UHF-7419](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7419)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed chat wrapper to `<aside>`
* Changed `<div>` to `<button>`
* Added visually hidden title for chat

Test in some instance that has chats i.e. Etusivu

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7419-chat-accessibility-changes`
* Update translations in shell `drush locale:check && drush locale:update`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

If your local instance doesn't have a frontpage set, set a page as frontpage and the chat will appear there

* [x] Go to the instances frontpage and inspect the chat in the bottom right
  * [x] The chat should now be wrapped in `<aside>`
  * [x] The actual trigger to opening the chat should be now `<button>`
  * [x] There should be a visually hidden title for the chat "Chat" (fi: Chat, sv: Chatt)
* [x] Check that code follows our standards