### PR TITLE
Fix news feed

### DIFF
--- a/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/helfi_features/helfi_news_feed/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -78,9 +78,8 @@ final class News extends ExternalEntityStorageClientBase {
   public function loadMultiple(array $ids = NULL) : array {
     $query = [
       'filter[id][operator]' => 'IN',
-      // Include main image, tags, neighbourhoods and groups fields.
-      'include' => 'main_image.media_image,tags,groups,neighbourhoods',
-      'fields[file--file]' => 'uri,url',
+      // Include tags, neighbourhoods and groups fields.
+      'include' => 'tags,groups,neighbourhoods',
     ];
     $language = $this->languageManager
       ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)


### PR DESCRIPTION
# [UHF-7739](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739)
News feeds did not update properly.

## What was done
Removed the part which would request main image url from json api since json-api would return error 500.

## How to install
* Make sure your Etusivu-instance is up and running on latest dev branch.

* Make sure your instance (`Strategia` most preferably) is up and running on latest dev branch.
  * Make sure the second instance has this line in the `local.settings.php`: `$config['helfi_news_feed.settings']['source_environment'] = 'local';` 
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_news_feed_update_problem`
* Run `make drush-updb drush-cr`


## How to test
- Go to your etusivu-instance
  - Add new `news tag` taxonomy term, for example `MyTestTag`
  - Create 1 or 2 `news items` with newly created term (or edit existing news items).
- Now go to the second environment
  - Go to `/admin/structure/external-entity-types` and edit `news item's` and `news tag's` `cache time` to few minutes to make things go smoother. (bottom of page, under cache tab). Save the cache settings and run `drush cr`
  - Create new `landing page` and add a `news feed` to it. 
    - Configure the feed to use the newly created `MyTestTag` and save the landing page.
  - Go check the landingpage. It should show the news you tagged with the new tag.
- Go back to `Etusivu` and create or edit another `news item` by adding `MyTestTag` to it.
- Go back to the second instance and refresh the landing page with the news feed.
  - News feed should update after the cache is expired


[UHF-7739]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ