### PR TITLE
UHF-8071: Use new version of IBM chat embed.

### DIFF
--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -79,9 +79,7 @@ class IbmChatApp extends BlockBase {
     $tenantId = $config['tenantId'];
     $assistantId = $config['assistantId'];
 
-    $optionsSrc = sprintf('%s/get-widget-options?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
-    $widgetSrc = sprintf('%s/get-widget?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
-    $defaultSrc = sprintf('%s/get-widget-default?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
+    $widgetSrc = sprintf('%s/get-widget-button?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
 
     $build['ibm_chat_app'] = [
       '#title' => $this->t('IBM Chat App'),
@@ -93,27 +91,9 @@ class IbmChatApp extends BlockBase {
               '#tag' => 'script',
               '#attributes' => [
                 'type' => 'text/javascript',
-                'src' => $optionsSrc,
-              ],
-            ], 'chat_app_options',
-          ],
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'type' => 'text/javascript',
                 'src' => $widgetSrc,
               ],
-            ], 'chat_app_widget',
-          ],
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'type' => 'text/javascript',
-                'src' => $defaultSrc,
-              ],
-            ], 'chat_app_default',
+            ], 'chat_app_widget_button',
           ],
         ],
       ],


### PR DESCRIPTION
# [UHF-8071](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8071)

This PR adjusts the IBM Chat App block to use the new embed code.

## What was done
Changed the embed code to the latest version which uses just one JS file instead of three.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8071-new-ibm-chat-app`
* Run `make drush-cr`
* Add a new `IBM Chat App` on `/admin/structure/block` to the `Attachments` region with the following info:
  * Hostname: https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud
  * Hide title (causes blank whitespace below the footer otherwie)
  * Chat Engagement Id: housing
  * Chat Tenant Id: www-hel-fi-test
  * Chat Assistant Id: housing
  * Add only to a specific page
## How to test
* [x] Open the page you added the block to and accept cookies
* [x] The chatbot button should show up
* [x] Click the button 
* [x] Check the JS console in the browser's developer toolbar. There should be a bunch of debug information prefixed with `[ACA]`, but there shouldn't be any JS errors or messages about deprecated URLs

[UHF-8071]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ