### PR TITLE
UHF-4213: Fix for landing page metatag description

### DIFF
--- a/helfi_features/helfi_content/config/install/metatag.metatag_defaults.node__landing_page.yml
+++ b/helfi_features/helfi_content/config/install/metatag.metatag_defaults.node__landing_page.yml
@@ -3,4 +3,5 @@ status: true
 dependencies: {  }
 id: node__landing_page
 label: 'Content: Landing page'
-tags: {  }
+tags:
+  description: '[node:field_hero:entity:field_hero_desc]'

--- a/helfi_features/helfi_content/helfi_content.install
+++ b/helfi_features/helfi_content/helfi_content.install
@@ -33,6 +33,7 @@ function helfi_content_install($is_syncing) {
     helfi_content_update_9025();
     helfi_content_update_9027();
     helfi_content_update_9028();
+    helfi_content_update_9041();
 
     // Override default meta tags configurations.
     $config_location = dirname(__FILE__) . '/config/override/';
@@ -1026,4 +1027,12 @@ function helfi_content_update_9040() : void {
       'aet',
     ]);
   }
+}
+
+/**
+ * Add description metatag default for landing page content type.
+ */
+function helfi_content_update_9041() {
+  // Update the configuration
+  ConfigHelper::updateExistingConfig(dirname(__FILE__) . '/config/install/', 'metatag.metatag_defaults.node__landing_page');
 }


### PR DESCRIPTION
# [UHF-4213](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4213)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added update hook that updates the landing page metatag description default value to correnct one

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4213_update_landing_page_metatag_description_default`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to any landing page that has hero-block with text inside the hero (not just the title) and make sure that the meta description of that page is now the same as the hero-text.
* [x] Check that code follows our standards

[UHF-4213]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ