### PR TITLE
UHF-8290 getCurrentLanguage parameter

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -251,7 +251,8 @@ function helfi_platform_config_tokens(
 
   foreach ($tokens as $name => $original) {
     if ($name === 'page-title-suffix') {
-      $language = Drupal::languageManager()->getCurrentLanguage();
+      $language = Drupal::languageManager()
+        ->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE);
 
       $replacements[$original] = match ($language->getId()) {
         'fi' => 'Helsingin kaupunki',

--- a/modules/hdbt_admin_tools/src/Form/SiteSettings.php
+++ b/modules/hdbt_admin_tools/src/Form/SiteSettings.php
@@ -185,10 +185,10 @@ class SiteSettings extends ConfigFormBase {
   protected function getSiteSettings(): ImmutableConfig|Config|LanguageConfigOverride {
     if (
       $this->languageManager->getDefaultLanguage()->getId() !==
-      $this->languageManager->getCurrentLanguage()->getId()
+      $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId()
     ) {
       return $this->languageManager->getLanguageConfigOverride(
-        $this->languageManager->getCurrentLanguage()->getId(),
+        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId(),
         $this->configName
       );
     }
@@ -245,7 +245,11 @@ class SiteSettings extends ConfigFormBase {
     }
 
     // Save the footer settings to current language only.
-    $this->saveConfiguration('footer_settings', $form_state, $this->languageManager->getCurrentLanguage());
+    $this->saveConfiguration(
+      'footer_settings',
+      $form_state,
+      $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)
+    );
   }
 
   /**

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\helfi_node_announcement\Plugin\Block;
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\node\NodeInterface;
 
 /**
@@ -28,13 +29,16 @@ class AnnouncementsBlock extends AnnouncementsBlockBase {
     ];
 
     $currentEntity = $this->getCurrentPageEntity(array_keys($entityTypeFields));
+    $langcode = $this->languageManager
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
 
     // Get all published announcement nodes.
     $nids = \Drupal::entityQuery('node')
       ->accessCheck(TRUE)
       ->condition('type', 'announcement')
       ->condition('status', NodeInterface::PUBLISHED)
-      ->condition('langcode', $this->languageManager->getCurrentLanguage()->getId())
+      ->condition('langcode', $langcode)
       ->execute();
     $announcementNodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
 

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -11,6 +11,7 @@ use Drupal\helfi_api_base\Environment\Project;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\BundleFieldDefinition;
 use Drupal\helfi_paragraphs_news_list\Entity\NewsFeedParagraph;
@@ -147,7 +148,9 @@ function helfi_paragraphs_news_list_entity_bundle_info_alter(array &$bundles) : 
  * Implements hook_preprocess_paragraph().
  */
 function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables) {
-  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $language_id = \Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
   $environment = \Drupal::configFactory()
     ->get('helfi_paragraphs_news_list.settings')
@@ -185,7 +188,9 @@ function helfi_paragraphs_news_list_preprocess_external_entity__helfi_news__medi
     return;
   }
 
-  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $language_id = \Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
   $environment = \Drupal::configFactory()
     ->get('helfi_paragraphs_news_list.settings')

--- a/modules/helfi_paragraphs_news_list/src/HelfiExternalEntityBase.php
+++ b/modules/helfi_paragraphs_news_list/src/HelfiExternalEntityBase.php
@@ -3,6 +3,7 @@
 namespace Drupal\helfi_paragraphs_news_list;
 
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\external_entities\ExternalEntityInterface;
 use Drupal\external_entities\StorageClient\ExternalEntityStorageClientBase;
@@ -166,7 +167,9 @@ abstract class HelfiExternalEntityBase extends ExternalEntityStorageClientBase {
     array $parameters,
   ) : array {
     try {
-      $langcode = $this->languageManager->getCurrentLanguage()->getId();
+      $langcode = $this->languageManager
+        ->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)
+        ->getId();
       $uri = vsprintf('%s%s?%s', [
         $this->environment->getInternalAddress($langcode),
         $endpoint,

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_react_search;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Cache\CacheBackendInterface;
 use GuzzleHttp\ClientInterface;
@@ -109,7 +110,9 @@ class LinkedEvents extends EventsApiBase {
       'sort' => 'end_time',
       'start' => 'now',
       'super_event_type' => 'umbrella,none',
-      'language' => \Drupal::languageManager()->getCurrentLanguage()->getId(),
+      'language' => \Drupal::languageManager()
+        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getId(),
     ];
 
     $options = array_merge($defaultOptions, $options);

--- a/src/Plugin/Block/ReactAndShare.php
+++ b/src/Plugin/Block/ReactAndShare.php
@@ -3,6 +3,7 @@
 namespace Drupal\helfi_platform_config\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 
 /**
@@ -35,7 +36,7 @@ class ReactAndShare extends BlockBase {
    */
   public function build() {
     $langcode = $this->languageManager
-      ->getCurrentLanguage()
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
       ->getId();
 
     if (!$apikey = getenv('REACT_AND_SHARE_APIKEY_' . strtoupper($langcode))) {


### PR DESCRIPTION
## AnnouncementBlock.php: using type_content on block build method.

Add new announcement with only finnish language. Add another with only english language. You should see the correct announcement always.

## paragraphs_news_list_preprocess: using type_content on preprocess.

Add news list paragraph to content (multiple translations). The urls pointing to front-page instance's news archive should 
 have correct url + lang code.

## LinkedEvents.php: using type_content on requests language parameter. 

Add events paragraph to a page. Fill the info (url for example https://tapahtumat.hel.fi/en/events?text=jooga).
The content should be on correct language.

## React and share: using type_content on block's build method.

Make sure you have REACT_AND_SHARE_APIKEY_{LANGCODE} set as env variable or otherwise the block won't show up. Check test environment for correct key. Now go to any page and you should see the block rendered with correct language. The language is only used to pass correct api key to the javascript.