### PR TITLE
UHF-7997: Fix admin content list wsod

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
                 "[#UHF-4325] Strip whitespaces from twig debug comments": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/f7c0e380e2deb9a1b46bdf779fb27a945b466575/patches/drupal_core_strip_debug_mode_whitespaces_9.3.x.patch",
                 "[#UHF-7008] Core localization file download URL is wrong (https://www.drupal.org/project/drupal/issues/3022876)": "https://git.drupalcode.org/project/drupal/-/commit/40a96136b2dfe4322338508dffa636f6cb407900.patch",
                 "[#UHF-7008] Add multilingual support for caching basefield definitions (https://www.drupal.org/project/drupal/issues/3114824)": "https://www.drupal.org/files/issues/2020-02-20/3114824_2.patch",
-                "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch"
+                "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2022-11-04/2313309-152.patch",
+                "[#UHF-7997] Admin content list wsod fix": "https://www.drupal.org/files/issues/2023-01-05/3007424-146-9.5.x.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"


### PR DESCRIPTION
# [UHF-7997](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7997)

Fixed admin content list WSOD

## What was done
Installed a patch

## How to install
* Kasko has reported this problem so using Kasko instance is advicable
* Make sure your instance is up and running on latest dev branch. Make sure you have DB from testing or production
    * `git pull origin dev`
    * `make fresh`
* Login as admin

## How to test
* Go to `/admin/content´, start browsing the content list with the pagination until you encounter wsod
  * try this link with testing database. If it works, just start browsing the pagination page by page: `en/childhood-and-education/admin/content?title=&type=All&status=All&langcode=All&order=name&sort=asc&page=0`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7997_admin_content_list_wsod`
* Run `composer install` to make sure the patch added in platform_config was installed 
* Run `make drush-updb drush-cr`
* Refresh the page which earlier gave wsod

WSOD should be gone


[UHF-7997]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ