### PR TITLE
UHF-8769: Change genesys chats api backend url to chat-proxy.hel.fi

### DIFF
--- a/assets/js/genesys_kymp.js
+++ b/assets/js/genesys_kymp.js
@@ -81,7 +81,7 @@
       var helFiChat_button = "";
 
       var helFiChat_localization =
-        "https://www.hel.fi/gms/sote/testpages/chat-kymp-fi.json";
+        "https://chat-proxy.hel.fi/gms/sote/testpages/chat-kymp-fi.json";
       var helFiChat_service = "KYMP";
       var helFiChat_language = "fi";
       var helfiChat_GUI_lang = helFiChat_language;
@@ -96,10 +96,10 @@
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://www.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://www.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */

--- a/assets/js/genesys_neuvonta.js
+++ b/assets/js/genesys_neuvonta.js
@@ -109,15 +109,15 @@
         case 'fi':
         default:
           var helFiChat_localization =
-            "https://www.hel.fi/gms/sote/testpages/chat-virkainfo-fi.json";
+            "https://chat-proxy.hel.fi/gms/sote/testpages/chat-virkainfo-fi.json";
           break;
         case 'sv':
           var helFiChat_localization =
-            "https://www.hel.fi/gms/sote/testpages/chat-virkainfo-se.json";
+            "https://chat-proxy.hel.fi/gms/sote/testpages/chat-virkainfo-se.json";
           break;
         case 'en':
           var helFiChat_localization =
-            "https://www.hel.fi/gms/sote/testpages/chat-virkainfo-en.json";
+            "https://chat-proxy.hel.fi/gms/sote/testpages/chat-virkainfo-en.json";
           break;
       }
 
@@ -135,10 +135,10 @@
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://www.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://www.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */

--- a/assets/js/genesys_suunte.js
+++ b/assets/js/genesys_suunte.js
@@ -128,7 +128,7 @@ var gcReturnSessionId = '';
       /* CHAT START BUTTON ICONS */
       var helFiChat_button = "";
       var helFiChat_localization =
-        "https://www.hel.fi/gms/sote/testpages/chat-suunte-fi.json";
+        "https://chat-proxy.hel.fi/gms/sote/testpages/chat-suunte-fi.json";
       var helFiChat_service = "SUUNTE"; //SUUNTE
       var helFiChat_language = "fi";
       var helfiChat_GUI_lang = helFiChat_language;
@@ -145,10 +145,10 @@ var gcReturnSessionId = '';
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://www.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://www.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */


### PR DESCRIPTION
# [UHF-8769](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8769)
Request chat backend from `chat-proxy.hel.fi`

## What was done
Switched references to `www.hel.fi` to `chat-proxy.hel.fi` where relevant

## How to install
Set up the following instances: 
* Etusivu https://github.com/City-of-Helsinki/drupal-helfi-etusivu/
* Liikenne https://github.com/City-of-Helsinki/drupal-helfi-kymp
* SOTE https://github.com/City-of-Helsinki/drupal-helfi-sote

Do the next step for all of them:
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8769`
* Run `make drush-cr`

## How to test

For etusivu:
 * Go to https://helfi-etusivu.docker.so/fi
 * Check that chat still works

For Liikenne:
 * Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pysakointi
 * Check that chat still works

For SOTE:
 * Go to https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/hammashoito
 * Check that chat still works



[UHF-8769]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ