### PR TITLE
UHF-8088: Include english announcements on non standard languages

### DIFF
--- a/modules/helfi_node_announcement/helfi_node_announcement.info.yml
+++ b/modules/helfi_node_announcement/helfi_node_announcement.info.yml
@@ -8,3 +8,4 @@ dependencies:
   - helfi_node_landing_page:helfi_node_landing_page
   - helfi_node_page:helfi_node_page
   - publication_date:publication_date
+  - helfi_api_base:helfi_api_base

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
@@ -34,8 +34,9 @@ class AnnouncementsBlock extends AnnouncementsBlockBase {
     $currentLangcode = $this->languageManager
       ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
       ->getId();
-    if (!in_array($currentLangcode, ['en', 'fi', 'sv'])) {
-      $langcode = ['en', $currentLangcode];
+
+    if ($this->defaultLanguageResolver->isAltLanguage($currentLangcode)) {
+      $langcode = [$this->defaultLanguageResolver->getFallbackLanguage(), $currentLangcode];
     }
     else {
       $langcode = [$currentLangcode];

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
@@ -46,7 +46,7 @@ class AnnouncementsBlock extends AnnouncementsBlockBase {
       ->accessCheck(TRUE)
       ->condition('type', 'announcement')
       ->condition('status', NodeInterface::PUBLISHED)
-      ->condition('langcode', $langcode , 'IN')
+      ->condition('langcode', $langcode, 'IN')
       ->execute();
     $announcementNodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
 

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
@@ -36,7 +36,10 @@ class AnnouncementsBlock extends AnnouncementsBlockBase {
       ->getId();
 
     if ($this->defaultLanguageResolver->isAltLanguage($currentLangcode)) {
-      $langcode = [$this->defaultLanguageResolver->getFallbackLanguage(), $currentLangcode];
+      $langcode = [
+        $this->defaultLanguageResolver->getFallbackLanguage(),
+        $currentLangcode,
+      ];
     }
     else {
       $langcode = [$currentLangcode];

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlock.php
@@ -29,16 +29,24 @@ class AnnouncementsBlock extends AnnouncementsBlockBase {
     ];
 
     $currentEntity = $this->getCurrentPageEntity(array_keys($entityTypeFields));
-    $langcode = $this->languageManager
+
+    // Also fetch english announcements for languages with non standard support.
+    $currentLangcode = $this->languageManager
       ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
       ->getId();
+    if (!in_array($currentLangcode, ['en', 'fi', 'sv'])) {
+      $langcode = ['en', $currentLangcode];
+    }
+    else {
+      $langcode = [$currentLangcode];
+    }
 
     // Get all published announcement nodes.
     $nids = \Drupal::entityQuery('node')
       ->accessCheck(TRUE)
       ->condition('type', 'announcement')
       ->condition('status', NodeInterface::PUBLISHED)
-      ->condition('langcode', $langcode)
+      ->condition('langcode', $langcode , 'IN')
       ->execute();
     $announcementNodes = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
 

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlockBase.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlockBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -41,6 +42,13 @@ abstract class AnnouncementsBlockBase extends BlockBase implements ContainerFact
   protected LanguageManagerInterface $languageManager;
 
   /**
+   * Default language resolver.
+   *
+   * @var \Drupal\helfi_api_base\Language\DefaultLanguageResolver
+   */
+  protected DefaultLanguageResolver $defaultLanguageResolver;
+
+  /**
    * Constructs a new AnnouncementsBlock instance.
    *
    * @param array $configuration
@@ -55,6 +63,8 @@ abstract class AnnouncementsBlockBase extends BlockBase implements ContainerFact
    *   The entity type manager.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
+   * @param \Drupal\helfi_api_base\Language\DefaultLanguageResolver @default_language_resolver
+   *   Default language resolver.
    */
   public function __construct(
     array $configuration,
@@ -62,12 +72,14 @@ abstract class AnnouncementsBlockBase extends BlockBase implements ContainerFact
     $plugin_definition,
     RouteMatchInterface $route_match,
     EntityTypeManagerInterface $entity_type_manager,
-    LanguageManagerInterface $language_manager
+    LanguageManagerInterface $language_manager,
+    DefaultLanguageResolver $default_language_resolver
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->routeMatch = $route_match;
     $this->entityTypeManager = $entity_type_manager;
     $this->languageManager = $language_manager;
+    $this->defaultLanguageResolver = $default_language_resolver;
   }
 
   /**
@@ -77,7 +89,8 @@ abstract class AnnouncementsBlockBase extends BlockBase implements ContainerFact
     return new static($configuration, $plugin_id, $plugin_definition,
       $container->get('current_route_match'),
       $container->get('entity_type.manager'),
-      $container->get('language_manager')
+      $container->get('language_manager'),
+      $container->get('helfi_api_base.default_language_resolver'),
     );
   }
 

--- a/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlockBase.php
+++ b/modules/helfi_node_announcement/src/Plugin/Block/AnnouncementsBlockBase.php
@@ -63,7 +63,7 @@ abstract class AnnouncementsBlockBase extends BlockBase implements ContainerFact
    *   The entity type manager.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
-   * @param \Drupal\helfi_api_base\Language\DefaultLanguageResolver @default_language_resolver
+   * @param \Drupal\helfi_api_base\Language\DefaultLanguageResolver $default_language_resolver
    *   Default language resolver.
    */
   public function __construct(


### PR DESCRIPTION
# [UHF-8088](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088)

## What was done
Modifies announcement loading logic to include english announcements on languages with non standard support.

## How to test
* Testing instructions in Etusivu instance PR: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/351
* [ ] Check that code follows our standards
* [ ] Could this change have unforeseen effects on other instances and sites?

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/351
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/646
* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/31
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/103


[UHF-8088]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ