### PR TITLE
UHF-7723: Enables translations for news item main image and adds old …

### DIFF
--- a/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_main_image.yml
+++ b/helfi_features/helfi_news_item/config/install/field.field.node.news_item.field_main_image.yml
@@ -12,7 +12,7 @@ bundle: news_item
 label: 'Main image'
 description: 'Main image is also used as liftup image in listings and social media shares.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9012.yml
+++ b/helfi_features/helfi_news_item/config/update/helfi_news_item_update_9012.yml
@@ -1,0 +1,6 @@
+field.field.node.news_item.field_main_image:
+  expected_config:
+    translatable: false
+  update_actions:
+    change:
+      translatable: true

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -261,9 +261,9 @@ function helfi_news_item_update_9012() {
  */
 function helfi_news_item_update_9013() {
   $nids = \Drupal::entityQuery('node')->condition('type','news_item')->execute();
-  $nodes =  \Drupal\node\Entity\Node::loadMultiple($nids);
+  $nodes = \Drupal\node\Entity\Node::loadMultiple($nids);
 
-  foreach ( $nodes as $node) {
+  foreach ($nodes as $node) {
     if ($node->hasField('field_main_image') && !$node->get('field_main_image')->isEmpty()) {
       $image = $node->get('field_main_image');
 

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -240,3 +240,50 @@ function helfi_news_item_update_9011() {
     ConfigHelper::installNewConfigTranslation($config_location, $configuration);
   }
 }
+
+
+/**
+ * Enables translations for news item main image
+ */
+function helfi_news_item_update_9012() {
+  /** @var \Drupal\update_helper\Updater $updateHelper */
+  $updateHelper = \Drupal::service('update_helper.updater');
+
+  // Execute configuration update definitions with logging of success.
+  $updateHelper->executeUpdate('helfi_news_item', 'helfi_news_item_update_9012');
+
+  // Output logged messages to related channel of update execution.
+  return $updateHelper->logger()->output();
+}
+
+/**
+ * Adds old image to all language versions of news item main image
+ */
+function helfi_news_item_update_9013() {
+  $nids = \Drupal::entityQuery('node')->condition('type','news_item')->execute();
+  $nodes =  \Drupal\node\Entity\Node::loadMultiple($nids);
+
+  foreach ( $nodes as $node) {
+    if ($node->hasField('field_main_image') && !$node->get('field_main_image')->isEmpty()) {
+      $image = $node->get('field_main_image');
+
+      if ($node->hasTranslation('sv')) {
+        $swedish = $node->getTranslation('sv');
+        $swedish->field_main_image = $image;
+        $swedish->save();
+      }
+
+      if ($node->hasTranslation('en')) {
+        $english = $node->getTranslation('en');
+        $english->field_main_image = $image;
+        $english->save();
+      }
+
+      if ($node->hasTranslation('fi')) {
+        $finnish = $node->getTranslation('fi');
+        $finnish->field_main_image = $image;
+        $finnish->save();
+      }
+    }
+  }
+}

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -5,6 +5,7 @@
  */
 
 use Drupal\helfi_platform_config\ConfigHelper;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_install().
@@ -259,11 +260,26 @@ function helfi_news_item_update_9012() {
 /**
  * Adds old image to all language versions of news item main image
  */
-function helfi_news_item_update_9013() {
-  $nids = \Drupal::entityQuery('node')->condition('type','news_item')->execute();
-  $nodes = \Drupal\node\Entity\Node::loadMultiple($nids);
-
-  foreach ($nodes as $node) {
+function helfi_news_item_update_9013(&$sandbox) {
+  // Initialize some variables during the first pass through.
+  if (!isset($sandbox['total'])) {
+    $nids = \Drupal::entityQuery('node')
+      ->condition('type', 'news_item')
+      ->execute();
+    $sandbox['total'] = count($nids);
+    $sandbox['current'] = 0;
+  }
+  
+  $nodes_per_batch = 25;
+  
+  // Handle one pass through.
+  $nids = \Drupal::entityQuery('node')
+    ->condition('type', 'news_item')
+    ->range($sandbox['current'], $sandbox['current'] + $nodes_per_batch)
+    ->execute();
+  
+  foreach($nids as $nid) {
+    $node = Node::load($nid);
     if ($node->hasField('field_main_image') && !$node->get('field_main_image')->isEmpty()) {
       $image = $node->get('field_main_image');
 
@@ -285,5 +301,11 @@ function helfi_news_item_update_9013() {
         $finnish->save();
       }
     }
+  }
+  
+  if ($sandbox['total'] == 0) {
+    $sandbox['#finished'] = 1;
+  } else {
+    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
   }
 }

--- a/helfi_features/helfi_news_item/helfi_news_item.install
+++ b/helfi_features/helfi_news_item/helfi_news_item.install
@@ -301,6 +301,8 @@ function helfi_news_item_update_9013(&$sandbox) {
         $finnish->save();
       }
     }
+
+    $sandbox['current']++;
   }
   
   if ($sandbox['total'] == 0) {


### PR DESCRIPTION
…images to all language versions

# [UHF-7723](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7723)
<!-- What problem does this solve? -->

* News item main image was not translatable

## What was done
<!-- Describe what was done -->

 * News item main image is now translatable 

## How to install (test in Etusivu)
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
## Before updating platform config 
* Create a new news item and publish it 
    * Add an image for the news item
    * Translate the news item to the two other available languages 
    * All three languages of the news items should have the same image since it cannot be translated yet
## Update the Helfi Platform config
* `composer require drupal/helfi_platform_config:dev-UHF-7723-make-news-image-translatable`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Clear caches from the drop in drupal admin (also browser caches if needed)
* [x] Check the news items, which were created, that they still all have the same image (the translations should have the same image as the original one)
   * [x] Images should now be translatable, try changing the image for some of the translations
* [ ] Check that code follows our standards
