### PR TITLE
UHF-X: Fix es_connector dependency

### DIFF
--- a/helfi_features/helfi_react_search/helfi_react_search.info.yml
+++ b/helfi_features/helfi_react_search/helfi_react_search.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - 'drupal:language'
   - 'drupal:link'
   - 'drupal:text'
+  - 'elasticsearch_connector:elasticsearch_connector'
   - 'helfi_platform_config:helfi_platform_config'
   - 'paragraphs:paragraphs'
 package: HELfi

--- a/helfi_features/helfi_react_search/src/EventSubscriber/BoostStripper.php
+++ b/helfi_features/helfi_react_search/src/EventSubscriber/BoostStripper.php
@@ -20,6 +20,10 @@ class BoostStripper implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
+    if (!class_exists('Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent')) {
+      return [];
+    }
+
     return [
       PrepareIndexMappingEvent::PREPARE_INDEX_MAPPING => 'stripBoost',
     ];

--- a/helfi_platform_config.info.yml
+++ b/helfi_platform_config.info.yml
@@ -5,6 +5,7 @@ core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
   - 'drupal:language'
+  - 'elasticsearch_connector:elasticsearch_connector'
   - 'helfi_api_base:helfi_api_base'
   - 'menu_block_current_language:menu_block_current_language'
   - 'update_helper:update_helper'

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -314,14 +314,3 @@ function helfi_platform_config_update_9014() : void {
     ]);
   }
 }
-
-/**
- * Make sure elasticsearch_connector is installed to prevent errors.
- */
-function helfi_platform_config_update_9014() : void {
-  if (!Drupal::moduleHandler()->moduleExists('elasticsearch_connector')) {
-    Drupal::service('module_installer')->install([
-      'elasticsearch_connector',
-    ]);
-  }
-}

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -314,3 +314,14 @@ function helfi_platform_config_update_9014() : void {
     ]);
   }
 }
+
+/**
+ * Make sure elasticsearch_connector is installed to prevent errors.
+ */
+function helfi_platform_config_update_9014() : void {
+  if (!Drupal::moduleHandler()->moduleExists('elasticsearch_connector')) {
+    Drupal::service('module_installer')->install([
+      'elasticsearch_connector',
+    ]);
+  }
+}

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -303,3 +303,14 @@ function helfi_platform_config_update_9013() : void {
     ]);
   }
 }
+
+/**
+ * Make sure elasticsearch_connector is installed to prevent errors.
+ */
+function helfi_platform_config_update_9014() : void {
+  if (!Drupal::moduleHandler()->moduleExists('elasticsearch_connector')) {
+    Drupal::service('module_installer')->install([
+      'elasticsearch_connector',
+    ]);
+  }
+}


### PR DESCRIPTION
# UHF-X: Fix elasticsearch_connector dependency
Fixes issues with BootStripper class throwing errors due to elastichsearch_connector not getting loaded.

## What was done
* Added es connector as dependency to `helfi_platform_config` & `helfi_react_search`
* Added upate hook to ensure elasticsearch_connector is enabled
* Added sanity check to BootStripper class to prevent errors

## How to install & test
* Install this branch to your instace of choice: `composer require drupal/helfi_platform_config:dev-UHF-X-fix-es-connector-dependency -W`
* Run `drush updb`
* Run `drush cr`
* Try loading frontpage of the instance

You should not be getting any errors. 
