### PR TITLE
UHF-8220: Screen reader support for quotes

### DIFF
--- a/modules/hdbt_admin_tools/assets/js/plugins/quote/dialogs/quote.js
+++ b/modules/hdbt_admin_tools/assets/js/plugins/quote/dialogs/quote.js
@@ -138,8 +138,6 @@ CKEDITOR.dialog.add('quoteDialog', function (editor) {
       if (!element || !element.hasClass('quote')) {
         element = editor.document.createElement('blockquote');
         element.addClass('quote');
-        element.setAttribute('aria-label', editor.lang.quote.quoteText);
-        element.setAttribute('role', 'region');
         // Flag the insertion mode for later use.
         this.insertMode = true;
       }


### PR DESCRIPTION
# [UHF-8220](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8220)
<!-- What problem does this solve? -->
Attribute `aria-label` is not well supported on `quoteblock` elements. Better would have been `aria-labelledby` but seems not to have common usage in general over internet, so all extra aria attributes are now removed.

## What was done
<!-- Describe what was done -->

* Aria-label and role removed due to bad support on `quoteblock` elements

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8220_Quote_plugin_lang_support`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Create new Quote block with CKEditor and check it doesn't produce any `aria` attributes for the element
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* [UHF-8220: Text paragraph RTL support](https://github.com/City-of-Helsinki/drupal-hdbt/pull/619)


[UHF-8220]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ