### PR TITLE
UHF-8604: Readded published or admin filter

### DIFF
--- a/modules/helfi_tpr_config/config/install/views.view.unit_services.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.unit_services.yml
@@ -191,46 +191,6 @@ display:
           transform_dash: false
           break_phrase: false
       filters:
-        content_translation_status:
-          id: content_translation_status
-          table: tpr_service_field_data
-          field: content_translation_status
-          relationship: services_target_id
-          group_type: group
-          admin_label: ''
-          entity_type: tpr_service
-          entity_field: content_translation_status
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
         langcode:
           id: langcode
           table: tpr_service_field_data
@@ -261,6 +221,45 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status_extra:
+          id: status_extra
+          table: tpr_service_field_data
+          field: status_extra
+          relationship: services_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: tpr_service
+          plugin_id: tpr_status
+          operator: '='
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
           is_grouped: false
           group_info:
             label: ''
@@ -308,10 +307,12 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags:
         - 'config:core.entity_view_display.tpr_service.tpr_service.default'
         - 'config:core.entity_view_display.tpr_service.tpr_service.teaser'
+        - 'config:core.entity_view_display.tpr_service.tpr_service.teaser_search_result'
   unit_services:
     id: unit_services
     display_title: Block
@@ -326,7 +327,9 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - user.permissions
       tags:
         - 'config:core.entity_view_display.tpr_service.tpr_service.default'
         - 'config:core.entity_view_display.tpr_service.tpr_service.teaser'
+        - 'config:core.entity_view_display.tpr_service.tpr_service.teaser_search_result'

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -209,3 +209,11 @@ function helfi_tpr_config_update_9036(): void {
 function helfi_tpr_config_update_9037(): void {
   helfi_platform_config_update_paragraph_target_types();
 }
+
+/**
+ * Update tpr views.
+ */
+function helfi_tpr_config_update_9038(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-8604](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8604)

The filter was removed in https://github.com/City-of-Helsinki/drupal-helfi-platform-config/commit/b191aefb93a638f5623129e2077675b3d54c9b6d, but it seemed to be a false positive. 

The view is actually cached, but the `X-Dynamic-Cache` header value itself was cached in page_cache.


[UHF-8604]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ