### PR TITLE
UHF-8274: pathauto max length from 100 to 255

### DIFF
--- a/modules/helfi_base_content/config/rewrite/pathauto.settings.yml
+++ b/modules/helfi_base_content/config/rewrite/pathauto.settings.yml
@@ -4,7 +4,7 @@ punctuation:
   hyphen: 1
 verbose: false
 separator: '-'
-max_length: 100
+max_length: 255
 max_component_length: 100
 transliterate: true
 reduce_ascii: false

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -223,3 +223,12 @@ function helfi_base_content_install($is_syncing) : void {
     $content_lock_settings->set('types', $content_lock_config)->save();
   }
 }
+
+/**
+ * UHF-8274 pathauto max length from 100 to 255.
+ */
+function helfi_base_content_update_9001() : void {
+  // Re-import 'helfi_base_content' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_base_content');
+}


### PR DESCRIPTION
# [UHF-8274](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8274)
Automatically generated path aliases were cut short forcing editor to manually save the generated url aliases

## What was done
Increased max length from 100 to 255

## How to install
* sote is a good choice for instance due to large menu.
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8274_pathauto_maxlength`
* Run `make drush-updb drush-cr`

## How to test
- Create content, add it to menu in a way that generate longest path alias.
- Save content and check that automatically created url alias is longer than 100 characters


[UHF-8274]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ