### PR TITLE
UHF-7123: Improve hiding of secondary languages.

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -190,16 +190,18 @@ function hdbt_admin_tools_language_switch_links_alter(array &$links): void {
   }
 
   // @todo UHF-6102 Needs refactoring during "Muut kielet" epic.
-  $alternative_languages = [
-    'ru',
+  $primary_languages = [
+    'fi',
+    'sv',
+    'en',
   ];
 
   // Compare the links with current entity and check for possible translations.
   foreach ($links as $lang_code => &$link) {
     $link['#abbreviation'] = $lang_code;
 
-    if (in_array($lang_code, $alternative_languages)) {
-      $link['#alternative_language'] = TRUE;
+    if (in_array($lang_code, $primary_languages)) {
+      $link['#primary_language'] = TRUE;
     }
 
     if (!$entity instanceof ContentEntityInterface) {


### PR DESCRIPTION
# [UHF-7123](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7123)
This does same change for hiding the secondary languages than the PR here: https://github.com/City-of-Helsinki/drupal-hdbt/pull/525, but since the code was moved under platform config in 3.x, this PR does that change there.

## What was done
* Added better support for non-primary languages hiding from primary lang menu when there's no content on such language.

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/525)
