### PR TITLE
UHF-8524: Fix news list params

### DIFF
--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_groups.helfi_news_groups.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_groups.helfi_news_groups.default.yml
@@ -1,0 +1,30 @@
+uuid: b95230b8-fb95-4373-b877-6117cf4d0f46
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_groups.helfi_news_groups.default
+targetEntityType: helfi_news_groups
+bundle: helfi_news_groups
+mode: default
+content:
+  field_frontpage_term_id:
+    type: string_textfield
+    weight: -4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_neighbourhoods.helfi_news_neighbourhoods.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_neighbourhoods.helfi_news_neighbourhoods.default.yml
@@ -1,0 +1,30 @@
+uuid: d13089ef-9704-4770-90a9-fd9fedc50405
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_neighbourhoods.helfi_news_neighbourhoods.default
+targetEntityType: helfi_news_neighbourhoods
+bundle: helfi_news_neighbourhoods
+mode: default
+content:
+  field_frontpage_term_id:
+    type: string_textfield
+    weight: -4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_tags.helfi_news_tags.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_form_display.helfi_news_tags.helfi_news_tags.default.yml
@@ -1,0 +1,30 @@
+uuid: 972acdae-8e71-4d12-a335-bc91828f4851
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_tags.helfi_news_tags.default
+targetEntityType: helfi_news_tags
+bundle: helfi_news_tags
+mode: default
+content:
+  field_frontpage_term_id:
+    type: string_textfield
+    weight: -4
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_groups.helfi_news_groups.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_groups.helfi_news_groups.default.yml
@@ -1,0 +1,24 @@
+uuid: 045f335b-7059-4d6a-9240-43909f3c1704
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_groups.helfi_news_groups.default
+targetEntityType: helfi_news_groups
+bundle: helfi_news_groups
+mode: default
+content:
+  title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_frontpage_term_id: true
+  search_api_excerpt: true

--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_neighbourhoods.helfi_news_neighbourhoods.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_neighbourhoods.helfi_news_neighbourhoods.default.yml
@@ -1,0 +1,24 @@
+uuid: f8d0f0da-4aff-436c-a4b8-4df8c6ee82f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_neighbourhoods.helfi_news_neighbourhoods.default
+targetEntityType: helfi_news_neighbourhoods
+bundle: helfi_news_neighbourhoods
+mode: default
+content:
+  title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_frontpage_term_id: true
+  search_api_excerpt: true

--- a/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_tags.helfi_news_tags.default.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/core.entity_view_display.helfi_news_tags.helfi_news_tags.default.yml
@@ -1,0 +1,24 @@
+uuid: 7060dc64-5f95-4fa5-8046-bf0ad5e265c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id
+  module:
+    - external_entities
+id: helfi_news_tags.helfi_news_tags.default
+targetEntityType: helfi_news_tags
+bundle: helfi_news_tags
+mode: default
+content:
+  title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_frontpage_term_id: true
+  search_api_excerpt: true

--- a/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_groups.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_groups.yml
@@ -15,6 +15,8 @@ field_mapper_config:
       value: $.id
     title:
       value: '$.attributes["name"]'
+    field_frontpage_term_id:
+      value: '$.attributes["drupal_internal__tid"]'
 storage_client_id: helfi_news_groups
 storage_client_config: {  }
 persistent_cache_max_age: 86400

--- a/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_neighbourhoods.yml
@@ -15,6 +15,8 @@ field_mapper_config:
       value: $.id
     title:
       value: '$.attributes["name"]'
+    field_frontpage_term_id:
+      value: '$.attributes["drupal_internal__tid"]'
 storage_client_id: helfi_news_neighbourhoods
 storage_client_config: {  }
 persistent_cache_max_age: 86400

--- a/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_tags.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/external_entities.external_entity_type.helfi_news_tags.yml
@@ -15,6 +15,8 @@ field_mapper_config:
       value: $.id
     title:
       value: '$.attributes["name"]'
+    field_frontpage_term_id:
+      value: '$.attributes["drupal_internal__tid"]'
 storage_client_id: helfi_news_tags
 storage_client_config: {  }
 persistent_cache_max_age: 86400

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
@@ -7,10 +7,6 @@ dependencies:
   module:
     - disable_field
     - external_entities
-third_party_settings:
-  disable_field:
-    add_disable: none
-    edit_disable: none
 id: helfi_news_groups.helfi_news_groups.field_frontpage_term_id
 field_name: field_frontpage_term_id
 entity_type: helfi_news_groups

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
@@ -1,0 +1,25 @@
+uuid: 42a81125-44b7-45d8-b676-46a27a7dbc07
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.helfi_news_groups.field_frontpage_term_id
+  module:
+    - disable_field
+    - external_entities
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: none
+id: helfi_news_groups.helfi_news_groups.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_groups
+bundle: helfi_news_groups
+label: 'Frontpage term id'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
@@ -7,10 +7,6 @@ dependencies:
   module:
     - disable_field
     - external_entities
-third_party_settings:
-  disable_field:
-    add_disable: none
-    edit_disable: none
 id: helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id
 field_name: field_frontpage_term_id
 entity_type: helfi_news_neighbourhoods

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
@@ -1,0 +1,25 @@
+uuid: eff4aa71-c0d3-470c-aa37-86ff0b3ef5b7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.helfi_news_neighbourhoods.field_frontpage_term_id
+  module:
+    - disable_field
+    - external_entities
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: none
+id: helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_neighbourhoods
+bundle: helfi_news_neighbourhoods
+label: 'Frontpage term id'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
@@ -1,0 +1,25 @@
+uuid: f6923133-8d94-49ec-a95c-48fadc1391ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.helfi_news_tags.field_frontpage_term_id
+  module:
+    - disable_field
+    - external_entities
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: none
+id: helfi_news_tags.helfi_news_tags.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_tags
+bundle: helfi_news_tags
+label: 'Frontpage term id'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
@@ -7,10 +7,6 @@ dependencies:
   module:
     - disable_field
     - external_entities
-third_party_settings:
-  disable_field:
-    add_disable: none
-    edit_disable: none
 id: helfi_news_tags.helfi_news_tags.field_frontpage_term_id
 field_name: field_frontpage_term_id
 entity_type: helfi_news_tags

--- a/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_groups.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_groups.field_frontpage_term_id.yml
@@ -1,0 +1,21 @@
+uuid: c62ebe15-2cb6-4553-b00d-3c21a0c1033b
+langcode: en
+status: true
+dependencies:
+  module:
+    - external_entities
+id: helfi_news_groups.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_groups
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_neighbourhoods.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_neighbourhoods.field_frontpage_term_id.yml
@@ -1,0 +1,21 @@
+uuid: aee9a7c0-c5e1-40eb-a2a6-f89250953161
+langcode: en
+status: true
+dependencies:
+  module:
+    - external_entities
+id: helfi_news_neighbourhoods.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_neighbourhoods
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_tags.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/field.storage.helfi_news_tags.field_frontpage_term_id.yml
@@ -1,0 +1,21 @@
+uuid: 636d25cf-d069-4660-bce2-10059bb6c5fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - external_entities
+id: helfi_news_tags.field_frontpage_term_id
+field_name: field_frontpage_term_id
+entity_type: helfi_news_tags
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_groups.helfi_news_groups.field_frontpage_term_id.yml
@@ -1,0 +1,1 @@
+label: 'Termin ID etusivu-instanssissa'

--- a/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_neighbourhoods.helfi_news_neighbourhoods.field_frontpage_term_id.yml
@@ -1,0 +1,1 @@
+label: 'Termin ID etusivu-instanssissa'

--- a/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
+++ b/modules/helfi_paragraphs_news_list/config/install/language/fi/field.field.helfi_news_tags.helfi_news_tags.field_frontpage_term_id.yml
@@ -1,0 +1,1 @@
+label: 'Termin ID etusivu-instanssissa'

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
@@ -109,3 +109,12 @@ function helfi_paragraphs_news_list_update_9003(&$sandbox) : void {
 function helfi_paragraphs_news_list_update_9004() : void {
   helfi_paragraphs_news_list_grant_permissions();
 }
+
+/**
+ * Adds field for frontpage tid of news list terms.
+ * Enables linking to correct results in news archive.
+ */
+function helfi_paragraphs_news_list_update_9005() : void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_paragraphs_news_list');
+}

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
@@ -111,8 +111,7 @@ function helfi_paragraphs_news_list_update_9004() : void {
 }
 
 /**
- * Adds field for frontpage tid of news list terms.
- * Enables linking to correct results in news archive.
+ * Adds field for frontpage tid of news list terms - fixes news archive link.
  */
 function helfi_paragraphs_news_list_update_9005() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -194,8 +194,13 @@ function helfi_paragraphs_news_list_preprocess_paragraph__news_list(&$variables)
 
     $terms = $field->referencedEntities();
     foreach ($terms as $term) {
-      // Format name to match app query param format.
-      $params[$paramKey][] = str_replace(' ', '+', strtolower($term->get('title')->value));
+      if (
+        $term->hasField('field_frontpage_term_id') &&
+        $external_tid = $term->get('field_frontpage_term_id')->value
+      ) {
+        // Format name to match app query param format.
+        $params[$paramKey][] = str_replace(' ', '+', strtolower($external_tid));
+      }
     }
   }
 

--- a/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsGroups.php
+++ b/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsGroups.php
@@ -23,7 +23,7 @@ final class NewsGroups extends HelfiExternalEntityBase {
    * @var array|string[]
    */
   protected array $query = [
-    'fields[taxonomy_term--news_groups]' => 'id,name,changed,langcode,status',
+    'fields[taxonomy_term--news_groups]' => 'id,name,changed,langcode,status,drupal_internal__tid',
   ];
 
   /**

--- a/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsNeighbourhoods.php
+++ b/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsNeighbourhoods.php
@@ -23,7 +23,7 @@ final class NewsNeighbourhoods extends HelfiExternalEntityBase {
    * @var array|string[]
    */
   protected array $query = [
-    'fields[taxonomy_term--news_neighbourhoods]' => 'id,name,changed,langcode,status',
+    'fields[taxonomy_term--news_neighbourhoods]' => 'id,name,changed,langcode,status,drupal_internal__tid',
   ];
 
   /**

--- a/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsTags.php
+++ b/modules/helfi_paragraphs_news_list/src/Plugin/ExternalEntities/StorageClient/NewsTags.php
@@ -23,7 +23,7 @@ final class NewsTags extends HelfiExternalEntityBase {
    * @var array|string[]
    */
   protected array $query = [
-    'fields[taxonomy_term--news_tags]' => 'id,name,changed,langcode,status',
+    'fields[taxonomy_term--news_tags]' => 'id,name,changed,langcode,status,drupal_internal__tid',
   ];
 
   /**


### PR DESCRIPTION
# [UHF-8524](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8524)
Fix linking to news archive app from news list paragraph

## What was done
* Added fields to external entities to read frontpage tid for terms
* Added reading jsonapi response into aforementioned fields
* Fixed news list preprocess to include tids instead of term names

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8524-fix-news-list-params`
* Run `make drush-updb drush-cr`

## How to test
* Check if your instance uses news list paragraph on it's frontpage (a lot of the instances do) or if you know a page where it's used, check that one
* ...or just make a landing page, add `news_list` paragraph, add some terms to it and view the page
* The link below the news list should link correctly to news archive page using term IDs instead of term names



[UHF-8524]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ