### PR TITLE
UHF-6848: Add event subscriber to strip boost parameter from index mappings

### DIFF
--- a/helfi_features/helfi_react_search/helfi_react_search.services.yml
+++ b/helfi_features/helfi_react_search/helfi_react_search.services.yml
@@ -9,3 +9,6 @@ services:
       - '@cache.default'
       - '@http_client'
       - '@logger.channel.helfi_react_search'
+  Drupal\helfi_react_search\EventSubscriber\BoostStripper:
+    tags:
+      - { name: 'event_subscriber' }

--- a/helfi_features/helfi_react_search/src/EventSubscriber/BoostStripper.php
+++ b/helfi_features/helfi_react_search/src/EventSubscriber/BoostStripper.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_react_search\EventSubscriber;
+
+use Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribe for stripping boost parameter from Elasticsearch indices.
+ *
+ * Search API wants to index fields with 'boost' parameter'.
+ * Index-time boosting has been deprecated in newer Elasticsearch versions.
+ * This subscriber strips boost from mapping to prevent errors.
+ */
+class BoostStripper implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      PrepareIndexMappingEvent::PREPARE_INDEX_MAPPING => 'stripBoost',
+    ];
+  }
+
+  /**
+   * Iterate over fields and remove any boosts.
+   *
+   * @param Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent $event
+   *   Event emitted by elasticsearch_connector.
+   */
+  public function stripBoost(PrepareIndexMappingEvent $event): void {
+    $params = $event->getIndexMappingParams();
+
+    // Bail if nothing to check against.
+    if (!isset($params['body']['properties'])) {
+      return;
+    }
+
+    foreach ($params['body']['properties'] as $key => $property) {
+      if (isset($property['boost'])) {
+        unset($params['body']['properties'][$key]['boost']);
+      }
+    }
+
+    $event->setIndexMappingParams($params);
+  }
+
+}


### PR DESCRIPTION
# [UHF-6848](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6848)
Strip boost parameter from index mappings to prevent errors.
Before this fix importing index mappings with boost parameter fail, since ES no longer supports index-time boosting (in favor of query-time boosting).

## What was done
* Add event subscriber to handle removing boost parameters from mappings before index creation / updating.

## How to install & test
* Read info here: https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/322


[UHF-6848]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ