### PR TITLE
UHF-8149: fix events missing nature category

### DIFF
--- a/helfi_features/helfi_react_search/src/Enum/CategoryKeywords.php
+++ b/helfi_features/helfi_react_search/src/Enum/CategoryKeywords.php
@@ -128,6 +128,10 @@ class CategoryKeywords {
     'yso:p2625',
   ];
 
+  public const NATURE = [
+    'yso:p2771',
+  ];
+
   public const CHILDREN = 'yso:p4354';
 
   /**

--- a/helfi_features/helfi_react_search/src/EventsApiBase.php
+++ b/helfi_features/helfi_react_search/src/EventsApiBase.php
@@ -129,7 +129,7 @@ abstract class EventsApiBase {
         'culture' => CategoryKeywords::CULTURE,
         'movie' => CategoryKeywords::MOVIE,
         'sport' => CategoryKeywords::SPORT,
-        'nature' => CategoryKeywords::CAMPS,
+        'nature' => CategoryKeywords::NATURE,
         'museum' => CategoryKeywords::MUSEUM,
         'music' => CategoryKeywords::MUSIC,
         'influence' => CategoryKeywords::INFLUENCE,


### PR DESCRIPTION
# [UHF-8149](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8149)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add missing nature category for event search

## How to install
* Make sure your SOTE instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8149-fix-events-nature-category-search`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to a page that has events search e.g. https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/tapahtumahaun-testisivu
* [x] Add this URL to Events paragraph api URL field: `https://tapahtumat.hel.fi/fi/events?categories=nature`. Save node.
* [x] Check how many events are found.
* [x] Go to the URL: `https://tapahtumat.hel.fi/fi/events?categories=nature` check how many events are found. It should be the same amount as in Drupal event search.
* [x] Do the same using this URL: `https://tapahtumat.hel.fi/fi/events?categories=nature&text=k%C3%A4vely`
* [x] Check that code follows our standards


[UHF-8149]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ