### PR TITLE
Updated admin toolbar module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "require": {
         "ext-curl": "*",
-        "drupal/admin_toolbar": "^2.4.0",
+        "drupal/admin_toolbar": "^3.0",
         "drupal/allowed_formats": "^1.3",
         "drupal/config_ignore": "^2.3",
         "drupal/config_rewrite": "^1.4",


### PR DESCRIPTION
Admin toolbar 2.0 is unsupported.

## What was done

* Updated `drupal/admin_toolbar` to 3.0

## How to install
* Update the HDBT Admin theme and platform config module
    * `composer require drupal/hdbt_admin:dev-UHF-X-update-admin-toolbar drupal/helfi_platform_config:dev-UHF-X-update-admin-toolbar -W`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Make sure admin toolbar still works

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/204