### PR TITLE
UHF-X: Added update hook that enables Focal Point 2.0 dependency

### DIFF
--- a/modules/helfi_media/helfi_media.install
+++ b/modules/helfi_media/helfi_media.install
@@ -106,3 +106,13 @@ function helfi_media_install($is_syncing) : void {
 
   helfi_media_grant_permissions();
 }
+
+/**
+ * Install Focal Point 2.0 dependencies jquery_ui and jquery_ui_draggable.
+ *
+ * The focal point 2.0 requires these modules but doesn't enable them
+ * automatically.
+ */
+function helfi_media_update_9001() : void {
+  \Drupal::service('module_installer')->install(['jquery_ui_draggable']);
+}

--- a/modules/helfi_media/helfi_media.install
+++ b/modules/helfi_media/helfi_media.install
@@ -113,6 +113,6 @@ function helfi_media_install($is_syncing) : void {
  * The focal point 2.0 requires these modules but doesn't enable them
  * automatically.
  */
-function helfi_media_update_9001() : void {
+function helfi_media_update_9013() : void {
   \Drupal::service('module_installer')->install(['jquery_ui_draggable']);
 }


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added update hook that enables the jquery_ui and jquery_ui_draggable modules that are required by Focal Point 2.0 version.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_focal_point_2.0_dependency`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that jquery_ui and jquery_ui_draggable modules are enabled after the update hook is run.
* [ ] Check that code follows our standards
