### PR TITLE
UHF-8217: Remove the generator tag from DOM

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -114,6 +114,17 @@ function helfi_platform_config_page_attachments(array &$attachments) : void {
 }
 
 /**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_platform_config_page_attachments_alter(array &$attachments): void {
+  foreach ($attachments['#attached']['html_head'] as $key => $attachment) {
+    if ($attachment[1] == 'system_meta_generator') {
+      unset($attachments['#attached']['html_head'][$key]);
+    }
+  }
+}
+
+/**
  * Implements hook_theme().
  */
 function helfi_platform_config_theme() : array {


### PR DESCRIPTION
# [UHF-8217](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8217)
<!-- What problem does this solve? -->
Generator info is visible in the DOM.

## What was done
<!-- Describe what was done -->

* Removed the generator metatag from the DOM by altering the html head.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8217_Remove-generator-info`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the Generator metatag is not anymore in the DOM.
