### PR TITLE
UHF-8479: Set service list search as grey bg paragraph

### DIFF
--- a/src/Plugin/Block/HeroBlock.php
+++ b/src/Plugin/Block/HeroBlock.php
@@ -49,7 +49,7 @@ class HeroBlock extends ContentBlockBase {
         $paragraph = $entity->get('field_content')->entity;
         $paragraphs_with_grey_bg = [
           'unit_search',
-          'service_list_search'
+          'service_list_search',
         ];
         foreach ($paragraphs_with_grey_bg as $paragraph_with_grey_bg) {
           if (

--- a/src/Plugin/Block/HeroBlock.php
+++ b/src/Plugin/Block/HeroBlock.php
@@ -46,8 +46,14 @@ class HeroBlock extends ContentBlockBase {
         // Check if the content field first paragraph is Unit search
         // and add classes accordingly.
         $paragraph = $entity->get('field_content')->entity;
-        if (!empty($paragraph) && $paragraph->getType() === 'unit_search') {
-          $first_paragraph_grey = 'has-first-gray-bg-block';
+        $paragraphs_with_grey_bg = [
+          'unit_search',
+          'service_list_search'
+        ];
+        foreach ($paragraphs_with_grey_bg as $paragraph_with_grey_bg) {
+          if (!empty($paragraph) && $paragraph->getType() === $paragraph_with_grey_bg) {
+            $first_paragraph_grey = 'has-first-gray-bg-block';
+          }
         }
       }
 

--- a/src/Plugin/Block/HeroBlock.php
+++ b/src/Plugin/Block/HeroBlock.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_platform_config\Plugin\Block;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\helfi_platform_config\EntityVersionMatcher;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Provides a 'HeroBlock' block.
@@ -51,7 +52,10 @@ class HeroBlock extends ContentBlockBase {
           'service_list_search'
         ];
         foreach ($paragraphs_with_grey_bg as $paragraph_with_grey_bg) {
-          if (!empty($paragraph) && $paragraph->getType() === $paragraph_with_grey_bg) {
+          if (
+            $paragraph instanceof ParagraphInterface &&
+            $paragraph->getType() === $paragraph_with_grey_bg
+          ) {
             $first_paragraph_grey = 'has-first-gray-bg-block';
           }
         }


### PR DESCRIPTION
# [UHF-8479](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8479)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Set service list search as grey background paragraph so that when it is added right after hero the grey background is moved under the hero block

## How to install
* Make sure your instance, for example päätöksenteko ja hallinto, is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8479_service_list_search_next_to_hero`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add landing page with a hero or edit one and set "Service list search" as first paragraph in the content right after the hero.
* [ ] Now check that the block with its grey background goes nicely under the hero and there isn't a white gap between the hero and the Service list search element.
* [ ] Check that code follows our standards


[UHF-8479]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ