### PR TITLE
UHF-X: Remove references to handorgel library that is no longer used

### DIFF
--- a/modules/helfi_toc/assets/js/tableOfContents.js
+++ b/modules/helfi_toc/assets/js/tableOfContents.js
@@ -38,8 +38,7 @@
         ':not(.breadcrumb__container *)' +
         ':not(#helfi-toc-table-of-contents *)' +
         ':not(.embedded-content-cookie-compliance *)' +
-        ':not(.react-and-share-cookie-compliance *)' +
-        ':not(.handorgel__header)';
+        ':not(.react-and-share-cookie-compliance *)'
 
       const titleComponents = [
         'h2'+exclusions,
@@ -47,7 +46,6 @@
         'h4'+exclusions,
         'h5'+exclusions,
         'h6'+exclusions,
-        '.handorgel__header > button',
       ];
 
       // Craft table of contents.

--- a/modules/helfi_toc/assets/js/tableOfContents.js
+++ b/modules/helfi_toc/assets/js/tableOfContents.js
@@ -38,7 +38,8 @@
         ':not(.breadcrumb__container *)' +
         ':not(#helfi-toc-table-of-contents *)' +
         ':not(.embedded-content-cookie-compliance *)' +
-        ':not(.react-and-share-cookie-compliance *)'
+        ':not(.react-and-share-cookie-compliance *)' +
+        ':not(.accordion-item__header)'
 
       const titleComponents = [
         'h2'+exclusions,


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove references to handorgel library that is no longer used from table of contents functionality.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_hdbt_cleanup  drupal/hdbt:dev-UHF-X_hdbt_cleanup`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that table of content functionality still works as it used to.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/686
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/533
