### PR TITLE
UHF-7449 announcement cache warmer

### DIFF
--- a/modules/helfi_global_announcement/README.md
+++ b/modules/helfi_global_announcement/README.md
@@ -1,0 +1,12 @@
+# Global announcement
+
+Global announcement module allows fetching announcements from `Etusivu`-instance.
+It utilizes `json-api` and `external_entities`-module to transfer the data between instances.
+Global announcements can be fetched to any instance and rendered using blocks.
+
+## How to set up locally
+
+Local setup requires Etusivu-instance to be up and running with some relevant data created to it.
+
+Add following line to local.settings.php in order to connect to local etusivu-instance
+`$config['helfi_global_announcement.settings']['source_environment'] = 'local'`

--- a/modules/helfi_global_announcement/helfi_global_announcement.module
+++ b/modules/helfi_global_announcement/helfi_global_announcement.module
@@ -94,6 +94,9 @@ function helfi_global_announcement_entity_bundle_field_info_alter(
   }
 }
 
+/**
+ * Implements hook_cron().
+ */
 function helfi_global_announcement_cron(): void {
   $store = \Drupal::service('tempstore.shared')->get('global_announcement');
   $globalEntityStorage = \Drupal::entityTypeManager()

--- a/modules/helfi_global_announcement/helfi_global_announcement.module
+++ b/modules/helfi_global_announcement/helfi_global_announcement.module
@@ -95,6 +95,7 @@ function helfi_global_announcement_entity_bundle_field_info_alter(
 }
 
 function helfi_global_announcement_cron(): void {
+  $store = \Drupal::service('tempstore.shared')->get('global_announcement');
   $globalEntityStorage = \Drupal::entityTypeManager()
     ->getStorage('helfi_announcements');
 
@@ -102,7 +103,6 @@ function helfi_global_announcement_cron(): void {
     ->loadMultiple();
 
   $newHash = hash('sha256', serialize($externalAnnouncements));
-  $store = \Drupal::service('tempstore.shared')->get('global_announcement');
   $hash = $store->get('announcements');
   if ($hash !== $newHash) {
     $store->set('announcements', $newHash);

--- a/modules/helfi_global_announcement/helfi_global_announcement.module
+++ b/modules/helfi_global_announcement/helfi_global_announcement.module
@@ -7,9 +7,11 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\BundleFieldDefinition;
+use Drupal\helfi_global_announcement\Plugin\ExternalEntities\StorageClient\Announcements;
 
 /**
  * Gets the block configurations.
@@ -89,5 +91,21 @@ function helfi_global_announcement_entity_bundle_field_info_alter(
         ->setDisplayConfigurable('view', TRUE)
         ->setDisplayConfigurable('form', TRUE);
     }
+  }
+}
+
+function helfi_global_announcement_cron(): void {
+  $globalEntityStorage = \Drupal::entityTypeManager()
+    ->getStorage('helfi_announcements');
+
+  $externalAnnouncements = $globalEntityStorage
+    ->loadMultiple();
+
+  $newHash = hash('sha256', serialize($externalAnnouncements));
+  $store = \Drupal::service('tempstore.shared')->get('global_announcement');
+  $hash = $store->get('announcements');
+  if ($hash !== $newHash) {
+    $store->set('announcements', $hash);
+    Cache::invalidateTags([Announcements::$customCacheTag]);
   }
 }

--- a/modules/helfi_global_announcement/helfi_global_announcement.module
+++ b/modules/helfi_global_announcement/helfi_global_announcement.module
@@ -105,7 +105,7 @@ function helfi_global_announcement_cron(): void {
   $store = \Drupal::service('tempstore.shared')->get('global_announcement');
   $hash = $store->get('announcements');
   if ($hash !== $newHash) {
-    $store->set('announcements', $hash);
+    $store->set('announcements', $newHash);
     Cache::invalidateTags([Announcements::$customCacheTag]);
   }
 }


### PR DESCRIPTION
# [UHF-7449](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7449)
Invalidate cache tags to clear global announcement block from varnish

## What was done
Cache invalidation via cron.

## How to install
* Set Etusivu-instance up and running
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7449_announcement_cache_warmer`
* Run `make drush-updb drush-cr`

## How to test
- Add  following line to local.settings.php (or change line 73 from `prod` to `local` on Announcements.php)
  - `$config['helfi_global_announcement.settings']['source_environment'] = 'local'`
- Add new global announcement to etusivu
- Check that you can see the external announcement in external site
- Go and unpublish the external announcement
- As anonymous user: 
  - Go to a page with external announcements using url `varnish-helfi-{instance}.docker.so/{the path to content}`
    - You should still see the announcement
  - Run `drush cron`
  - Check the page again with varnish link
    - The announcement should have disappeared
 


[UHF-7449]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ