### PR TITLE
UHF-X Add missing translation for cookie banner text

### DIFF
--- a/helfi_features/helfi_gdpr_compliance/translations/fi.po
+++ b/helfi_features/helfi_gdpr_compliance/translations/fi.po
@@ -1247,3 +1247,8 @@ msgstr "Näytä evästeet"
 msgid "Statistics cookies"
 msgstr "Tilastointi"
 
+msgid "<p>Your current cookie settings are below. Submit the form to make changes.</p>"
+msgstr "<p>Nykyiset evästeasetuksesi näkyvät alla. Tallenna lomake, jos teet muutoksia asetuksiin.</p>"
+
+msgid "<p><strong>You have not saved any cookie preferences.</strong> By default only essential cookies are saved. See details below.</p>"
+msgstr "<p><strong>Et ole tallentanut evästeasetuksia.</strong> Oletusarvoisesti vain välttämättömät evästeet tallennetaan.</p>"

--- a/helfi_features/helfi_gdpr_compliance/translations/fi.po
+++ b/helfi_features/helfi_gdpr_compliance/translations/fi.po
@@ -1211,6 +1211,9 @@ msgstr "Hyväksy kaikki evästeet"
 msgid "Accept selected cookies"
 msgstr "Hyväksy valitut evästeet"
 
+msgid "Accept only essential cookies"
+msgstr "Hyväksy vain välttämättömät evästeet"
+
 msgid "Cookie settings"
 msgstr "Evästeasetukset"
 

--- a/helfi_features/helfi_gdpr_compliance/translations/sv.po
+++ b/helfi_features/helfi_gdpr_compliance/translations/sv.po
@@ -1265,3 +1265,8 @@ msgstr "Statistik"
 msgid "Withdraw consent"
 msgstr "Återkalla samtycke"
 
+msgid "<p>Your current cookie settings are below. Submit the form to make changes.</p>"
+msgstr "<p>Dina nuvarande cookie -inställningar finns nedan. Skicka in formuläret för att göra ändringar.</p>"
+
+msgid "<p><strong>You have not saved any cookie preferences.</strong> By default only essential cookies are saved. See details below.</p>"
+msgstr "<p><strong>Du har inte sparat några cookieinställningar.</strong> Som standard sparas endast viktiga cookies. Se detaljer nedan.</p>"

--- a/helfi_features/helfi_gdpr_compliance/translations/sv.po
+++ b/helfi_features/helfi_gdpr_compliance/translations/sv.po
@@ -1226,6 +1226,9 @@ msgstr "Acceptera alla cookies"
 msgid "Accept selected cookies"
 msgstr "Acceptera valda cookies"
 
+msgid "Accept only essential cookies"
+msgstr "Acceptera endast nödvändiga cookies"
+
 msgid "Cookie settings"
 msgstr "Cookie -inställningar"
 


### PR DESCRIPTION
# Missing translations for cookie banner
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added missing translations for cookie banner.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git checkout origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_add_missing_translation_for_cookie_banner`
* Run `make shell`
* Run `drush locale:check; drush locale:update; drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the cookie banner text string is translated. This issue was present in local version of form-tool so might be that this is not an visible issue on other instances.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
