### PR TITLE
UHF-8503: CKEditor cleanup (path fix)

### DIFF
--- a/modules/hdbt_admin_tools/assets/js/ckeditor-config.js
+++ b/modules/hdbt_admin_tools/assets/js/ckeditor-config.js
@@ -1,0 +1,3 @@
+CKEDITOR.editorConfig = function( config ) {
+  config.fillEmptyBlocks = false;
+};

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1033,9 +1033,15 @@ function hdbt_admin_tools_ckeditor_css_alter(array &$css): void {
  * Implements hook_editor_js_settings_alter().
  */
 function hdbt_admin_tools_editor_js_settings_alter(array &$settings) {
-  $asset_path = Drupal::config('helfi_proxy.settings')->get('asset_path');
-  $theme_path = Drupal::service('extension.list.theme')->getPath('hdbt_admin');
-  $js_path = '/' . $asset_path . '/' . $theme_path . '/dist/js/ckeditor-config.min.js';
+  /** @var \Drupal\Core\File\FileUrlGeneratorInterface $service */
+  $service = \Drupal::service('file_url_generator');
+
+  // Add theme path to as variable.
+  $theme = \Drupal::service('theme_handler')->getTheme('hdbt_admin');
+  $theme_path = $service->generate($theme->getPath())
+    ->toString(TRUE)->getGeneratedUrl();
+
+  $js_path = $theme_path . '/dist/js/ckeditor-config.min.js';
 
   foreach (array_keys($settings['editor']['formats']) as $text_format_id) {
     $settings['editor']['formats'][$text_format_id]['editorSettings']['customConfig'] = $js_path;

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1035,13 +1035,10 @@ function hdbt_admin_tools_ckeditor_css_alter(array &$css): void {
 function hdbt_admin_tools_editor_js_settings_alter(array &$settings) {
   /** @var \Drupal\Core\File\FileUrlGeneratorInterface $service */
   $service = \Drupal::service('file_url_generator');
-
-  // Add theme path to as variable.
-  $theme = \Drupal::service('theme_handler')->getTheme('hdbt_admin');
-  $theme_path = $service->generate($theme->getPath())
+  $module = \Drupal::service('module_handler')->getModule('hdbt_admin_tools');
+  $module_path = $service->generate($module->getPath())
     ->toString(TRUE)->getGeneratedUrl();
-
-  $js_path = $theme_path . '/dist/js/ckeditor-config.min.js';
+  $js_path = $module_path . '/assets/js/ckeditor-config.js';
 
   foreach (array_keys($settings['editor']['formats']) as $text_format_id) {
     $settings['editor']['formats'][$text_format_id]['editorSettings']['customConfig'] = $js_path;

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1033,11 +1033,12 @@ function hdbt_admin_tools_ckeditor_css_alter(array &$css): void {
  * Implements hook_editor_js_settings_alter().
  */
 function hdbt_admin_tools_editor_js_settings_alter(array &$settings) {
-  $theme_path = '/' . Drupal::service('extension.list.theme')->getPath('hdbt_admin');
+  $asset_path = \Drupal::config('helfi_proxy.settings')->get('asset_path');
+  $theme_path = Drupal::service('extension.list.theme')->getPath('hdbt_admin');
+  $js_path = '/' . $asset_path . '/' . $theme_path . '/dist/js/ckeditor-config.min.js';
 
   foreach (array_keys($settings['editor']['formats']) as $text_format_id) {
-    $settings['editor']['formats'][$text_format_id]['editorSettings']['customConfig'] =
-      $theme_path . '/dist/js/ckeditor-config.min.js';
+    $settings['editor']['formats'][$text_format_id]['editorSettings']['customConfig'] = $js_path;
   }
 }
 

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1033,7 +1033,7 @@ function hdbt_admin_tools_ckeditor_css_alter(array &$css): void {
  * Implements hook_editor_js_settings_alter().
  */
 function hdbt_admin_tools_editor_js_settings_alter(array &$settings) {
-  $asset_path = \Drupal::config('helfi_proxy.settings')->get('asset_path');
+  $asset_path = Drupal::config('helfi_proxy.settings')->get('asset_path');
   $theme_path = Drupal::service('extension.list.theme')->getPath('hdbt_admin');
   $js_path = '/' . $asset_path . '/' . $theme_path . '/dist/js/ckeditor-config.min.js';
 


### PR DESCRIPTION
# [UHF-8503](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8503)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* CKE configuration filepath was not using assets-path

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8503_CKEditor_cleanup`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that CKE config is loaded via assets-path
* [ ] Check that code follows our standards

## Relates to PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/227
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/549
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/225


[UHF-8503]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ