### PR TITLE
UHF-8005: Add Talbotti (Watson) to ChatLeijuke

### DIFF
--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -139,6 +139,23 @@ watson_sote:
       minified: true
     }
 
+watson_talpa:
+  version: 1.0.x
+  header: false
+  js:
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/widget.min.js': {
+      type: external,
+      minified: true
+    }
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/static/talpa/custom.widget.min.js?tenantId=www-hel-fi-prod&assistantId=talpa': {
+      type: external,
+      minified: true
+    }
+    'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/default.min.js': {
+      type: external,
+      minified: true
+    }
+
 genesys_neuvonta:
   version: 1.0.x
   header: true

--- a/src/Plugin/Block/ChatLeijuke.php
+++ b/src/Plugin/Block/ChatLeijuke.php
@@ -37,6 +37,7 @@ class ChatLeijuke extends BlockBase {
         'watson_chatbot' => 'Asunnonhakubotti (watson)',
         'kuura_health_chat' => 'Kuura Health Chat',
         'watson_sote' => 'Hester/Sotebotti (watson)',
+        'watson_talpa' => 'Talbotti (watson)',
       ],
     ];
 


### PR DESCRIPTION
# [UHF-8005](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8005)

## What was done
Add Talbotti / Watson chabot implemented by IBM to ChatLeijuke libraries and block form.

## How to install
* Test on any instance you have working currently
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8005-add-watson-talbotti-to-leijuke`
* Run `make drush-cr`

## How to test
* [ ] Check that the new library is available in the ChatLeijuke block settings form
  * Go to block layout config: /admin/structure/block
  * Add a "Chat Leijuke" block to the "Attachments region"
    * Add whatever as the title 
    * Select "Talbotti (watson)" from the Dropdown
    * Add "Talbotti" as the chat title
    * Configure block visibility so that it's visible only on finnish and on a specific page
* [ ] Check that no external scripts are loaded if cookies aren't accepted
  * Open the page you specified
  * None of the scripts from `https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud` should be loaded if you haven't accepted cookies. The button might still show up though (that's how it is on the other Leijuke implementations too).
* [ ] Check that the chatbot opens once cookies are accepted (`chat` cookie category)
  * Once you have accepted cookies, the button should work and pop up the chatbot. If it doesn't, try reloading the page.
  * Unaccept all cookies from `/cookie-information-and-settings` and make sure the chatbot is blocked again
  * Accept the `chat` cookie category only and check that the bot starts working
* [ ] Check that code follows our standards

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/399

[UHF-8005]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ