### PR TITLE
UHF-8726: Handle remote video provider error

### DIFF
--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -8,6 +8,7 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\media\OEmbed\Resource;
+use Drupal\media\OEmbed\ResourceException;
 
 const HELFI_MEDIA_REMOTE_VIDEO_HELSINKI_KANAVA_URL_PATTERN = 'https://www.helsinkikanava.fi/*/web/helsinkikanava/player/vod?assetId=*';
 
@@ -81,7 +82,7 @@ function _helfi_media_remote_video_remote_video_provider_validation(array $form,
     try {
       $provider = $url_resolver->getProviderByUrl($user_input['url']);
     }
-    catch (\Exception $e) {
+    catch (ResourceException $e) {
       return $form;
     }
 
@@ -140,7 +141,7 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
     try {
       $converted_url = _helfi_media_remote_video_remote_video_url_handler($video_url);
     }
-    catch (\Exception $e) {
+    catch (ResourceException $e) {
       return $form;
     }
 

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -77,7 +77,14 @@ function _helfi_media_remote_video_remote_video_provider_validation(array $form,
     $user_input = $form_state->getUserInput();
     $allowed_providers = $config_data['source_configuration']['providers'];
     $url_resolver = Drupal::service('media.oembed.url_resolver');
-    $provider = $url_resolver->getProviderByUrl($user_input['url']);
+
+    try {
+      $provider = $url_resolver->getProviderByUrl($user_input['url']);
+    }
+    catch (\Exception $e) {
+      return $form;
+    }
+
     $provider_name = $provider->getName();
 
     if (!in_array($provider_name, $allowed_providers)) {
@@ -130,7 +137,12 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
 
   // Convert the video url if needed.
   if ($video_url) {
-    $converted_url = _helfi_media_remote_video_remote_video_url_handler($video_url);
+    try {
+      $converted_url = _helfi_media_remote_video_remote_video_url_handler($video_url);
+    }
+    catch (\Exception $e) {
+      return $form;
+    }
 
     if ($converted_url) {
       $video_url = $converted_url;


### PR DESCRIPTION
# [UHF-8726](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8726)
<!-- What problem does this solve? -->
When adding an event video from Helsinkikanava as a remote video, the page results in and error page or just an invisible error to the user. A schema for this type of URL wouldn't help as the URL doesn't have the actual video ID.

## What was done
<!-- Describe what was done -->

* Handle the error so that at least "No matching provider found" message is shown.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8726_handle-remote-video-provider-error`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add a remote video component, open the media library and try to add https://www.helsinkikanava.fi/fi/web/helsinkikanava/player/event/view?eventId=215325506 as the URL. "No matchin provider found" message should be shown above the URL input.
* [ ] Check that code follows our standards


[UHF-8726]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ