### PR TITLE
UHF-7413: Labels visibility to hidden

### DIFF
--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -23,7 +23,7 @@ mode: default
 content:
   field_contact_description:
     type: text_span
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 5
@@ -47,7 +47,7 @@ content:
     region: content
   field_contact_name:
     type: string
-    label: visually_hidden
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -64,7 +64,7 @@ content:
     region: content
   field_contact_title:
     type: string
-    label: visually_hidden
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
@@ -72,14 +72,14 @@ content:
     region: content
   field_email:
     type: email_mailto
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 4
     region: content
   field_phone_number:
     type: telephone_link
-    label: visually_hidden
+    label: hidden
     settings:
       title: ''
     third_party_settings: {  }

--- a/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
+++ b/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Labels visibility to hidden
+ */
+function helfi_paragraphs_contact_card_listing_update_9001() : void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_paragraphs_contact_card_listing');
+}

--- a/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
+++ b/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
@@ -1,7 +1,12 @@
 <?php
 
 /**
- * Labels visibility to hidden
+ * @file
+ * Contains update hooks for 'helfi_paragraphs_contact_card_listing' module.
+ */
+
+/**
+ * Labels visibility to hidden.
  */
 function helfi_paragraphs_contact_card_listing_update_9001() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')


### PR DESCRIPTION
# [UHF-7413](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7413)
<!-- What problem does this solve? -->
This change is related to another PR where translation method of labels were changed.

## What was done
<!-- Describe what was done -->

* Changed Contact Card paragraph's label visibility to hidden.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7413_Config_update`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that `contact_card` paragraph has all fields label marked as "hidden"
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* [UHF-7413: Change translate method](https://github.com/City-of-Helsinki/drupal-hdbt/pull/630)


[UHF-7413]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ