### PR TITLE
UHF-7739 news feed fix

### DIFF
--- a/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news.yml
+++ b/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news.yml
@@ -31,5 +31,5 @@ field_mapper_config:
     short_title:
       value: '$.attributes[''short_title'']'
 storage_client_id: helfi_news
-persistent_cache_max_age: 86400
+persistent_cache_max_age: 10800
 inherits_annotation_fields: false

--- a/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news.yml
+++ b/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news.yml
@@ -31,5 +31,5 @@ field_mapper_config:
     short_title:
       value: '$.attributes[''short_title'']'
 storage_client_id: helfi_news
-persistent_cache_max_age: -1
+persistent_cache_max_age: 86400
 inherits_annotation_fields: false

--- a/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_groups.yml
+++ b/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_groups.yml
@@ -17,7 +17,7 @@ field_mapper_config:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_groups
 storage_client_config: {  }
-persistent_cache_max_age: -1
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
+++ b/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
@@ -17,7 +17,7 @@ field_mapper_config:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_neighbourhoods
 storage_client_config: {  }
-persistent_cache_max_age: -1
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_tags.yml
+++ b/helfi_features/helfi_news_feed/config/install/external_entities.external_entity_type.helfi_news_tags.yml
@@ -17,7 +17,7 @@ field_mapper_config:
       value: '$.attributes["name"]'
 storage_client_id: helfi_news_tags
 storage_client_config: {  }
-persistent_cache_max_age: -1
+persistent_cache_max_age: 86400
 annotation_entity_type_id: null
 annotation_bundle_id: null
 annotation_field_name: null

--- a/helfi_features/helfi_news_feed/helfi_news_feed.install
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.install
@@ -241,7 +241,7 @@ function helfi_news_feed_update_9006() : void {
 }
 
 /**
- * Change field weights.
+ * Change news feed external entity cache from persistant to 1d.
  */
 function helfi_news_feed_update_9007() : void {
   $configLocation = dirname(__FILE__) . '/config/install/';

--- a/helfi_features/helfi_news_feed/helfi_news_feed.install
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.install
@@ -239,3 +239,22 @@ function helfi_news_feed_update_9006() : void {
     ConfigHelper::updateExistingConfig($configLocation, $config);
   }
 }
+
+/**
+ * Change field weights.
+ */
+function helfi_news_feed_update_9007() : void {
+  $configLocation = dirname(__FILE__) . '/config/install/';
+
+  // Update existing configuration.
+  $updateConfig = [
+    'external_entities.external_entity_type.helfi_news.yml',
+    'external_entities.external_entity_type.helfi_news_groups.yml',
+    'external_entities.external_entity_type.helfi_news_neighbourhoods.yml',
+    'external_entities.external_entity_type.helfi_news_tags.yml',
+  ];
+
+  foreach ($updateConfig as $config) {
+    ConfigHelper::updateExistingConfig($configLocation, $config);
+  }
+}

--- a/helfi_features/helfi_news_feed/helfi_news_feed.install
+++ b/helfi_features/helfi_news_feed/helfi_news_feed.install
@@ -248,10 +248,10 @@ function helfi_news_feed_update_9007() : void {
 
   // Update existing configuration.
   $updateConfig = [
-    'external_entities.external_entity_type.helfi_news.yml',
-    'external_entities.external_entity_type.helfi_news_groups.yml',
-    'external_entities.external_entity_type.helfi_news_neighbourhoods.yml',
-    'external_entities.external_entity_type.helfi_news_tags.yml',
+    'external_entities.external_entity_type.helfi_news',
+    'external_entities.external_entity_type.helfi_news_groups',
+    'external_entities.external_entity_type.helfi_news_neighbourhoods',
+    'external_entities.external_entity_type.helfi_news_tags',
   ];
 
   foreach ($updateConfig as $config) {


### PR DESCRIPTION
# [UHF-7739](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739)
External entities were cached indefinitely which caused news feeds to not update.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7739_news_feed_fix`
* Run `make drush-updb drush-cr`

## How to test
- Run drush cex
  - Configurations were updated: external_entities.external_entity_type.*
    - Cache time changed from -1 to 86400(1 day) 


[UHF-7739]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ