### PR TITLE
UHF-8595: Revert unit display configs

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -42,7 +42,7 @@ content:
     third_party_settings: {  }
   accessibility_www:
     type: readonly_field_widget
-    weight: 14
+    weight: 12
     region: content
     settings:
       label: above
@@ -52,7 +52,7 @@ content:
     third_party_settings: {  }
   address:
     type: readonly_field_widget
-    weight: 16
+    weight: 14
     region: content
     settings:
       label: above
@@ -62,7 +62,7 @@ content:
     third_party_settings: {  }
   address_postal:
     type: readonly_field_widget
-    weight: 18
+    weight: 16
     region: content
     settings:
       label: above
@@ -72,17 +72,7 @@ content:
     third_party_settings: {  }
   call_charge_info:
     type: readonly_field_widget
-    weight: 17
-    region: content
-    settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
-      show_description: false
-    third_party_settings: {  }
-  contacts:
-    type: readonly_field_widget
-    weight: 28
+    weight: 15
     region: content
     settings:
       label: above
@@ -92,7 +82,7 @@ content:
     third_party_settings: {  }
   description:
     type: readonly_field_widget
-    weight: 15
+    weight: 13
     region: content
     settings:
       label: above
@@ -112,7 +102,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 29
+    weight: 27
     region: content
     settings:
       title: Paragraph
@@ -131,7 +121,7 @@ content:
     third_party_settings: {  }
   field_lower_content:
     type: paragraphs
-    weight: 30
+    weight: 28
     region: content
     settings:
       title: Paragraph
@@ -150,14 +140,14 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 24
+    weight: 26
     region: content
     settings:
       sidebar: false
     third_party_settings: {  }
   field_unit_type:
     type: entity_reference_autocomplete
-    weight: 31
+    weight: 28
     region: content
     settings:
       match_operator: CONTAINS
@@ -167,7 +157,7 @@ content:
     third_party_settings: {  }
   hide_sidebar_navigation:
     type: boolean_checkbox
-    weight: 32
+    weight: 29
     region: content
     settings:
       display_label: true
@@ -181,17 +171,7 @@ content:
     third_party_settings: {  }
   latitude:
     type: readonly_field_widget
-    weight: 19
-    region: content
-    settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
-      show_description: false
-    third_party_settings: {  }
-  links:
-    type: readonly_field_widget
-    weight: 27
+    weight: 17
     region: content
     settings:
       label: above
@@ -201,7 +181,7 @@ content:
     third_party_settings: {  }
   longitude:
     type: readonly_field_widget
-    weight: 20
+    weight: 18
     region: content
     settings:
       label: above
@@ -227,19 +207,9 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  other_info:
-    type: readonly_field_widget
-    weight: 25
-    region: content
-    settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
-      show_description: false
-    third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -270,19 +240,9 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
-  price_info:
-    type: readonly_field_widget
-    weight: 26
-    region: content
-    settings:
-      label: above
-      formatter_type: null
-      formatter_settings: {  }
-      show_description: false
-    third_party_settings: {  }
   provided_languages:
     type: readonly_field_widget
-    weight: 33
+    weight: 30
     region: content
     settings:
       label: above
@@ -292,7 +252,7 @@ content:
     third_party_settings: {  }
   service_map_embed:
     type: readonly_field_widget
-    weight: 22
+    weight: 20
     region: content
     settings:
       label: above
@@ -302,7 +262,7 @@ content:
     third_party_settings: {  }
   services:
     type: readonly_field_widget
-    weight: 23
+    weight: 21
     region: content
     settings:
       label: above
@@ -312,19 +272,19 @@ content:
     third_party_settings: {  }
   show_www:
     type: boolean_checkbox
-    weight: 12
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   streetview_entrance_url:
     type: readonly_field_widget
-    weight: 21
+    weight: 19
     region: content
     settings:
       label: above

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -42,7 +42,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 21
+    weight: 19
     region: content
   accessibility_www:
     type: link
@@ -78,13 +78,6 @@ content:
     third_party_settings: {  }
     weight: 11
     region: content
-  contacts:
-    type: tpr_connection
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 26
-    region: content
   description:
     type: text_default
     label: hidden
@@ -107,7 +100,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 20
+    weight: 18
     region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
@@ -116,7 +109,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 22
+    weight: 20
     region: content
   field_metatags:
     type: metatag_empty_formatter
@@ -130,14 +123,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 24
-    region: content
-  links:
-    type: tpr_connection
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 25
+    weight: 22
     region: content
   name:
     type: string
@@ -161,13 +147,6 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 7
-    region: content
-  other_info:
-    type: tpr_connection
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 18
     region: content
   phone:
     type: telephone_link
@@ -195,20 +174,13 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
-  price_info:
-    type: tpr_connection
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 19
-    region: content
   provided_languages:
     type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 23
+    weight: 21
     region: content
   service_map_embed:
     type: service_map_embed

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -221,8 +221,6 @@ function helfi_tpr_config_update_9038(): void {
 
 /**
  * UHF-8532 Update the "Open larger map" text on maps.
- *
- * UHF-8595 Update unit view and form display configs to show new fields.
  */
 function helfi_tpr_config_update_9039(): void {
   // Re-import 'helfi_tpr_config' configuration.

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -227,3 +227,12 @@ function helfi_tpr_config_update_9039(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-8595 Update after reverting unit display configs.
+ */
+function helfi_tpr_config_update_9040(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-8595](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595)
<!-- What problem does this solve? -->
These config changes are wanted only in KUVA instance.

## What was done
<!-- Describe what was done -->

* Reverted changes in the tpr_unit display configs.

## How to install and test
* Mostly just check the config changes. Following fields shouldn't be enabled anymore for the view display:
  * other_info
  * price_info
  * contacts
  * links 

### If you prefer to actually test
* Make sure your instance (something else than kuva) is up and running
  * `composer require drupal/helfi_platform_config:dev-UHF-8595_Revert-unit-display-config-changes`
  * `make fresh`
* Run `make drush-updb drush-cr`
* Check that the four fields (Further information, Charges, Other contact information and Web sites) are not displayed on TPR Unit pages: `/admin/structure/tpr_unit/settings/display`.


[UHF-8595]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ