### PR TITLE
UHF-6966: Validate remote video URL.

### DIFF
--- a/helfi_features/helfi_media/helfi_media.module
+++ b/helfi_features/helfi_media/helfi_media.module
@@ -31,6 +31,7 @@ function helfi_media_form_alter(&$form, &$form_state, $form_id) {
   // Handle input URLs in form after build.
   if (in_array($form_id, $forms)) {
     $form['#after_build'][] = '_helfi_media_remote_video_validate';
+    $form['container']['submit']['#validate'][] = '_helfi_media_remote_video_provider_validation';
 
     // Switch provider names to more understandable format as the true provider
     // for Helsinki-kanava is Icareus Suite.
@@ -44,6 +45,48 @@ function helfi_media_form_alter(&$form, &$form_state, $form_id) {
       $form['container']['url']['#description'] = t('Allowed providers: @providers.', $providers);
     }
   }
+}
+
+/**
+ * Check that the video provider is allowed.
+ *
+ * @param array $form
+ *   An associative array containing the structure of the form.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @return array
+ *   Returns the form.
+ */
+function _helfi_media_remote_video_provider_validation($form, &$form_state) {
+  // No need for validation if user input is empty.
+  if (empty($form_state->getUserInput())) {
+    return $form;
+  }
+
+  // Skip if OEmbed providers module doesn't exist.
+  if (!Drupal::moduleHandler()->moduleExists('oembed_providers')) {
+    return $form;
+  }
+
+  $config = \Drupal::configFactory()->getEditable('media.type.remote_video');
+  $config_data = $config->getRawData();
+
+  if (isset($config_data['source_configuration']['providers'])) {
+    $user_input = $form_state->getUserInput();
+    $allowed_providers = $config_data['source_configuration']['providers'];
+    $url_resolver = Drupal::service('media.oembed.url_resolver');
+    $provider = $url_resolver->getProviderByUrl($user_input['url']);
+    $provider_name = $provider->getName();
+  
+    if (!in_array($provider_name, $allowed_providers)) {
+      $form_state->setErrorByName('url', t('@provider is not an allowed video provider.', [
+        '@provider' => $provider_name,
+      ]));
+    }
+  }
+
+  return $form;
 }
 
 /**
@@ -82,10 +125,6 @@ function _helfi_media_remote_video_validate($form, &$form_state) {
   ) {
     $oembed_video_field = 'url';
     $video_url = &$user_input[$oembed_video_field];
-
-    // Do not validate URL as it is cached in media library form and would in
-    // some cases try to validate wrong URL.
-    $form_state->setValidationComplete(TRUE);
   }
 
   // Convert the video url if needed.


### PR DESCRIPTION
# [UHF-6966](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6966)
The video provider wasn't limited when a remote video is added through the media browser in the remote video paragraph.

## What was done
<!-- Describe what was done -->

* Added a validation that checks that given URL is from an allowed provider.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6966_Limit-allowed-remote-video-providers`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add a remote video paragraph to any page and try add for example a Vimeo video. It shouldn't give an error.
* [x] Check that adding YouTube and Helsinkikanava videos still work.

[UHF-6966]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ