### PR TITLE
UHF-8708

### DIFF
--- a/modules/helfi_toc/assets/js/tableOfContents.js
+++ b/modules/helfi_toc/assets/js/tableOfContents.js
@@ -30,7 +30,8 @@
         reserved.push(elem.id);
       });
 
-      // Do not include sidebar H2, Table of contents H2 or cookie compliance warnings.
+      // Exclude elements from TOC that are not content:
+      // e.g. TOC, sidebar, cookie compliency-banner etc.
       const exclusions = '' +
         ':not(.layout-sidebar-first *)' +
         ':not(.layout-sidebar-second *)' +
@@ -38,8 +39,7 @@
         ':not(.breadcrumb__container *)' +
         ':not(#helfi-toc-table-of-contents *)' +
         ':not(.embedded-content-cookie-compliance *)' +
-        ':not(.react-and-share-cookie-compliance *)' +
-        ':not(.accordion-item__header)'
+        ':not(.react-and-share-cookie-compliance *)'
 
       const titleComponents = [
         'h2'+exclusions,

--- a/modules/helfi_toc/helfi_toc.libraries.yml
+++ b/modules/helfi_toc/helfi_toc.libraries.yml
@@ -1,5 +1,5 @@
 table_of_contents:
-  version: 1.x
+  version: 1.0.1
   js:
     assets/js/tableOfContents.js: {}
   dependencies:


### PR DESCRIPTION
# [UHF-8708](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8708)

## What was done

Remove bug inducing exclusion from TOC module.
The change creates id's for accordion headers which fixes the anchor link bug.

## How to install
Kuva is a good environment to test with.
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8708`
* Run `make drush-updb drush-cr`

## How to test
- Go to a page with an accordion, for example fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/ulkoilualueet/mustikkamaa#reitit-ja-luontopolut

What should happen
- Anchor link should work
- Accordion should open automatically

[UHF-8708]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ