### PR TITLE
UHF-8099: Field group patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,9 +82,6 @@
             "drupal/eu_cookie_compliance": {
                 "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/923b35f699820b544397a35b7696570e101cd02c/patches/eu_cookie_compliance_block_8.x-1.24.patch"
             },
-            "drupal/field_group": {
-                "[#UHF-3268] Support for field group translations (https://www.drupal.org/node/3111107)": "https://www.drupal.org/files/issues/2022-09-27/3111107-39.patch"
-            },
             "drupal/linkit": {
               "[#UHF-1872] Linkit support for link field (https://www.drupal.org/i/2712951)": "https://www.drupal.org/files/issues/2023-03-07/2712951_329.6.x.diff"
             },

--- a/modules/helfi_base_content/config/install/language/fi/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
+++ b/modules/helfi_base_content/config/install/language/fi/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
@@ -1,0 +1,1 @@
+label: Lohkot

--- a/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,0 +1,1 @@
+ label: Ändrad

--- a/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,1 +1,1 @@
- label: Ändrad
+label: Ändrad

--- a/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.description.yml
+++ b/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.description.yml
@@ -1,0 +1,2 @@
+label: Beskrivning
+description: 'Visas när man för musmarkören över menylänken.'

--- a/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.title.yml
+++ b/modules/helfi_base_content/config/install/language/sv/core.base_field_override.menu_link_content.menu_link_content.title.yml
@@ -1,0 +1,2 @@
+label: 'Titel på menylänken'
+description: 'Texten som skall användas för denna länken i menyn.'

--- a/modules/helfi_base_content/config/install/language/sv/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
+++ b/modules/helfi_base_content/config/install/language/sv/core.base_field_override.paragraphs_library_item.paragraphs_library_item.paragraphs.yml
@@ -1,0 +1,1 @@
+label: Paragrafer

--- a/modules/helfi_node_announcement/config/install/core.entity_form_display.node.announcement.default.yml
+++ b/modules/helfi_node_announcement/config/install/core.entity_form_display.node.announcement.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - hdbt_admin_tools
     - link
     - path
+    - publication_date
     - scheduler
     - select2
     - text
@@ -107,11 +108,22 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   scheduler_settings:
     weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 9

--- a/modules/helfi_node_news_item/config/install/core.base_field_override.node.news_item.promote.yml
+++ b/modules/helfi_node_news_item/config/install/core.base_field_override.node.news_item.promote.yml
@@ -13,7 +13,7 @@ required: false
 translatable: true
 default_value:
   -
-    value: 1
+    value: 0
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/modules/helfi_node_news_item/config/install/core.entity_form_display.node.news_item.default.yml
+++ b/modules/helfi_node_news_item/config/install/core.entity_form_display.node.news_item.default.yml
@@ -195,6 +195,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 14

--- a/modules/helfi_node_news_item/config/install/language/fi/core.entity_form_display.node.news_item.default.yml
+++ b/modules/helfi_node_news_item/config/install/language/fi/core.entity_form_display.node.news_item.default.yml
@@ -6,3 +6,8 @@ third_party_settings:
       label: Linkit
     group_main_image:
       label: Pääkuva
+content:
+  field_content:
+    settings:
+      title: Lohko
+      title_plural: Lohkot

--- a/modules/helfi_node_news_item/config/install/language/sv/core.entity_form_display.node.news_item.default.yml
+++ b/modules/helfi_node_news_item/config/install/language/sv/core.entity_form_display.node.news_item.default.yml
@@ -4,6 +4,8 @@ third_party_settings:
       label: Länkar
     group_news_item_links_wrapper:
       label: Länkar
+    group_main_image:
+      label: Huvudbild
 content:
   field_content:
     settings:

--- a/modules/helfi_node_news_item/helfi_node_news_item.install
+++ b/modules/helfi_node_news_item/helfi_node_news_item.install
@@ -79,3 +79,12 @@ function helfi_node_news_item_install($is_syncing) : void {
 
   helfi_node_news_item_grant_permissions();
 }
+
+/**
+ * Implements hook_update_N().
+ */
+function helfi_node_news_item_update_9001(): void {
+  // Re-import 'helfi_node_news_item' configuration.
+  \Drupal::service('config.installer')
+    ->installDefaultConfig('module', 'helfi_node_news_item');
+}

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_has_hero.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_has_hero.yml
@@ -1,0 +1,2 @@
+label: Hero-block
+description: 'Välj om du vill visa hjältelyftelementet på sidan. Om du väljer en hjälte kommer dess titel att användas som huvudtitel på sidan.'

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_hero.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_hero.yml
@@ -1,0 +1,1 @@
+label: Hero-block

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_lead_in.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_lead_in.yml
@@ -1,0 +1,2 @@
+label: Leda
+description: 'Inlägget är synligt på innehållssidan samt i uttag, sökresultat och delningar i sociala medier.'

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_liftup_image.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_liftup_image.yml
@@ -1,0 +1,2 @@
+label: Lyftbild
+description: 'Bilden syns i uttag, sökmotorer och delningar i sociala medier.'

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_lower_content.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_lower_content.yml
@@ -1,0 +1,1 @@
+label: 'Botteninnehåll'

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_metatags.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_metatags.yml
@@ -1,0 +1,1 @@
+label: Metataggar

--- a/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_sidebar_content.yml
+++ b/modules/helfi_node_page/config/install/language/sv/field.field.node.page.field_sidebar_content.yml
@@ -1,0 +1,1 @@
+label: 'Sidofältets innehåll'

--- a/modules/helfi_tpr_config/config/install/language/sv/core.entity_form_display.paragraph.unit_search.default.yml
+++ b/modules/helfi_tpr_config/config/install/language/sv/core.entity_form_display.paragraph.unit_search.default.yml
@@ -1,0 +1,4 @@
+third_party_settings:
+  field_group:
+    group_unit_search_metadata:
+      label: Metadata

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -177,3 +177,12 @@ function helfi_tpr_config_install($is_syncing) : void {
     $content_lock_settings->set('types', $content_lock_config)->save();
   }
 }
+
+/**
+ * Implements hook_update_N().
+ */
+function helfi_tpr_config_update_9001(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('config.installer')
+    ->installDefaultConfig('module', 'helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-8099](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8099)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed patch for field_group translations and added missing translations to configuration

# Notice: Test on etusivu instance
## How to install
* Make sure your Etusivu instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8099 -W`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in and go to admin page to change the administration pages language to Finnish -> https://helfi-etusivu.docker.so/en/user/1/edit
* [ ] Go and create a news item and check that the "Main image" and "Links" field groups are translated to Finnish; "Pääkuva" and "Linkit". See pictures below
![image](https://user-images.githubusercontent.com/1712902/228237498-c1fe5aec-7e67-4f04-be2a-deb062df93ec.png)
![image](https://user-images.githubusercontent.com/1712902/228237699-aa71f3d8-a620-4658-b084-d2a0b51838dc.png)



[UHF-8099]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ