### PR TITLE
UHF-8084: improve search performance

### DIFF
--- a/helfi_features/helfi_react_search/src/EventsApiBase.php
+++ b/helfi_features/helfi_react_search/src/EventsApiBase.php
@@ -29,7 +29,7 @@ abstract class EventsApiBase {
       foreach ($parsed['query'] as $key => $param) {
         switch ($key) {
           case 'categories':
-            $params['keyword_OR_set1'] = $this->categoriesToKeywords($param);
+            $params['keyword'] = $this->categoriesToKeywords($param);
             break;
 
           case 'start':

--- a/helfi_features/helfi_react_search/src/LinkedEvents.php
+++ b/helfi_features/helfi_react_search/src/LinkedEvents.php
@@ -8,7 +8,6 @@ use Drupal\Core\Url;
 use Drupal\Core\Cache\CacheBackendInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\json_decode;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -38,7 +37,7 @@ class LinkedEvents extends EventsApiBase {
    * Max age for cache.
    */
   public function getCacheMaxAge() : int {
-    return time() + 60 * 60;
+    return time() + 60 * 60 * 8;
   }
 
   /**
@@ -136,6 +135,9 @@ class LinkedEvents extends EventsApiBase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function getPlacesList($url) : array {
+    // Remove keywords from api url not to get detailed keyword data for places.
+    $url = str_replace('keywords%2C', '', $url);
+
     if ($data = $this->getFromCache($url)) {
       return $data;
     }


### PR DESCRIPTION
# [UHF-8084](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8084)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Increase Places fetch from Linkedevents API cache time to 8 hours
* Remove keywords from places Linkedevents API URL not to get detailed keyword data for places
* Change keyword parameter from `keyword_OR_set1 `to `keyword` because keyword is documented and works in the same way.

## How to test
Check instructions from: [UHF-8084-improve-search-performance](https://github.com/City-of-Helsinki/drupal-hdbt/pull/562)


[UHF-8084]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ