### PR TITLE
UHF-X Removed drupal/core-recommended dependency from platform config…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
         "drupal/config_rewrite": "^1.4",
         "drupal/config_replace": "^2.0",
         "drupal/content_lock": "^2.2",
-        "drupal/core-recommended": ">=9.3",
         "drupal/crop": "^2.1",
         "drupal/default_content": "^2.0.0-alpha2",
         "drupal/diff": "^1.0",


### PR DESCRIPTION
… to be able to install guzzle version 7 on instances

# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed drupal/core-recommended dependency.
