### PR TITLE
Uhf 7766 sote chatapp

### DIFF
--- a/assets/js/user_consent_functions.js
+++ b/assets/js/user_consent_functions.js
@@ -1,0 +1,12 @@
+(function (Drupal) {
+  'use strict';
+
+  window.chat_user_consent = {
+    retrieveUserConsent: () => (!Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')),
+    confirmUserConsent: () => {
+      if (Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')) return;
+      Drupal.eu_cookie_compliance.setAcceptedCategories([ ...Drupal.eu_cookie_compliance.getAcceptedCategories(), 'chat' ]);
+    }
+  };
+
+})(Drupal);

--- a/assets/js/user_consent_functions.js
+++ b/assets/js/user_consent_functions.js
@@ -2,7 +2,7 @@
   'use strict';
 
   window.chat_user_consent = {
-    retrieveUserConsent: () => (!Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')),
+    retrieveUserConsent: () => (Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')),
     confirmUserConsent: () => {
       if (Drupal.eu_cookie_compliance.hasAgreedWithCategory('chat')) return;
       Drupal.eu_cookie_compliance.setAcceptedCategories([ ...Drupal.eu_cookie_compliance.getAcceptedCategories(), 'chat' ]);

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -122,6 +122,23 @@ watson_chatbot:
       minified: true
     }
 
+watson_sote:
+  version: 1.0.x
+  header: false
+  js:
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/widget.min.js': {
+      type: external,
+      minified: true
+    }
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/static/sote/custom.widget.min.js?tenantId=www-hel-fi-prod&assistantId=sote': {
+      type: external,
+      minified: true
+    }
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/default.min.js': {
+      type: external,
+      minified: true
+    }
+
 genesys_neuvonta:
   version: 1.0.x
   header: true

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -130,7 +130,7 @@ watson_sote:
       type: external,
       minified: true
     }
-    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/static/sote/custom.widget.min.js?tenantId=www-hel-fi-prod&assistantId=sote': {
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/static/sote-bot/custom.widget.min.js?tenantId=sote-prod&assistantId=sote-bot': {
       type: external,
       minified: true
     }

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -171,3 +171,11 @@ chat_leijuke:
   dependencies:
     - core/drupal
     - core/drupalSettings
+
+user_consent_functions:
+  version: 1.0.x
+  header: true
+  js:
+    assets/js/user_consent_functions.js: {}
+  dependencies:
+    - core/drupal

--- a/src/Plugin/Block/ChatLeijuke.php
+++ b/src/Plugin/Block/ChatLeijuke.php
@@ -36,6 +36,7 @@ class ChatLeijuke extends BlockBase {
         'genesys_neuvonta' => 'Genesys Neuvonta',
         'watson_chatbot' => 'Watson Chatbot',
         'kuura_health_chat' => 'Kuura Health Chat (dontuse)',
+        'watson_sote' => 'Hester/Sotebotti',
       ],
     ];
 

--- a/src/Plugin/Block/ChatLeijuke.php
+++ b/src/Plugin/Block/ChatLeijuke.php
@@ -34,9 +34,9 @@ class ChatLeijuke extends BlockBase {
         'genesys_kymp' => 'Genesys KYMP',
         'genesys_suunte' => 'Genesys SUUNTE',
         'genesys_neuvonta' => 'Genesys Neuvonta',
-        'watson_chatbot' => 'Watson Chatbot',
-        'kuura_health_chat' => 'Kuura Health Chat (dontuse)',
-        'watson_sote' => 'Hester/Sotebotti',
+        'watson_chatbot' => 'Asunnonhakubotti (watson)',
+        'kuura_health_chat' => 'Kuura Health Chat',
+        'watson_sote' => 'Hester/Sotebotti (watson)',
       ],
     ];
 

--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -56,6 +56,16 @@ class IbmChatApp extends BlockBase {
   /**
    * {@inheritdoc}
    */
+  public function blockSubmit($form, FormStateInterface $formState) {
+    $this->configuration['hostname'] = $formState->getValue('hostname');
+    $this->configuration['engagementId'] = $formState->getValue('engagementId');
+    $this->configuration['tenantId'] = $formState->getValue('tenantId');
+    $this->configuration['assistantId'] = $formState->getValue('assistantId');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build() {
     $build = [];
 
@@ -66,36 +76,45 @@ class IbmChatApp extends BlockBase {
     $tenantId = $config['tenantId'];
     $assistantId = $config['assistantId'];
 
-    $optionsSrc = `<script type="text/javascript" src="$hostname/get-widget-options?tenantId=$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
-    $widgetSrc = `<script type="text/javascript" src="$hostname/get-widget?tenantId=$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
-    $defaultSrc = `<script type="text/javascript" src="$hostname/get-widget-default?tenantId=<$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
-
+    $optionsSrc = sprintf('%s/get-widget-options?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
+    $widgetSrc = sprintf('%s/get-widget?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
+    $defaultSrc = sprintf('%s/get-widget-default?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
 
     $build['ibm_chat_app'] = [
       '#title' => $this->t('IBM Chat App'),
       '#attached' => [
+        'drupalSettings' => [
+          'chatapp' => $widgetSrc,
+        ],
         'html_head' => [
           [
-            '#tag' => 'script',
-            '#attributes' => [
-              'type' => 'text/javascript',
-              'src' => $optionsSrc,
+            [
+              '#tag' => 'script',
+              '#attributes' => [
+                'type' => 'text/javascript',
+                'src' => $optionsSrc,
+              ],
             ],
-          ],  'chat_app_options',
+            'chat_app_options',
+          ],
           [
-            '#tag' => 'script',
-            '#attributes' => [
-              'type' => 'text/javascript',
-              'src' => $widgetSrc,
-            ],
-          ],  'chat_app_widget',
+            [
+              '#tag' => 'script',
+              '#attributes' => [
+                'type' => 'text/javascript',
+                'src' => $widgetSrc,
+              ],
+            ],  'chat_app_widget',
+          ],
           [
-            '#tag' => 'script',
-            '#attributes' => [
-              'type' => 'text/javascript',
-              'src' => $defaultSrc,
-            ],
-          ],  'chat_app_default',
+            [
+              '#tag' => 'script',
+              '#attributes' => [
+                'type' => 'text/javascript',
+                'src' => $defaultSrc,
+              ],
+            ],  'chat_app_default',
+          ],
         ],
       ],
     ];

--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\helfi_platform_config\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a Watson chatbot block.
+ *
+ * @Block(
+ *  id = "ibm_chat_app",
+ *  admin_label = @Translation("IBM Chat App"),
+ * )
+ */
+class IbmChatApp extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    // hostname: Hostname of chat application.
+    $form['hostname'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chat Hostname'),
+      '#default_value' => $config['hostname'] ?? '',
+    ];
+
+    // engagementId: will define how our chat application looks and behaves, and the versionto be used
+    $form['engagementId'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chat Engagement Id'),
+      '#default_value' => $config['engagementId'] ?? '',
+    ];
+
+    // tenantId: defines the environment to be used by the chat and chatbotservices
+    $form['tenantId'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chat Tenant Id'),
+      '#default_value' => $config['tenantId'] ?? '',
+    ];
+
+    // assistantId: identifies the bot instance to be used
+    $form['assistantId'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Chat Assistant Id'),
+      '#default_value' => $config['assistantId'] ?? '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    $config = $this->getConfiguration();
+
+    $hostname = $config['hostname'];
+    $engagementId = $config['engagementId'];
+    $tenantId = $config['tenantId'];
+    $assistantId = $config['assistantId'];
+
+    $optionsSrc = `<script type="text/javascript" src="$hostname/get-widget-options?tenantId=$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
+    $widgetSrc = `<script type="text/javascript" src="$hostname/get-widget?tenantId=$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
+    $defaultSrc = `<script type="text/javascript" src="$hostname/get-widget-default?tenantId=<$tenantId&assistantId=$assistantId&engagementId=$engagementId"></script>`;
+
+
+    $build['ibm_chat_app'] = [
+      '#title' => $this->t('IBM Chat App'),
+      '#attached' => [
+        'html_head' => [
+          [
+            '#tag' => 'script',
+            '#attributes' => [
+              'type' => 'text/javascript',
+              'src' => $optionsSrc,
+            ],
+          ],  'chat_app_options',
+          [
+            '#tag' => 'script',
+            '#attributes' => [
+              'type' => 'text/javascript',
+              'src' => $widgetSrc,
+            ],
+          ],  'chat_app_widget',
+          [
+            '#tag' => 'script',
+            '#attributes' => [
+              'type' => 'text/javascript',
+              'src' => $defaultSrc,
+            ],
+          ],  'chat_app_default',
+        ],
+      ],
+    ];
+
+    return $build;
+  }
+
+}

--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -29,21 +29,21 @@ class IbmChatApp extends BlockBase {
       '#default_value' => $config['hostname'] ?? '',
     ];
 
-    // engagementId: will define how our chat application looks and behaves, and the versionto be used
+    // engagementId: will define how our chat application looks and behaves.
     $form['engagementId'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Chat Engagement Id'),
       '#default_value' => $config['engagementId'] ?? '',
     ];
 
-    // tenantId: defines the environment to be used by the chat and chatbotservices
+    // tenantId: defines the environment to be used.
     $form['tenantId'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Chat Tenant Id'),
       '#default_value' => $config['tenantId'] ?? '',
     ];
 
-    // assistantId: identifies the bot instance to be used
+    // assistantId: identifies the bot instance to be used.
     $form['assistantId'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Chat Assistant Id'),
@@ -95,8 +95,7 @@ class IbmChatApp extends BlockBase {
                 'type' => 'text/javascript',
                 'src' => $optionsSrc,
               ],
-            ],
-            'chat_app_options',
+            ], 'chat_app_options',
           ],
           [
             [
@@ -105,7 +104,7 @@ class IbmChatApp extends BlockBase {
                 'type' => 'text/javascript',
                 'src' => $widgetSrc,
               ],
-            ],  'chat_app_widget',
+            ], 'chat_app_widget',
           ],
           [
             [
@@ -114,7 +113,7 @@ class IbmChatApp extends BlockBase {
                 'type' => 'text/javascript',
                 'src' => $defaultSrc,
               ],
-            ],  'chat_app_default',
+            ], 'chat_app_default',
           ],
         ],
       ],

--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -67,6 +67,9 @@ class IbmChatApp extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
+
+    $library = ['helfi_platform_config/user_consent_functions'];
+
     $build = [];
 
     $config = $this->getConfiguration();
@@ -83,9 +86,7 @@ class IbmChatApp extends BlockBase {
     $build['ibm_chat_app'] = [
       '#title' => $this->t('IBM Chat App'),
       '#attached' => [
-        'drupalSettings' => [
-          'chatapp' => $widgetSrc,
-        ],
+        'library' => $library,
         'html_head' => [
           [
             [


### PR DESCRIPTION
# [UHF-7766](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7766)
<!-- What problem does this solve? -->
Allow Hester/Sotebot to be used with leijuke just like the watson on housing.
Allow new Virtual Assistants to be used without leijuke after they implement the user consent before loading chat code that might store cookies etc.
Provides user consent functions in window.
## What was done
<!-- Describe what was done -->
* Added Sotebot library definition and sotebot chat selection to leijuke. (This needs to be updated once they launch the sotebot.) 
* Added new configurable IBM Chat App block that injects the appropriate script tags.
* Added user consent functions for chat app to use.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git checkout dev`
    * `git pull`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7766-sote-chatapp`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that this feature works by adding the appropriate blocks with the appropriate configuration.
* [x] Check that the user consent functions are available in the window object and they update the cookie consent.
* [x] Check that code follows our standards.

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
