### PR TITLE
UHF-8006: Removed branding navigation configuration and mentions from code

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.links.menu.yml
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.links.menu.yml
@@ -36,13 +36,6 @@ hdbt_admin_tools.header_top_menu:
   route_parameters: { menu: 'header-top-navigation' }
   weight: 0
 
-hdbt_admin_tools.header_branding_menu:
-  title: 'Header branding navigation menu links'
-  parent: hdbt_admin_tools.menus
-  route_name: entity.menu.edit_form
-  route_parameters: { menu: 'branding-navigation' }
-  weight: 1
-
 hdbt_admin_tools.main_menu:
   title: 'Main menu'
   parent: hdbt_admin_tools.menus

--- a/modules/helfi_base_content/config/install/system.menu.branding-navigation.yml
+++ b/modules/helfi_base_content/config/install/system.menu.branding-navigation.yml
@@ -1,7 +1,0 @@
-langcode: und
-status: true
-dependencies: {  }
-id: branding-navigation
-label: 'Branding - Navigation'
-description: 'Navigation for branding bar'
-locked: false

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -254,3 +254,13 @@ function helfi_base_content_update_9003() : void {
     ->set('selected_langcode', 'site_default')
     ->save();
 }
+
+/**
+ * Implements hook_install().
+ */
+function helfi_base_content_update_9004() : void {
+  $config_factory = Drupal::configFactory();
+
+  // Remove the default frontpage view.
+  $config_factory->getEditable('system.menu.branding-navigation')->delete();
+}

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -261,6 +261,8 @@ function helfi_base_content_update_9003() : void {
 function helfi_base_content_update_9004() : void {
   $config_factory = Drupal::configFactory();
 
-  // Remove the default frontpage view.
+  // Remove the branding navigation and blocks related to it.
   $config_factory->getEditable('system.menu.branding-navigation')->delete();
+  $config_factory->getEditable('block.block.brandingnavigation')->delete();
+  $config_factory->getEditable('block.block.hdbt_subtheme_brandingnavigation')->delete();
 }

--- a/modules/helfi_base_content/helfi_base_content.module
+++ b/modules/helfi_base_content/helfi_base_content.module
@@ -53,36 +53,6 @@ function helfi_base_content_themes_installed($theme_list) {
  */
 function helfi_base_content_get_block_configurations(string $theme) : array {
   return [
-    'brandingnavigation' => [
-      'block' => [
-        'id' => 'brandingnavigation',
-        'plugin' => 'menu_block_current_language:branding-navigation',
-        'provider' => 'helfi_base_content',
-        'settings' => [
-          'id' => 'menu_block_current_language:branding-navigation',
-          'label' => 'Branding - Navigation',
-          'depth' => 1,
-          'level' => 1,
-          'expand_all_items' => FALSE,
-          'translation_providers' => [
-            'views' => 'views',
-            'menu_link_content' => 'menu_link_content',
-            'default' => '0',
-          ],
-          'provider' => 'helfi_base_content',
-        ],
-      ],
-      'variations' => [
-        [
-          'theme' => $theme,
-          'region' => 'header_branding',
-        ],
-        [
-          'theme' => 'stark',
-          'region' => 'content',
-        ],
-      ],
-    ],
     'breadcrumbs' => [
       'block' => [
         'id' => 'breadcrumbs',

--- a/src/Menu/FilterByLanguage.php
+++ b/src/Menu/FilterByLanguage.php
@@ -21,7 +21,6 @@ final class FilterByLanguage implements EventSubscriberInterface {
    * @var string[]
    */
   protected array $menuNames = [
-    'branding-navigation',
     'footer-bottom-navigation',
     'footer-top-navigation',
     'footer-top-navigation-2',


### PR DESCRIPTION
# [UHF-8006](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8006)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Configuration related to branding navigation was removed.
* Added update hook that removes branding navigation related content from the instances.

## How to install
* Check installation instructions from the hdbt PR listed below.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the hdbt PR listed below.
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/708
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/551
* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/144


[UHF-8006]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ