### PR TITLE
UHF-7249: Adds update hook to add title field for popular services pa…

### DIFF
--- a/helfi_features/helfi_content/config/install/core.entity_form_display.paragraph.popular_services.default.yml
+++ b/helfi_features/helfi_content/config/install/core.entity_form_display.paragraph.popular_services.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.popular_services.field_service_items
     - paragraphs.paragraphs_type.popular_services
+    - field.field.paragraph.popular_services.field_popular_services_title
   module:
     - paragraphs
 _core:
@@ -13,9 +14,17 @@ targetEntityType: paragraph
 bundle: popular_services
 mode: default
 content:
+  field_popular_services_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_service_items:
     type: paragraphs
-    weight: 0
+    weight: 1
     region: content
     settings:
       title: Paragraph

--- a/helfi_features/helfi_content/config/install/core.entity_view_display.paragraph.popular_services.default.yml
+++ b/helfi_features/helfi_content/config/install/core.entity_view_display.paragraph.popular_services.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.paragraph.popular_services.field_service_items
     - paragraphs.paragraphs_type.popular_services
+    - field.field.paragraph.popular_services.field_popular_services_title
   module:
     - entity_reference_revisions
 _core:
@@ -13,6 +14,14 @@ targetEntityType: paragraph
 bundle: popular_services
 mode: default
 content:
+  field_popular_services_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_service_items:
     type: entity_reference_revisions_entity_view
     label: hidden
@@ -20,7 +29,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   search_api_excerpt: true

--- a/helfi_features/helfi_content/config/install/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/install/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -12,9 +12,7 @@ label: Title
 description: 'If this field is left empty, the title will be "Popular services"'
 required: false
 translatable: false
-default_value:
-  -
-    value: 'Popular services'
+default_value: {  }
 default_value_callback: ''
 settings: {  }
 field_type: string

--- a/helfi_features/helfi_content/config/install/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/install/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_popular_services_title
+    - paragraphs.paragraphs_type.popular_services
+id: paragraph.popular_services.field_popular_services_title
+field_name: field_popular_services_title
+entity_type: paragraph
+bundle: popular_services
+label: Title
+description: 'If this field is left empty, the title will be "Popular services"'
+required: false
+translatable: false
+default_value:
+  -
+    value: 'Popular services'
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/helfi_features/helfi_content/config/install/field.storage.paragraph.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/install/field.storage.paragraph.field_popular_services_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_popular_services_title
+field_name: field_popular_services_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/helfi_features/helfi_content/config/language/fi/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/language/fi/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -1,0 +1,4 @@
+default_value:
+  -
+    value: 'Suosittuja palveluja'
+description: 'Jos kenttä jätetään tyhjäksi, otsikoksi tulee "Suosittuja palveluja"'

--- a/helfi_features/helfi_content/config/language/fi/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/language/fi/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -1,4 +1,1 @@
-default_value:
-  -
-    value: 'Suosittuja palveluja'
 description: 'Jos kenttä jätetään tyhjäksi, otsikoksi tulee "Suosittuja palveluja"'

--- a/helfi_features/helfi_content/config/language/sv/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/language/sv/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -1,0 +1,4 @@
+default_value:
+  -
+    value: 'Populära tjänster'
+description: 'Om detta lämnas tomt, titel är "Populära tjänster"'

--- a/helfi_features/helfi_content/config/language/sv/field.field.paragraph.popular_services.field_popular_services_title.yml
+++ b/helfi_features/helfi_content/config/language/sv/field.field.paragraph.popular_services.field_popular_services_title.yml
@@ -1,4 +1,1 @@
-default_value:
-  -
-    value: 'Populära tjänster'
 description: 'Om detta lämnas tomt, titel är "Populära tjänster"'

--- a/helfi_features/helfi_content/config/update/helfi_content_update_9039.yml
+++ b/helfi_features/helfi_content/config/update/helfi_content_update_9039.yml
@@ -1,0 +1,40 @@
+core.entity_form_display.paragraph.popular_services.default:
+  expected_config:
+    content:
+      field_service_items:
+        weight: 0
+  update_actions:
+    add:
+      content:
+        field_popular_services_title:
+          type: string_textfield
+          weight: 0
+          region: content
+          settings:
+            size: 60
+            placeholder: ''
+          third_party_settings: {  }
+    change:
+      content:
+        field_service_items:
+          weight: 1
+core.entity_view_display.paragraph.popular_services.default:
+  expected_config:
+    content:
+      field_service_items:
+        weight: 0
+  update_actions:
+    add:
+      content:
+        field_popular_services_title:
+          type: string
+          label: hidden
+          settings:
+            link_to_entity: false
+          third_party_settings: {  }
+          weight: 0
+          region: content
+    change:
+      content:
+        field_service_items:
+          weight: 1

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -974,3 +974,32 @@ function helfi_content_update_9038() {
     ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
   }
 }
+
+/**
+ * Update the popular service paragraph with new field.
+ */
+function helfi_content_update_9039() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Add the new fields for popular services paragraph.
+  $configLocation = dirname(__FILE__) . '/config/install/';
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  // Key field storage and value is field configuration.
+  $configFields = [
+    'field.storage.paragraph.field_popular_services_title' => 'field.field.paragraph.popular_services.field_popular_services_title',
+  ];
+
+  // Install title field and its translations.
+  foreach ($configFields as $field_storage => $field_config) {
+    ConfigHelper::installNewField($configLocation, $field_storage, $field_config);
+    ConfigHelper::installNewConfigTranslation($configTranslationLocation, $field_config);
+  }
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_content', 'helfi_content_update_9039');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}


### PR DESCRIPTION
# [UHF-7249](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7249)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Adds a new field "title" for popular services paragraph and its translations

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7249-popular-services-editable-title`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See instructions in hdbt pr
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/504
