### PR TITLE
UHF-8390 D10 deprecation

### DIFF
--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -15,7 +15,7 @@ services:
 
   helfi_platform_config.translation_writer_command:
     class: Drupal\helfi_platform_config\Commands\TranslationWriterCommand
-    arguments: ['@language_manager','@string_translation', '@file_system']
+    arguments: ['@language_manager','@string_translation', '@file_system', '@extension.path.resolver']
     tags:
       - { name: drush.command }
 

--- a/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
+++ b/modules/helfi_global_announcement/src/Plugin/ExternalEntities/StorageClient/Announcements.php
@@ -14,6 +14,7 @@ use Drupal\helfi_api_base\Environment\Project;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Utils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -171,9 +172,7 @@ final class Announcements extends ExternalEntityStorageClientBase {
         \GuzzleHttp\http_build_query($parameters),
       ]);
       $content = $this->client->request('GET', $uri);
-
-      $json = \GuzzleHttp\json_decode($content->getBody()->getContents(), TRUE);
-
+      $json = Utils::jsonDecode($content->getBody()->getContents(), TRUE);
       return $json['data'];
     }
     catch (RequestException | GuzzleException $e) {

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.info.yml
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.info.yml
@@ -1,7 +1,7 @@
 name: 'HELfi Paragraphs: News list'
 type: module
 package: Custom
-core_version_requirement: ^9.3
+core_version_requirement: ^9.3 || ^10
 dependencies:
   - allowed_formats:allowed_formats
   - drupal:entity

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -65,6 +65,7 @@ function helfi_paragraphs_news_list_paragraph_view(
     }
 
     $query->sort('published_at', 'DESC');
+    $query->accessCheck(FALSE);
 
     $ids = $query->execute();
     $entities = $storage->loadMultiple(array_keys($ids));

--- a/modules/helfi_paragraphs_news_list/src/HelfiExternalEntityBase.php
+++ b/modules/helfi_paragraphs_news_list/src/HelfiExternalEntityBase.php
@@ -12,6 +12,7 @@ use Drupal\helfi_api_base\Environment\Project;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Utils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -179,7 +180,7 @@ abstract class HelfiExternalEntityBase extends ExternalEntityStorageClientBase {
       $content = $this->client->request('GET', $uri, [
         'curl' => [CURLOPT_TCP_KEEPALIVE => TRUE],
       ]);
-      $json = \GuzzleHttp\json_decode($content->getBody()->getContents(), TRUE);
+      $json = Utils::jsonDecode($content->getBody()->getContents(), TRUE);
       return $json['data'];
     }
     catch (RequestException | GuzzleException $e) {

--- a/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/News.php
+++ b/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/News.php
@@ -14,6 +14,7 @@ use Drupal\helfi_api_base\Environment\Project;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Utils;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -242,7 +243,7 @@ final class News extends ExternalEntityStorageClientBase {
       ]);
       $content = $this->client->request('GET', $uri);
 
-      $json = \GuzzleHttp\json_decode($content->getBody()->getContents(), TRUE);
+      $json = Utils::jsonDecode($content->getBody()->getContents(), TRUE);
 
       return array_map(function (array $item) use ($json) : array {
         // Resolve and place all relationship data under corresponding parent

--- a/src/Commands/RemoveNonHelsinkiTPRUnitsCommands.php
+++ b/src/Commands/RemoveNonHelsinkiTPRUnitsCommands.php
@@ -42,6 +42,7 @@ final class RemoveNonHelsinkiTPRUnitsCommands extends DrushCommands {
     $unit_ids = $entityStorage->getQuery()
       ->condition('address__locality', 'Helsinki', '!=')
       ->condition('address__locality', 'Helsingfors', '!=')
+      ->accessCheck(FALSE)
       ->execute();
 
     $unit_count = 0;

--- a/src/Commands/TranslationWriterCommand.php
+++ b/src/Commands/TranslationWriterCommand.php
@@ -29,7 +29,7 @@ class TranslationWriterCommand extends DrushCommands {
    *   The translation manager.
    * @param \Drupal\Core\File\FileSystemInterface $fileSystem
    *   The filesystem.
-   * @param \Drupal\Core\Extension\ExtensionPathResolver
+   * @param \Drupal\Core\Extension\ExtensionPathResolver $extensionPathResolver
    *   The Extension path resolver.
    */
   public function __construct(

--- a/src/Commands/TranslationWriterCommand.php
+++ b/src/Commands/TranslationWriterCommand.php
@@ -29,6 +29,8 @@ class TranslationWriterCommand extends DrushCommands {
    *   The translation manager.
    * @param \Drupal\Core\File\FileSystemInterface $fileSystem
    *   The filesystem.
+   * @param \Drupal\Core\Extension\ExtensionPathResolver
+   *   The Extension path resolver.
    */
   public function __construct(
     protected LanguageManager $languageManager,
@@ -59,7 +61,7 @@ class TranslationWriterCommand extends DrushCommands {
    * Get path for the feature.
    */
   private function getModulePath($module): string {
-    return $this->extensionPathResolver->getPath('module', 'helfi_platform_config'). '/helfi_features/' . $module;
+    return $this->extensionPathResolver->getPath('module', 'helfi_platform_config') . '/helfi_features/' . $module;
   }
 
   /**

--- a/src/Commands/TranslationWriterCommand.php
+++ b/src/Commands/TranslationWriterCommand.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_platform_config\Commands;
 
 use Drupal\Component\Gettext\PoItem;
 use Drupal\Component\Gettext\PoStreamWriter;
+use Drupal\Core\Extension\ExtensionPathResolver;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Language\LanguageManager;
 use Drupal\Core\StringTranslation\TranslationManager;
@@ -18,26 +19,6 @@ use Symfony\Component\Yaml\Yaml;
  * @package Drupal\drush9_custom_commands\Commands
  */
 class TranslationWriterCommand extends DrushCommands {
-  /**
-   * The language manager.
-   *
-   * @var \Drupal\Core\Language\LanguageManager
-   */
-  protected $languageManager;
-
-  /**
-   * The translation manager.
-   *
-   * @var \Drupal\Core\StringTranslation\TranslationManager
-   */
-  protected $translationManager;
-
-  /**
-   * The file system.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
 
   /**
    * Constructor.
@@ -49,10 +30,12 @@ class TranslationWriterCommand extends DrushCommands {
    * @param \Drupal\Core\File\FileSystemInterface $fileSystem
    *   The filesystem.
    */
-  public function __construct(LanguageManager $languageManager, TranslationManager $translationManager, FileSystemInterface $fileSystem) {
-    $this->languageManager = $languageManager;
-    $this->translationManager = $translationManager;
-    $this->fileSystem = $fileSystem;
+  public function __construct(
+    protected LanguageManager $languageManager,
+    protected TranslationManager $translationManager,
+    protected FileSystemInterface $fileSystem,
+    protected ExtensionPathResolver $extensionPathResolver
+  ) {
   }
 
   /**
@@ -76,7 +59,7 @@ class TranslationWriterCommand extends DrushCommands {
    * Get path for the feature.
    */
   private function getModulePath($module): string {
-    return drupal_get_path('module', 'helfi_platform_config') . '/helfi_features/' . $module;
+    return $this->extensionPathResolver->getPath('module', 'helfi_platform_config'). '/helfi_features/' . $module;
   }
 
   /**


### PR DESCRIPTION
Entity query access checks
Guzzle::jsonDecode to utils::jsonDecode
ProphesizeTrait for prophesize method

How to test:

run `composer require drupal/helfi_platform_config:dev-UHF-8390`
run `composer require drupal/upgrade_status` and `drush en -y upgrade_status`
run `drush upgrade_status:analyze helfi_platform_config`
You should only see deprecation errors from prophecy / prophesize method.