### PR TITLE
UHF-4213: Fix for landing page metatag description 3.x

### DIFF
--- a/modules/helfi_node_landing_page/config/install/metatag.metatag_defaults.node__landing_page.yml
+++ b/modules/helfi_node_landing_page/config/install/metatag.metatag_defaults.node__landing_page.yml
@@ -3,4 +3,6 @@ status: true
 dependencies: {  }
 id: node__landing_page
 label: 'Content: Landing page'
-tags: {  }
+tags:
+  description: '[node:field_hero:entity:field_hero_desc]'
+


### PR DESCRIPTION
# [UHF-4213](https://helsinkisolutionoffice.atlassian.net/browse/UHF-4213)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added correct default value for landing page meta description to the install configurations.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-4213_update_landing_page_metatag_description_default_3x`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any landing page that has hero-block with text inside the hero (not just the title) and make sure that the meta description of that page is now the same as the hero-text.
* [ ] Check that code follows our standards


[UHF-4213]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ