### PR TITLE
UHF-X: Remove ckeditor dependency from helfi react search module

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.info.yml
+++ b/modules/helfi_react_search/helfi_react_search.info.yml
@@ -3,7 +3,6 @@ type: module
 description: 'Add react search related backend features'
 core_version_requirement: '^9 || ^10'
 dependencies:
-  - 'drupal:ckeditor'
   - 'drupal:content_translation'
   - 'drupal:editor'
   - 'drupal:language'


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Remove ckeditor dependency from helfi_react_search module because the module got uninstalled when testing with ckeditor5

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X-remove-ckeditor-dependecy-from-react-search-module`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that helfi_react_search module is installed after `make fresh`
* [ ] Check that adding events paragraph to a node works 
* [ ] Check that code follows our standards
