### PR TITLE
UHF-7650: Fix neuvonta chat compatibility with disable-genesys-chat

### DIFF
--- a/assets/js/genesys_neuvonta.js
+++ b/assets/js/genesys_neuvonta.js
@@ -7,29 +7,6 @@
 
   Drupal.behaviors.genesys_neuvonta = {
     attach: function (context, settings) {
-      // Replace the link with a button.
-      var openChatButton = `<button
-        class="hds-button hds-button--primary"
-        data-design="hds-button hds-button--primary"
-        data-link-text="` + Drupal.t('Start a chat') + `"
-        data-selected-icon="speechbubble-text"
-        id="openChat"
-      >
-        <span
-          class="hel-icon hel-icon--speechbubble-text "
-          aria-hidden="true"
-        ></span>
-        <span class="hds-button__label">` + Drupal.t('Start a chat') + `</span>
-      </button>`;
-
-      $("#openChat").replaceWith(openChatButton);
-
-      // Open chat when clicking the button.
-      $('#openChat').click(function(e) {
-        e.preventDefault();
-        $("#chatButtonStart").click();
-      });
-
       var helFiChatPageUrl = document.location.href;
       helFiChatPageUrl = helFiChatPageUrl.toLowerCase();
       var helfiChat_lang = document.documentElement.lang;
@@ -276,6 +253,34 @@
       }
       if (!window._gt) { window._gt = [];
       }
+
+      // Replace the link with a button.
+      var openChatButton = `<button
+        class="hds-button hds-button--primary"
+        data-design="hds-button hds-button--primary"
+        data-link-text="` + Drupal.t('Start a chat') + `"
+        data-selected-icon="speechbubble-text"
+        id="openChat"
+      >
+        <span
+          class="hel-icon hel-icon--speechbubble-text "
+          aria-hidden="true"
+        ></span>
+        <span class="hds-button__label">` + Drupal.t('Start a chat') + `</span>
+      </button>`;
+
+      const chatButtonOpen = $("#openChat");
+      const fallbackOpen = $("#genesys-disabled-message");
+
+      const openChatElement = chatButtonOpen.length ? chatButtonOpen : fallbackOpen;
+
+      openChatElement.replaceWith(openChatButton);
+
+      // Open chat when clicking the button.
+      $('#openChat').click(function(e) {
+        e.preventDefault();
+        $("#chatButtonStart").click();
+      });
 
       window._genesys.widgets = {
         main: {


### PR DESCRIPTION
# [UHF-7650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7650)
Make chat open button available for the helsinki-info page (again). 

## What was done
Added logic to check if `disable-genesys-button` has disabled the chat button and replace it with the open chat button.

## How to install
* Boot up strategia instance (https://github.com/City-of-Helsinki/drupal-helfi-strategia/)
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-7650-helsinki-info-button`
* Update HDBT 
  *  `composer require drupal/hdbt:dev-UHF-7650-helsinki-info-button` 
* Run `make drush-cr`

## How to test
* If you ran `make fresh`, you should be able to navigate to this page: https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/ota-yhteytta/helsinki-info
* Edit the page, specifically the first 50/50 paragraph containing a text paragraph
* Edit the html to include an element with an id of `openChat` (as in something like `<a id="openChat">Avaa chat</a>`)
* Load the page. You should see a button element where you added the element.
* Clicking on the button should pop the neuvonta chat open.

## Other PRs
<!-- For example an related PR in another repository -->

* HDBT: https://github.com/City-of-Helsinki/drupal-hdbt/pull/751


[UHF-7650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ