### PR TITLE
UHF-8080: WatsonAdapter chat bug fix

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -343,7 +343,7 @@
           // Check if the adapter is of type Watson
           if (this.adapter instanceof WatsonAdapter) {
             // Cannot call open before adapter is loaded.
-            setTimeout(this.openAdapter, 1100);
+            setTimeout(this.openAdapter, 500);
           } else {
             this.adapter.onLoaded(this.openChat.bind(this));
           }
@@ -355,8 +355,15 @@
     }
 
     openAdapter = () => {
-      this.adapter.open(()=>{});
+      let acaWidgetInitialized = setInterval(() => {
+        if (acaWidget) {
+          setTimeout(this.doOpenAdapter, 800);
+          clearInterval(acaWidgetInitialized);
+        }
+      }, 500)
     }
+
+    doOpenAdapter = () => this.adapter.open(()=>{});
 
     setLeijukeCookie(cname, cvalue) {
       document.cookie = `${cname}=${cvalue}; path=/; SameSite=Strict; `;


### PR DESCRIPTION
# [UHF-8080](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8080)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added additional interval on top of the timeout to tackle issues with slower connections.

## How to install
* Make sure your asuminen instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8080_watson_chat_opening_issue_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helfi-asuminen.docker.so/fi/asuminen/vuokra-asunnot
* [x] On your inspectors Network tab select to throttle the download speed to Slow 3G.
* [x] Clear page cookies.
* [x] Refresh the page where the chat is and accept only compulsory cookies.
* [x] Click on the chat and make sure it opens with first click.
* [x] Close the chat so that there is no more popup visible.
* [x] Open the chat again and close it once more.
* [x] Refresh the page and make sure the chat opens again nicely.
* [x] Clear the page cookies again.
* [x] Refresh the page where the chat is and accept all cookies.
* [x] Click on the chat and make sure it opens with first click.
* [x] Close the chat so that there is no more popup visible.
* [x] Open the chat again and close it once more.
* [x] Refresh the page and make sure the chat opens again nicely.
* [x] Check that code follows our standards


[UHF-8080]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ