### PR TITLE
UHF-X: Removed references to removed field_hero_bg_color

### DIFF
--- a/modules/helfi_test_content/content/node/18345d84-b4f9-4d5f-bdf0-f1f518411a7b.yml
+++ b/modules/helfi_test_content/content/node/18345d84-b4f9-4d5f-bdf0-f1f518411a7b.yml
@@ -114,9 +114,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_hero_bg_color:
-            -
-              value: coat-of-arms
           field_hero_desc:
             -
               value: "<p>Nulla porttitor accumsan tincidunt. Nulla porttitor accumsan tincidunt.</p>\r\n\r\n<p>Proin eget tortor risus. Nulla porttitor accumsan tincidunt.</p>\r\n"

--- a/modules/helfi_test_content/content/node/329149fd-3e4b-40b9-a7d4-59fb34234320.yml
+++ b/modules/helfi_test_content/content/node/329149fd-3e4b-40b9-a7d4-59fb34234320.yml
@@ -114,9 +114,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_hero_bg_color:
-            -
-              value: coat-of-arms
           field_hero_desc:
             -
               value: "<p>Nulla porttitor accumsan tincidunt. Nulla porttitor accumsan tincidunt.</p>\r\n\r\n<p>Proin eget tortor risus. Nulla porttitor accumsan tincidunt.</p>\r\n"

--- a/modules/helfi_test_content/content/node/482655a9-4767-4564-9edb-68ce6a668674.yml
+++ b/modules/helfi_test_content/content/node/482655a9-4767-4564-9edb-68ce6a668674.yml
@@ -114,9 +114,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_hero_bg_color:
-            -
-              value: coat-of-arms
           field_hero_desc:
             -
               value: "<p>Nulla porttitor accumsan tincidunt. Nulla porttitor accumsan tincidunt.</p>\r\n\r\n<p>Proin eget tortor risus. Nulla porttitor accumsan tincidunt.</p>\r\n"

--- a/modules/helfi_test_content/content/node/a23b06b0-090b-46a1-b761-b86f04e61f7e.yml
+++ b/modules/helfi_test_content/content/node/a23b06b0-090b-46a1-b761-b86f04e61f7e.yml
@@ -114,9 +114,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_hero_bg_color:
-            -
-              value: coat-of-arms
           field_hero_desc:
             -
               value: "<p>Nulla porttitor accumsan tincidunt. Nulla porttitor accumsan tincidunt.</p>\r\n\r\n<p>Proin eget tortor risus. Nulla porttitor accumsan tincidunt.</p>\r\n"

--- a/modules/helfi_test_content/content/node/a9033e6e-9009-40d8-95c1-402ad4604709.yml
+++ b/modules/helfi_test_content/content/node/a9033e6e-9009-40d8-95c1-402ad4604709.yml
@@ -114,9 +114,6 @@ default:
           revision_translation_affected:
             -
               value: true
-          field_hero_bg_color:
-            -
-              value: coat-of-arms
           field_hero_desc:
             -
               value: "<p>Nulla porttitor accumsan tincidunt. Nulla porttitor accumsan tincidunt.</p>\r\n\r\n<p>Proin eget tortor risus. Nulla porttitor accumsan tincidunt.</p>\r\n"


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

*  Removed references to removed field_hero_bg_color from the test content.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_field_hero_bg_color_removal`
* Run `make shell`
* Inside the shell run `drush en -y helfi_test_content` and the `drush dcim helfi_test_content`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log into the site and check that the test content has been added to the site without a problem and that the content with heros still look good and work normally.
* [ ] Check that code follows our standards