### PR TITLE
UHF-7721: Apply patch for the publication date module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,9 @@
             },
             "drupal/field_group": {
                 "[#UHF-3268] Support for field group translations": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/736077493b73d83b63081820790dc68e226a6460/patches/field_group_fix-translations_label_description-3111107-31-rerolled.patch"
+            },
+            "drupal/publication_date": {
+                "[#UHF-7721] Fixed node preview when publication date is not set. (https://www.drupal.org/project/publication_date/issues/3074373)": "https://www.drupal.org/files/issues/2022-12-20/publication_date_is_required_for_completing_the_form-3074373-11.patch"
             }
         }
     }


### PR DESCRIPTION
# [UHF-7721](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7721)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Apply patch for the publication date module to fix node preview when publication date is not set.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7721_publication_date_preview`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

