### PR TITLE
UHF-X Table row and column spans

### DIFF
--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote role aria-* cite class=""> <code> <ul type class=""> <ol start type> <li class=""> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role aria-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <pre> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <span role aria-* lang dir class="">'
+      allowed_html: '<em> <strong> <cite> <blockquote role aria-* cite class=""> <code> <ul type class=""> <ol start type> <li class=""> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <p class=""> <footer class=""> <br> <div role aria-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <pre> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th colspan rowspan> <td colspan rowspan> <tr> <hr> <span role aria-* lang dir class="">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -40,3 +40,11 @@ function helfi_ckeditor_install($is_syncing) : void {
 
   helfi_ckeditor_grant_permissions();
 }
+
+/**
+ * Allow colspan and rowspan attributes to be used in th and td tags.
+ */
+function helfi_ckeditor_update_9001(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_ckeditor');
+}


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Allow `colspan` and `rowspan` attributes to be used in `th` and `td` tags.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_table_row_and_column_spans`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that you can add `colspan` and/or `rowspan` attributes in to a ckeditor table `td` and/or `th` tags
