### PR TITLE
Uhf X announcement block enable filter

### DIFF
--- a/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
+++ b/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
@@ -69,7 +69,7 @@ final class Announcements extends ExternalEntityStorageClientBase {
     $instance->client = $container->get('http_client');
 
     $environment = $container->get('config.factory')
-      ->get('helfi_announcement.settings')
+      ->get('helfi_global_announcement.settings')
       ->get('source_environment') ?: 'prod';
 
     /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolver $environmentResolver */
@@ -83,18 +83,17 @@ final class Announcements extends ExternalEntityStorageClientBase {
    * {@inheritdoc}
    */
   public function loadMultiple(array $ids = NULL) : array {
+    $ids = $ids ?: [];
+
     $query = [
       'filter[id][operator]' => 'IN',
     ];
 
-    $language = $this->languageManager
-      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
-      ->getId();
-
-    foreach ($ids ?? [] as $index => $id) {
+    foreach ($ids as $index => $id) {
       $query[sprintf('filter[id][value][%d]', $index)] = $id;
     }
-    $data = $this->request($query, $language);
+
+    $data = $this->query($query);
 
     // The $ids are passed in correct order, but the external data is not
     // in same order. Sort data by given $ids.

--- a/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
+++ b/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
@@ -131,6 +131,7 @@ final class Announcements extends ExternalEntityStorageClientBase {
       'fields[node--announcements]' => 'id',
       'fields[status]' => 1,
       'filter[status][value]' => 1,
+      'filter[field_publish_externally][value]' => 1,
     ];
 
     if ($start) {


### PR DESCRIPTION
Read correct module specific configuration file
Announcement query bypassed filter string creation and too much results were returned.

## What was done
Call the query -method instead of calling directly to request -method (query method calls the request method after creating the query string)
