### PR TITLE
UHF-4062: Add new Helsinkikanava URL matcher.

### DIFF
--- a/helfi_features/helfi_media/config/override/oembed_providers.provider.icareus_suite.yml
+++ b/helfi_features/helfi_media/config/override/oembed_providers.provider.icareus_suite.yml
@@ -1,0 +1,12 @@
+endpoints:
+  -
+    schemes:
+      - 'https://www.helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
+      - 'http://www.helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
+      - 'https://helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
+      - 'http://helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
+    url: 'https://suite.icareus.com/api/oembed'
+    discovery: false
+    formats:
+      json: true
+      xml: false

--- a/helfi_features/helfi_media/config/override/oembed_providers.provider.icareus_suite.yml
+++ b/helfi_features/helfi_media/config/override/oembed_providers.provider.icareus_suite.yml
@@ -2,9 +2,7 @@ endpoints:
   -
     schemes:
       - 'https://www.helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
-      - 'http://www.helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
       - 'https://helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
-      - 'http://helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=*'
     url: 'https://suite.icareus.com/api/oembed'
     discovery: false
     formats:

--- a/helfi_features/helfi_media/helfi_media.install
+++ b/helfi_features/helfi_media/helfi_media.install
@@ -195,3 +195,11 @@ function helfi_media_update_9011() : void {
   }
   Drupal::service('module_installer')->uninstall(['media_entity_soundcloud']);
 }
+
+/**
+ * Update Icareus Suita OEmbed providers.
+ */
+function helfi_media_update_9012() {
+  $configLocation = dirname(__FILE__) . '/config/override/';
+  ConfigHelper::updateExistingConfig($configLocation, 'oembed_providers.provider.icareus_suite');
+}


### PR DESCRIPTION
# [UHF-4062](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4062)
Helsinkikanava URLs following pattern https://www.helsinkikanava.fi/*/web/helsinkikanava/player/embed/vod?assetId=* don't work.

## What was done
<!-- Describe what was done -->

* Added a new URL pattern to the Icareus Suite provider schemes.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4062_Add-new-Helsinkikanava-url-matcher`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that it's possible to add a remote video with the URL https://www.helsinkikanava.fi/fi/web/helsinkikanava/player/embed/vod?assetId=147950614 and that the video embed also works.


[UHF-4062]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ