### PR TITLE
UHF-8135: Field label translations

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -31,7 +31,7 @@ function hdbt_admin_tools_install(): void {
 /**
  * UHF-8135: Set super admin (UID1) preferred admin pages langcode to NULL.
  */
-function hdbt_admin_tools_update_9001() : void {
+function hdbt_admin_tools_update_9002() : void {
   $user = User::load(1);
 
   if ($user && !empty($user->getPreferredAdminLangcode(FALSE))) {

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\user\Entity\User;
+
 /**
  * Installs Helfi admin tools module.
  */
@@ -24,4 +26,15 @@ function hdbt_admin_tools_install(): void {
     $ignored[] = $config_ignore;
   }
   $config->set('ignored_config_entities', $ignored)->save();
+}
+
+/**
+ * UHF-8135: Set super admin (UID1) preferred admin pages langcode to NULL.
+ */
+function hdbt_admin_tools_update_9001() : void {
+  $user = User::load(1);
+
+  if ($user && !empty($user->getPreferredAdminLangcode(FALSE))) {
+    $user->set('preferred_admin_langcode', '')->save();
+  }
 }


### PR DESCRIPTION
# [UHF-8135](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8135)
<!-- What problem does this solve? -->

**_Work in progress..._**
See: https://www.drupal.org/project/drupal/issues/3221375

## What was done
<!-- Describe what was done -->

* Added an update hook to set the UID1 preferred admin pages lang code to null. This should fix issues with rendering field labels in wrong languages when editing content.

## How to install
* Make sure your etusivu instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`

## How to reproduce the bug (in Etusivu-instance)
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as UID1 and rebuild the caches from the UI (drop -> flush all caches)
* [ ] In incognito, Log in as a normal editor - for example `drush uli --uid=2`
   * [ ] Go to https://helfi-etusivu.docker.so/fi/user/2/edit and check that the **Administration pages language** is Finnish
   * [ ] Go to create a news item https://helfi-etusivu.docker.so/fi/node/add/news_item
   * [ ] Check the field labels - some of the field labels are in English and some are in Finnish. [See this image for an example.](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/assets/1712902/667b0f75-d54d-402b-8a6b-2dc99387a2ae)

## Update the code base
* Update the Helfi Platform config, Helfi navigation and HDBT Admin
    * `composer require drupal/helfi_platform_config:dev-UHF-8135_field_label_translations drupal/helfi_navigation:dev-UHF-8135_field_label_translations drupal/hdbt_admin:dev-UHF-8135_field_label_translations`
* Run `make shell` and in shell run `drush updb -y; drush locale:check; drush locale:update; drush cr` 
   * This is a good time to go for a coffee or somn.. it takes a while ☕ ⏳  

## How to test (in Etusivu-instance)
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] In incognito, Go to create a news item https://helfi-etusivu.docker.so/fi/node/add/news_item and check that the field labels are in Finnish
* [ ] ...

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/32/files
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/217/files

[UHF-8135]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ