### PR TITLE
UHF-6469: Converted banner design from centered to left

### DIFF
--- a/modules/helfi_paragraphs_banner/config/install/field.field.paragraph.banner.field_banner_design.yml
+++ b/modules/helfi_paragraphs_banner/config/install/field.field.paragraph.banner.field_banner_design.yml
@@ -16,7 +16,7 @@ required: true
 translatable: false
 default_value:
   -
-    value: align-center
+    value: align-left
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/modules/helfi_paragraphs_banner/config/install/field.field.paragraph.banner.field_banner_title.yml
+++ b/modules/helfi_paragraphs_banner/config/install/field.field.paragraph.banner.field_banner_title.yml
@@ -10,7 +10,7 @@ entity_type: paragraph
 bundle: banner
 label: Title
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/helfi_paragraphs_banner/config/install/field.storage.paragraph.field_banner_design.yml
+++ b/modules/helfi_paragraphs_banner/config/install/field.storage.paragraph.field_banner_design.yml
@@ -11,14 +11,8 @@ type: list_string
 settings:
   allowed_values:
     -
-      value: align-center
-      label: 'Aligned to the center'
-    -
       value: align-left
       label: 'Aligned to the left'
-    -
-      value: align-center-secondary
-      label: 'Aligned to the center, secondary color'
     -
       value: align-left-secondary
       label: 'Aligned to the left, secondary color'

--- a/modules/helfi_paragraphs_banner/config/install/language/fi/field.storage.paragraph.field_banner_design.yml
+++ b/modules/helfi_paragraphs_banner/config/install/language/fi/field.storage.paragraph.field_banner_design.yml
@@ -1,10 +1,6 @@
 settings:
   allowed_values:
     -
-      label: Keskitetty
-    -
       label: 'Tasattu vasemmalle'
-    -
-      label: 'Keskitetty, toissijainen väri'
     -
       label: 'Tasattu vasemmalle, toissijainen väri'

--- a/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
+++ b/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
@@ -18,7 +18,7 @@ function helfi_paragraphs_banner_update_9001() : void {
     ->condition('type', 'banner')
     ->condition('field_banner_design', [
       'align-center',
-      'align-center-secondary'
+      'align-center-secondary',
     ], "IN")
     ->execute();
 

--- a/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
+++ b/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains installation tasks for helfi_paragraphs_banner module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * UHF-6469: Remove centered banner designs and convert them to be left aligned.
+ */
+function helfi_paragraphs_banner_update_9001() : void {
+  // Get all paragraphs with centered design.
+  $pids = \Drupal::entityQuery('paragraph')
+  ->condition('type', 'banner')
+  ->condition('field_banner_design', ['align-center', 'align-center-secondary'], "IN")
+  ->execute();
+
+  $paragraphs = Paragraph::loadMultiple($pids);
+
+  // Convert to left aligned design.
+  foreach ($paragraphs as $paragraph) {
+    $field_update_map = [
+      'align-center' => 'align-left',
+      'align-center-secondary' => 'align-left-secondary',
+    ];
+
+    $paragraph
+      ->set('field_banner_design', $field_update_map[$paragraph->field_banner_design->value])
+      ->save();
+  }
+
+  // Re-import 'helfi_paragraphs_banner' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+  ->update('helfi_paragraphs_banner');
+}

--- a/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
+++ b/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
@@ -15,9 +15,9 @@ use Drupal\paragraphs\Entity\Paragraph;
 function helfi_paragraphs_banner_update_9001() : void {
   // Get all paragraphs with centered design.
   $pids = \Drupal::entityQuery('paragraph')
-  ->condition('type', 'banner')
-  ->condition('field_banner_design', ['align-center', 'align-center-secondary'], "IN")
-  ->execute();
+    ->condition('type', 'banner')
+    ->condition('field_banner_design', ['align-center', 'align-center-secondary'], "IN")
+    ->execute();
 
   $paragraphs = Paragraph::loadMultiple($pids);
 
@@ -35,5 +35,5 @@ function helfi_paragraphs_banner_update_9001() : void {
 
   // Re-import 'helfi_paragraphs_banner' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
-  ->update('helfi_paragraphs_banner');
+    ->update('helfi_paragraphs_banner');
 }

--- a/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
+++ b/modules/helfi_paragraphs_banner/helfi_paragraphs_banner.install
@@ -16,7 +16,10 @@ function helfi_paragraphs_banner_update_9001() : void {
   // Get all paragraphs with centered design.
   $pids = \Drupal::entityQuery('paragraph')
     ->condition('type', 'banner')
-    ->condition('field_banner_design', ['align-center', 'align-center-secondary'], "IN")
+    ->condition('field_banner_design', [
+      'align-center',
+      'align-center-secondary'
+    ], "IN")
     ->execute();
 
   $paragraphs = Paragraph::loadMultiple($pids);


### PR DESCRIPTION
# [UHF-6469](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6469)
<!-- What problem does this solve? -->
We are getting rid of center aligned banners. Banner title needs to be required.

## What was done
<!-- Describe what was done -->

* Made banner title required
* Added update hook to update the banner design and re-import the configs.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Before composer require, find or create one page with banner that has centered design and one that has centered secondary design.
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-6469_Banner-updates`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the centered designs in banners are converted to left aligned design after `updb`.
* [ ] Check that the banner title is required.
* [ ] Check that code follows our standards.


[UHF-6469]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-6469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ