### PR TITLE
UHF-7741: prevent wsod by checking that the field exists

### DIFF
--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -117,7 +117,11 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
 
       // Get announcement's referenced entities from the appropriate field,
       // depending on the current page's entity.
-      $referencedEntities = $announcementNode->get($entityTypeFields[$currentEntity->getEntityType()->id()])->referencedEntities();
+      $referencedEntities = [];
+      if ($announcementNode->hasField($entityTypeFields[$currentEntity->getEntityType()->id()])) {
+        $referencedEntities = $announcementNode->get($entityTypeFields[$currentEntity->getEntityType()->id()])->referencedEntities();
+      }
+
 
       // Add announcement to showed announcements if current page's entity
       // is found from the list of referenced entities.
@@ -262,13 +266,18 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
     }
 
     if (
-      !$announcement->get('field_announcement_unit_pages')->isEmpty() ||
-      !$announcement->get('field_announcement_service_pages')->isEmpty()
+      ($announcement->hasField('field_announcement_unit_pages') &&
+      !$announcement->get('field_announcement_unit_pages')->isEmpty()) ||
+      ($announcement->hasField('field_announcement_service_pages') &&
+      !$announcement->get('field_announcement_service_pages')->isEmpty())
     ) {
       return self::VISIBILITY_REGION_WEIGHT;
     }
 
-    if (!$announcement->get('field_announcement_content_pages')->isEmpty()) {
+    if (
+      ($announcement->hasField('field_announcement_content_pages') &&
+      !$announcement->get('field_announcement_content_pages')->isEmpty())
+    ) {
       return self::VISIBILITY_PAGE_WEIGHT;
     }
 

--- a/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
+++ b/helfi_features/helfi_announcements/src/Plugin/Block/AnnouncementsBlock.php
@@ -122,7 +122,6 @@ class AnnouncementsBlock extends BlockBase implements ContainerFactoryPluginInte
         $referencedEntities = $announcementNode->get($entityTypeFields[$currentEntity->getEntityType()->id()])->referencedEntities();
       }
 
-
       // Add announcement to showed announcements if current page's entity
       // is found from the list of referenced entities.
       foreach ($referencedEntities as $referencedEntity) {


### PR DESCRIPTION
# [UHF-7741](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7741)
Announcement module tried to get value out of non-existing field.

## What was done
Added checks to prevent getting values out of non-existing field.

## How to install
* Test with ETUSIVU -instance
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7741_announcement_wsod_bug`
* Run `make drush-updb drush-cr`

## How to test
- Ota etusivun instanssista viimeisin versio ja mene muokkaamaan Poikkeusilmoitus sisältötyypin “Show on content pages” kenttää https://helfi-etusivu.docker.so/fi/admin/structure/types/manage/announcement/fields/node.announcement.field_announcement_content_pages ja laita News item sallituksi sisältötyypiksi. Tallenna.

- Mene luomaan kaksi poikkeusilmoitusta: Minä tein Varoituksen ja Ilmoituksen joista Varoituksen laitoin aktiiviseksi kaikille sivuille ja Ilmoituksen laitoin aktiiviseksi yhdelle uutiselle.

- Mene nyt uutissivulle jossa pitäis näkyä kaksi ilmoitusta

* [x] Check that this feature works
* [x] Check that code follows our standards
