### PR TITLE
UHF-7611 Drush cr workaround

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
                 "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch",
                 "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch",
                 "[#UHF-7008] Add multilingual support for caching basefield definitions (https://www.drupal.org/project/drupal/issues/3114824)": "https://www.drupal.org/files/issues/2020-02-20/3114824_2.patch",
-                "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch"
+                "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch",
+                "[#UHF-7611] Workaround for the field definitions caching with wrong language. (https://www.drupal.org/project/drupal/issues/3221375#comment-14299886)": "https://www.drupal.org/files/issues/2021-12-01/3221375-27-workaround.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
                 "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch",
                 "[#UHF-7008] Add multilingual support for caching basefield definitions (https://www.drupal.org/project/drupal/issues/3114824)": "https://www.drupal.org/files/issues/2020-02-20/3114824_2.patch",
                 "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch",
-                "[#UHF-7611] Workaround for the field definitions caching with wrong language. (https://www.drupal.org/project/drupal/issues/3221375#comment-14299886)": "https://www.drupal.org/files/issues/2021-12-01/3221375-27-workaround.patch"
+                "[#UHF-7611] Workaround for the field definitions caching with wrong language. (https://www.drupal.org/project/drupal/issues/3221375#comment-14911480)": "https://www.drupal.org/files/issues/2023-02-07/3221375-35.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"


### PR DESCRIPTION
# [UHF-7611](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7611)
<!-- What problem does this solve? -->
When the entity field definitions are accessed and cached after running `drush cr`, they are loaded in the default LanguageConfigFactoryOverride language (en), but cached in the current negotiated language cid (fi or sv).

## What was done
<!-- Describe what was done -->

* Attached patch to supply PHP_SAPI === 'cli' in drupal_flush_all_caches() to trigger (if needed) the container rebuild when running cache rebuild with drush.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7611_drush_cr_workaround`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
