### PR TITLE
UHF-8358 entity usage permission

### DIFF
--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -89,6 +89,8 @@ function helfi_base_content_grant_permissions() : void {
       'view the administration theme',
       // @taxonomy.
       'access taxonomy overview',
+      // @entity_usage
+      'access entity usage statistics',
     ],
     'content_producer' => [
       // @content_translation.
@@ -120,6 +122,8 @@ function helfi_base_content_grant_permissions() : void {
       'access taxonomy overview',
       // @view_unpublished.
       'view any unpublished content',
+      // @entity_usage
+      'access entity usage statistics',
     ],
     'editor' => [
       // @content_translation.
@@ -167,6 +171,8 @@ function helfi_base_content_grant_permissions() : void {
       'access taxonomy overview',
       // @view_unpublished.
       'view any unpublished content',
+      // @entity_usage
+      'access entity usage statistics',
     ],
     'read_only' => [
       // @node.
@@ -231,4 +237,11 @@ function helfi_base_content_update_9001() : void {
   // Re-import 'helfi_base_content' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_base_content');
+}
+
+/**
+ * UHF-8353 give editors entity usage permission.
+ */
+function helfi_base_content_update_9002(): void {
+  helfi_base_content_grant_permissions();
 }

--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -18,18 +18,21 @@ function helfi_user_roles_grant_permissions() : void {
       'administer users',
       'cancel account',
       'change own username',
+      'access entity usage statistics',
     ],
     'content_producer' => [
       // @user.
       'access user profiles',
       'cancel account',
       'change own username',
+      'access entity usage statistics',
     ],
     'editor' => [
       // @user.
       'access user profiles',
       'cancel account',
       'change own username',
+      'access entity usage statistics',
     ],
   ];
   helfi_platform_config_grant_permissions($permissions);

--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -50,3 +50,10 @@ function helfi_user_roles_install($is_syncing) : void {
 
   helfi_user_roles_grant_permissions();
 }
+
+/**
+ * UHF-8353 give editors entity usage permission.
+ */
+function helfi_user_roles__update_9001(): void {
+  helfi_user_roles_grant_permissions();
+}

--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -54,6 +54,6 @@ function helfi_user_roles_install($is_syncing) : void {
 /**
  * UHF-8353 give editors entity usage permission.
  */
-function helfi_user_roles__update_9001(): void {
+function helfi_user_roles_update_9001(): void {
   helfi_user_roles_grant_permissions();
 }

--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -47,5 +47,3 @@ function helfi_user_roles_install($is_syncing) : void {
 
   helfi_user_roles_grant_permissions();
 }
-
-

--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -18,21 +18,18 @@ function helfi_user_roles_grant_permissions() : void {
       'administer users',
       'cancel account',
       'change own username',
-      'access entity usage statistics',
     ],
     'content_producer' => [
       // @user.
       'access user profiles',
       'cancel account',
       'change own username',
-      'access entity usage statistics',
     ],
     'editor' => [
       // @user.
       'access user profiles',
       'cancel account',
       'change own username',
-      'access entity usage statistics',
     ],
   ];
   helfi_platform_config_grant_permissions($permissions);
@@ -51,9 +48,4 @@ function helfi_user_roles_install($is_syncing) : void {
   helfi_user_roles_grant_permissions();
 }
 
-/**
- * UHF-8353 give editors entity usage permission.
- */
-function helfi_user_roles_update_9001(): void {
-  helfi_user_roles_grant_permissions();
-}
+


### PR DESCRIPTION
# [UHF-8358](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8358)
Allow editors, admins and content_producer to see entity usage statistics

## What was done
Updated permissions

## How to install
* Test this with a site with plenty of content, for example sote.
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8358_entity_usage_permission`
* Run `make drush-updb drush-cr`

## How to test
- Log in as user with editor, admin or content_producer role (you can use for example drush uli --uid=user-id-goes-here)
- Go to `/admin/content/paragraphs`
- On the content table, under 'Used'-title: 
  - The number should be a link
  - User should have permission to access the link


[UHF-8358]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ