### PR TITLE
UHF-3592: Set nodes as unpublish on default

### DIFF
--- a/modules/helfi_node_announcement/config/install/core.base_field_override.node.announcement.status.yml
+++ b/modules/helfi_node_announcement/config/install/core.base_field_override.node.announcement.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.announcement
+id: node.announcement.status
+field_name: status
+entity_type: node
+bundle: announcement
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_node_announcement/helfi_node_announcement.install
+++ b/modules/helfi_node_announcement/helfi_node_announcement.install
@@ -86,3 +86,12 @@ function _helfi_global_announcement_enable() {
 function helfi_node_announcement_update_9001() : void {
   _helfi_global_announcement_enable();
 }
+
+/**
+ * Set node as unpublished on default.
+ */
+function helfi_node_announcement_update_9002() : void {
+  // Re-import configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_node_announcement');
+}

--- a/modules/helfi_node_landing_page/config/install/core.base_field_override.node.landing_page.status.yml
+++ b/modules/helfi_node_landing_page/config/install/core.base_field_override.node.landing_page.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.status
+field_name: status
+entity_type: node
+bundle: landing_page
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_node_landing_page/helfi_node_landing_page.install
+++ b/modules/helfi_node_landing_page/helfi_node_landing_page.install
@@ -95,3 +95,12 @@ function helfi_node_landing_page_install($is_syncing) : void {
     helfi_node_landing_page_install_metatag_settings();
   }
 }
+
+/**
+ * Set node as unpublished on default.
+ */
+function helfi_node_landing_page_update_9001() : void {
+  // Re-import configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_node_landing_page');
+}

--- a/modules/helfi_node_page/config/install/core.base_field_override.node.page.status.yml
+++ b/modules/helfi_node_page/config/install/core.base_field_override.node.page.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.status
+field_name: status
+entity_type: node
+bundle: page
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_node_page/helfi_node_page.install
+++ b/modules/helfi_node_page/helfi_node_page.install
@@ -102,3 +102,12 @@ function helfi_node_page_install($is_syncing) : void {
 function helfi_node_page_update_9001() : void {
   helfi_platform_config_update_paragraph_target_types();
 }
+
+/**
+ * Set node as unpublished on default.
+ */
+function helfi_node_page_update_9002() : void {
+  // Re-import configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_node_page');
+}


### PR DESCRIPTION
# [UHF-3592](https://helsinkisolutionoffice.atlassian.net/browse/UHF-3592)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Set nodes to an 'unpublished' state as default

## How to install
* Read instructions from the related PR on KYMP instance

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* [UHF-3592: Set nodes unpublished as default `KYMP`](https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/669)


[UHF-3592]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-3592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ