### PR TITLE
UHF-8215: Include news list params to archive url

### DIFF
--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -149,7 +149,9 @@ function helfi_paragraphs_news_list_entity_bundle_info_alter(array &$bundles) : 
  */
 function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables) {
   $paragraph = $variables['paragraph'];
-  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $language_id = \Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
   $environment = \Drupal::configFactory()
     ->get('helfi_paragraphs_news_list.settings')

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -179,10 +179,10 @@ function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables)
   $refFields = [
     'field_helfi_news_groups' => 'groups',
     'field_helfi_news_tags' => 'topic',
-    'field_helfi_news_neighbourhoods' => 'neighbourhoods'
+    'field_helfi_news_neighbourhoods' => 'neighbourhoods',
   ];
 
-  foreach($refFields as $fieldName => $paramKey) {
+  foreach ($refFields as $fieldName => $paramKey) {
     $field = $paragraph->get($fieldName);
 
     if ($field->isEmpty()) {
@@ -191,7 +191,7 @@ function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables)
 
     $terms = $field->referencedEntities();
     foreach ($terms as $term) {
-      // Format name to match app query param format
+      // Format name to match app query param format.
       $params[$paramKey][] = str_replace(' ', '+', strtolower($term->get('title')->value));
     }
   }

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -148,9 +148,8 @@ function helfi_paragraphs_news_list_entity_bundle_info_alter(array &$bundles) : 
  * Implements hook_preprocess_paragraph().
  */
 function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables) {
-  $language_id = \Drupal::languageManager()
-    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
-    ->getId();
+  $paragraph = $variables['paragraph'];
+  $language_id = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $resolver = \Drupal::service('helfi_api_base.environment_resolver');
   $environment = \Drupal::configFactory()
     ->get('helfi_paragraphs_news_list.settings')
@@ -175,8 +174,34 @@ function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables)
       break;
   }
 
+  $archiveUrl = $environment_url . $news_path;
+  $params = [];
+  $refFields = [
+    'field_helfi_news_groups' => 'groups',
+    'field_helfi_news_tags' => 'topic',
+    'field_helfi_news_neighbourhoods' => 'neighbourhoods'
+  ];
+
+  foreach($refFields as $fieldName => $paramKey) {
+    $field = $paragraph->get($fieldName);
+
+    if ($field->isEmpty()) {
+      continue;
+    }
+
+    $terms = $field->referencedEntities();
+    foreach ($terms as $term) {
+      // Format name to match app query param format
+      $params[$paramKey][] = str_replace(' ', '+', strtolower($term->get('title')->value));
+    }
+  }
+
+  if (count($params)) {
+    $archiveUrl .= '?' . urldecode(http_build_query($params));
+  }
+
   // Assign the URL variable to the template.
-  $variables['news_archive_url'] = $environment_url . $news_path;
+  $variables['news_archive_url'] = $archiveUrl;
 }
 
 /**


### PR DESCRIPTION
# [UHF-8215](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8215)
HDBT:
Adds tags to news list component

This branch: 
Adds query string to the news archive link at the bottom of the news list

## What was done

HDBT PR:
* Moved news tags list to its own template for reusability
* Added tags to news-list component
* Added block for tags display to the component template

This PR:
* Added logic for passing query params to news archive

## How to install

* Start up an instance of your choice
* Get the correct branches:
  * `composer require drupal/hdbt:dev-UHF-8215-news-list-params drupal/helfi_platform_config:dev-UHF-8215-news-list-params`
* Run `make drush-cr`

## How to test
* Add or edit a landing page to include paragraph of type "News list"
* Select some taxonomy terms to go along with it from the paragraph options
* View the page. Check for these:
  * Selected taxonomy terms should be displayed as tag pills on the top of the news list paragraph
  * The button link at the bottom of the paragraph should take you to news archive with the selected terms as filters

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/638


[UHF-8215]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ