### PR TITLE
UHF-8404: Blockquote attribute cleansing

### DIFF
--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -48,3 +48,57 @@ function helfi_ckeditor_update_9001(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_ckeditor');
 }
+
+/**
+ * UHF-8404 Reconstruct CKEditor generated blockquote elements.
+ */
+function helfi_ckeditor_update_9002(): void {
+  $entity_type_manager = Drupal::entityTypeManager();
+  $field_storage = $entity_type_manager->getStorage('field_config');
+
+  // Load all field configurations.
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  foreach ($field_storage->loadMultiple() as $field_config) {
+
+    // Go through each field and check for long text fields (html formatted).
+    if ($field_config->getType() === 'text_long') {
+      $field_storage_definition = $field_config->getFieldStorageDefinition();
+      $entity_type = $field_config->getTargetEntityTypeId();
+
+      /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
+      $table_mapping = $entity_type_manager->getStorage($entity_type)->getTableMapping();
+
+      // Get current field's table name and column.
+      $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
+      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+
+      // Search for <blockquote> elements containing aria-label and
+      // role="region" attributes. Remove them if found.
+      $regex = '<blockquote([^>]*)aria-label="[^"]*"([^>]*) role="region"([^>]*)>';
+      $query = \Drupal::database()->select($table_name, 'v')
+        ->distinct()
+        ->fields('v', ['entity_id', $column])
+        ->condition($column, $regex, 'REGEXP');
+
+      $query_result = $query->execute()->fetchAll();
+
+      if (!empty($query_result)) {
+        \Drupal::messenger()->addMessage(
+          t('Removed aria-label and role="region" attributes from @number blockquote elements found in %column.',
+          [
+            '@number' => count($query_result),
+            '%column' => str_replace('/', '', $column),
+          ]
+        ));
+        $replacement = '<blockquote$1$2$3>';
+        $update = \Drupal::database()->update($table_name);
+        $update->expression(
+          $column,
+          "REGEXP_REPLACE($column, :pattern, :replacement)",
+          [':pattern' => $regex, ':replacement' => $replacement]
+        );
+        $result = $update->execute();
+      }
+    }
+  }
+}

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -70,10 +70,10 @@ function helfi_ckeditor_update_9002(): void {
 
       // Get current field's table name and column.
       $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
-      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+      $column = $table_mapping->getFieldColumnName($field_storage_definition, 'value');
 
       // Search for <blockquote> elements containing aria-label and
-      // role="region" attributes. Remove them if found.
+      // role="region" attributes...
       $regex = '<blockquote([^>]*)aria-label="[^"]*"([^>]*) role="region"([^>]*)>';
       $query = \Drupal::database()->select($table_name, 'v')
         ->distinct()
@@ -82,6 +82,7 @@ function helfi_ckeditor_update_9002(): void {
 
       $query_result = $query->execute()->fetchAll();
 
+      // ...and remove the attributes if found.
       if (!empty($query_result)) {
         \Drupal::messenger()->addMessage(
           t('Removed aria-label and role="region" attributes from @number blockquote elements found in %column.',

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -74,31 +74,37 @@ function helfi_ckeditor_update_9002(): void {
 
       // Search for <blockquote> elements containing aria-label and
       // role="region" attributes...
-      $regex = '<blockquote([^>]*)aria-label="[^"]*"([^>]*) role="region"([^>]*)>';
-      $query = \Drupal::database()->select($table_name, 'v')
-        ->distinct()
-        ->fields('v', ['entity_id', $column])
-        ->condition($column, $regex, 'REGEXP');
+      $regex_expressions = [
+        'aria-label' => '<blockquote(.*?)aria-label="[^"]*"(.*?)>',
+        'role' => '<blockquote(.*?)role="[^"]*"(.*?)>',
+      ];
 
-      $query_result = $query->execute()->fetchAll();
+      foreach ($regex_expressions as $attribute => $regex) {
+        $query = \Drupal::database()->select($table_name, 'v')
+          ->distinct()
+          ->fields('v', ['entity_id', $column])
+          ->condition($column, $regex, 'REGEXP');
 
-      // ...and remove the attributes if found.
-      if (!empty($query_result)) {
-        \Drupal::messenger()->addMessage(
-          t('Removed aria-label and role="region" attributes from @number blockquote elements found in %column.',
-          [
-            '@number' => count($query_result),
-            '%column' => str_replace('/', '', $column),
-          ]
-        ));
-        $replacement = '<blockquote$1$2$3>';
-        $update = \Drupal::database()->update($table_name);
-        $update->expression(
-          $column,
-          "REGEXP_REPLACE($column, :pattern, :replacement)",
-          [':pattern' => $regex, ':replacement' => $replacement]
-        );
-        $result = $update->execute();
+        $query_result = $query->execute()->fetchAll();
+
+        if (!empty($query_result)) {
+          \Drupal::messenger()->addMessage(
+            t('Removed @attribute attribute from @number blockquote elements found in @column.',
+              [
+                '@number' => count($query_result),
+                '@column' => $column,
+                '@attribute' => $attribute,
+              ]
+            ));
+          $replacement = '<blockquote\\1\\2>';
+          $update = \Drupal::database()->update($table_name);
+          $update->expression(
+            $column,
+            "REGEXP_REPLACE($column, :pattern, :replacement)",
+            [':pattern' => $regex, ':replacement' => $replacement]
+          );
+          $result = $update->execute();
+        }
       }
     }
   }


### PR DESCRIPTION
# [UHF-8404](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8404)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added update hook to remove unwanted aria-label and role=region attributes from blockquote elements in long text fields.

## Before installing
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* [ ] Go to edit some page with text paragraph
* [ ] Create a "broken" blockquote element manually 
```
<blockquote aria-label="Quote" class="quote" role="region"><p class="quote__text">This is quote text</p>
<footer class="quote__author"><cite>Your name</cite></footer></blockquote>
```
* [ ] Save the page

## How to install
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8404`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
* [ ] Go to that page you've created and check that the markup for the broken blockquote is some what like this
```
<blockquote class="quote"><p class="quote__text">This is quote text</p>
<footer class="quote__author"><cite>Your name</cite></footer></blockquote>
```
* [ ] Check the code


[UHF-8404]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ