### PR TITLE
UHF-8460: Term page permissions

### DIFF
--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -40,3 +40,8 @@ services:
       - '@config.installer'
       - '@config_rewrite.config_rewriter'
       - '@module_handler'
+
+  helfi_platform_config.term_route_subscriber:
+    class: Drupal\helfi_platform_config\Routing\TermRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/Routing/TermRouteSubscriber.php
+++ b/src/Routing/TermRouteSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\helfi_platform_config\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+use Drupal\Core\Routing\RoutingEvents;  
+
+/**
+ * Class TermRouteSubscriber.
+ *
+ * A simple RouteSubscriber to alter term page routes.
+ *
+ * @package Drupal\helfi_platform_config\Routing
+ */
+class TermRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    $viewsRoute = $collection->get('view.taxonomy_term.page_1');
+    $canonicalRoute = $collection->get('entity.taxonomy_term.canonical');
+
+    if ($viewsRoute) {
+      $viewsRoute->setRequirements([
+        '_role' => 'authenticated',
+      ]);
+    }
+
+    if ($canonicalRoute) {
+      $canonicalRoute->setRequirements([
+        '_role' => 'authenticated',
+      ]);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Run after the RouteSubscriber of Views, which has priority -175.
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -180];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
# [UHF-8460](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8460)
<!-- What problem does this solve? -->
Anonymous users have access to the term pages, e.g. `/taxonomy/term/{term_id}`.

## What was done
<!-- Describe what was done -->

* Added a role check by altering the term page routes.

## How to install
* Make sure your instance (in this example Rekry) is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8460_Term-page-permissions`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] As anonymous user, try to access a term page, e.g. https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/taxonomy/term/88. It should lead to 403 page.
* [ ] As logged in user (any role) the same page should be working fine.
