### PR TITLE
UHF-8514: Add patch for simple_sitemap module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,9 @@
             },
             "drupal/translatable_menu_link_uri": {
                 "[#UHF-8616] D10 compatibility patch for translatable menu link uri": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/c03c575cdd293b7933248cfb4d0fb7b47be5422b/patches/translatable_menu_link_uri_d10.patch"
+            },
+            "drupal/simple_sitemap": {
+                "[#UHF-8514] Fix frontpage URLs in sitemap. (https://www.drupal.org/project/simple_sitemap/issues/3264573)": "https://www.drupal.org/files/issues/2022-02-15/3264573-2.patch"
             }
         }
     }


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-0000_insert_correct_branch`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
