### PR TITLE
UHF-8597: Combine IBM chats under one script tag

### DIFF
--- a/src/Plugin/Block/IbmChatApp.php
+++ b/src/Plugin/Block/IbmChatApp.php
@@ -79,9 +79,7 @@ class IbmChatApp extends BlockBase {
     $tenantId = $config['tenantId'];
     $assistantId = $config['assistantId'];
 
-    $optionsSrc = sprintf('%s/get-widget-options?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
-    $widgetSrc = sprintf('%s/get-widget?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
-    $defaultSrc = sprintf('%s/get-widget-default?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
+    $buttonSrc = sprintf('%s/get-widget-button?tenantId=%s&assistantId=%s&engagementId=%s', $hostname, $tenantId, $assistantId, $engagementId);
 
     $build['ibm_chat_app'] = [
       '#title' => $this->t('IBM Chat App'),
@@ -92,28 +90,11 @@ class IbmChatApp extends BlockBase {
             [
               '#tag' => 'script',
               '#attributes' => [
+                'async' => TRUE,
                 'type' => 'text/javascript',
-                'src' => $optionsSrc,
+                'src' => $buttonSrc,
               ],
-            ], 'chat_app_options',
-          ],
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'type' => 'text/javascript',
-                'src' => $widgetSrc,
-              ],
-            ], 'chat_app_widget',
-          ],
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'type' => 'text/javascript',
-                'src' => $defaultSrc,
-              ],
-            ], 'chat_app_default',
+            ], 'chat_app_button',
           ],
         ],
       ],


### PR DESCRIPTION
# [UHF-8597](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8597)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Combined ibm chat scripts under one script tag
* Added async attribute for the script tag

## How to install
* Make sure your instance is up and running on latest dev branch. For example SOTE or Asuminen are good instances to test this.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8597_combine_ibm_chat_scripts`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the chat still works (for example Sotebotti Hester on for example SOTE front page or Asunnonhakubotti on Asuminen instance for example Vuokra-asunnot page).
* [x] Check that there is only one script tag that adds the chat now (search for get-widget-button string from the page source code and you should find it).
* [x] Check that the script tag has async-attribute.
* [x] Download the [URL throttler](https://chrome.google.com/webstore/detail/url-throttler/kpkeghonflnkockcnaegmphgdldfnden/related) chrome extension and block the url `https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud/*` with the extension.
* [x] Try reloading the page and it should load normally but the chat just doesn't appear. 
* [x] Check that code follows our standards


[UHF-8597]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ