### PR TITLE
UHF-7794: remove dependencies to old accordion library

### DIFF
--- a/helfi_features/helfi_toc/assets/js/tableOfContents.js
+++ b/helfi_features/helfi_toc/assets/js/tableOfContents.js
@@ -93,43 +93,6 @@
 
       // Remove loading text.
       $('.js-remove', tableOfContents).remove();
-
-      // Open accordions that contain linked anchors
-      function handleAccordionAnchors() {
-        var hash = window.location.hash;
-        if (!hash) return;
-
-        var hashTarget = document.getElementById(hash.replace('#', ''));
-        if (!hashTarget) return;
-
-        var hashParent = hashTarget.closest('.handorgel__content');
-        if (!hashParent) return;
-
-        if (document.readyState === 'complete') { // if document has already been loaded
-
-          if (!window.handorgel_accordions) return; // We need access to the accordion objects to open them
-
-          window.handorgel_accordions.forEach(function (accordion) {
-            accordion.folds.forEach(function (fold) {
-              if (fold.id === hashParent.id.replace('-content','')) {
-                fold.open(false); // false prevents animation
-                hashTarget.scrollIntoView();
-              }
-            });
-          });
-          hashTarget.scrollIntoView();
-
-        } else { // If we have not yet loaded the document
-          hashParent.setAttribute('data-open', '');
-          window.addEventListener('DOMContentLoaded', function () {
-            window.setTimeout(function () {
-              hashTarget.scrollIntoView();
-            }, 1000);
-          })
-        }
-      }
-      handleAccordionAnchors();
-      window.addEventListener('popstate', handleAccordionAnchors); //popstate instead of hashchange to handle re-click
     },
   };
 })(jQuery, Drupal);


### PR DESCRIPTION
# [UHF-7794](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
Remove the dependency. Handorgel libary is deleted elsewhere and this functionality is handled in hdbt-theme accordion js library

## What was done
Removed accordion specific code from toc module.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7794_accordion`
* Run `make drush-updb drush-cr`

## How to test

Check https://github.com/City-of-Helsinki/drupal-hdbt/pull/541

## Other PRs
https://github.com/City-of-Helsinki/drupal-hdbt/pull/541

[UHF-7794]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ