### PR TITLE
UHF-7298: Uninstalled views_infinite_scroll on update hook

### DIFF
--- a/helfi_features/helfi_tpr_config/helfi_tpr_config.install
+++ b/helfi_features/helfi_tpr_config/helfi_tpr_config.install
@@ -636,4 +636,8 @@ function helfi_tpr_config_update_9030() {
     ConfigHelper::installNewConfig($configLocation, $configuration);
     ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
   }
+
+  // Manually uninstall views_infinite_scroll module.
+  $installer = Drupal::service('module_installer');
+  $installer->uninstall(['views_infinite_scroll']);
 }


### PR DESCRIPTION
# [UHF-7298](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7298)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Uninstalled views_infinite_scroll

[UHF-7298]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ