### PR TITLE
UHF-8770: Unit accessibility information and Unit contact card to global components

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.paragraph.unit_accessibility_information.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.paragraph.unit_accessibility_information.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.default
+targetEntityType: paragraph
+bundle: unit_accessibility_information
+mode: default
+content:
+  field_unit_accessibility_unit:
+    type: entity_reference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.paragraph.unit_contact_card.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.paragraph.unit_contact_card.default.yml
@@ -1,0 +1,97 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_contact_card.field_unit_contact_title
+    - field.field.paragraph.unit_contact_card.field_unit_contact_unit
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_address
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_details
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_link
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_opening
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_override
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_phone
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_picture
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_postal
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.default
+targetEntityType: paragraph
+bundle: unit_contact_card
+mode: default
+content:
+  field_unit_contact_title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_unit_contact_unit:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_unit_contact_use_address:
+    type: boolean_checkbox
+    weight: 2
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_details:
+    type: boolean_checkbox
+    weight: 8
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_link:
+    type: boolean_checkbox
+    weight: 9
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_opening:
+    type: boolean_checkbox
+    weight: 5
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_override:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_phone:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_picture:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_unit_contact_use_postal:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.paragraph.unit_accessibility_information.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.paragraph.unit_accessibility_information.default.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.default
+targetEntityType: paragraph
+bundle: unit_accessibility_information
+mode: default
+content:
+  field_unit_accessibility_unit:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.paragraph.unit_contact_card.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.paragraph.unit_contact_card.default.yml
@@ -1,0 +1,45 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.unit_contact_card.field_unit_contact_title
+    - field.field.paragraph.unit_contact_card.field_unit_contact_unit
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_address
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_details
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_link
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_opening
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_override
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_phone
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_picture
+    - field.field.paragraph.unit_contact_card.field_unit_contact_use_postal
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.default
+targetEntityType: paragraph
+bundle: unit_contact_card
+mode: default
+content:
+  field_unit_contact_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_unit_contact_unit:
+    type: entity_reference_label
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  field_unit_contact_use_address: true
+  field_unit_contact_use_details: true
+  field_unit_contact_use_link: true
+  field_unit_contact_use_opening: true
+  field_unit_contact_use_override: true
+  field_unit_contact_use_phone: true
+  field_unit_contact_use_picture: true
+  field_unit_contact_use_postal: true

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_accessibility_unit
+    - paragraphs.paragraphs_type.unit_accessibility_information
+id: paragraph.unit_accessibility_information.field_unit_accessibility_unit
+field_name: field_unit_accessibility_unit
+entity_type: paragraph
+bundle: unit_accessibility_information
+label: Unit
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:tpr_unit'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: name
+      direction: DESC
+    auto_create: false
+field_type: entity_reference

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_title.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_title
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_title
+field_name: field_unit_contact_title
+entity_type: paragraph
+bundle: unit_contact_card
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_unit.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_unit.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_unit
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_unit
+field_name: field_unit_contact_unit
+entity_type: paragraph
+bundle: unit_contact_card
+label: Unit
+description: 'Add here the unit that you want to appear as the contact card. The unit doesn''t have to be published.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:tpr_unit'
+  handler_settings:
+    target_bundles: null
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+field_type: entity_reference

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_address.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_address.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_address
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_address
+field_name: field_unit_contact_use_address
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show address'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_details.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_details.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_details
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_details
+field_name: field_unit_contact_use_details
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show additional details'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_link.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_link.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_link
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_link
+field_name: field_unit_contact_use_link
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show link to unit page'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_opening.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_opening.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_opening
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_opening
+field_name: field_unit_contact_use_opening
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show opening hours'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_override.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_override.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_override
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_override
+field_name: field_unit_contact_use_override
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Prefer override picture'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_phone.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_phone.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_phone
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_phone
+field_name: field_unit_contact_use_phone
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show phone number'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_picture.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_picture.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_picture
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_picture
+field_name: field_unit_contact_use_picture
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show picture'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_postal.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.paragraph.unit_contact_card.field_unit_contact_use_postal.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_unit_contact_use_postal
+    - paragraphs.paragraphs_type.unit_contact_card
+id: paragraph.unit_contact_card.field_unit_contact_use_postal
+field_name: field_unit_contact_use_postal
+entity_type: paragraph
+bundle: unit_contact_card
+label: 'Show postal address'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_accessibility_unit.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_accessibility_unit.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - paragraphs
+id: paragraph.field_unit_accessibility_unit
+field_name: field_unit_accessibility_unit
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: tpr_unit
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_title.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_title
+field_name: field_unit_contact_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_unit.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_unit.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_tpr
+    - paragraphs
+id: paragraph.field_unit_contact_unit
+field_name: field_unit_contact_unit
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: tpr_unit
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_address.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_address.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_address
+field_name: field_unit_contact_use_address
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_details.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_details.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_details
+field_name: field_unit_contact_use_details
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_link.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_link.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_link
+field_name: field_unit_contact_use_link
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_opening.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_opening.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_opening
+field_name: field_unit_contact_use_opening
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_override.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_override.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_override
+field_name: field_unit_contact_use_override
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_phone.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_phone.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_phone
+field_name: field_unit_contact_use_phone
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_picture.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_picture.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_picture
+field_name: field_unit_contact_use_picture
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_postal.yml
+++ b/modules/helfi_tpr_config/config/install/field.storage.paragraph.field_unit_contact_use_postal.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_unit_contact_use_postal
+field_name: field_unit_contact_use_postal
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_accessibility_information.field_unit_accessibility_unit.yml
@@ -1,0 +1,1 @@
+label: Toimipiste

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_title.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_title.yml
@@ -1,0 +1,1 @@
+label: Otsikko

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_unit.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_unit.yml
@@ -1,0 +1,2 @@
+label: Toimipiste
+description: 'Lisää tähän sen toimipisteen otsikko jonka haluat nostaa sivulle. Toimipisteen ei tarvitse olla julkaistu.'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_address.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_address.yml
@@ -1,0 +1,1 @@
+label: 'Näytä katuosoite'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_details.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_details.yml
@@ -1,0 +1,1 @@
+label: 'Näytä lisätiedot'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_link.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_link.yml
@@ -1,0 +1,1 @@
+label: 'Näytä linkki toimipistesivulle'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_opening.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_opening.yml
@@ -1,0 +1,1 @@
+label: 'Näytä aukioloajat'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_override.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_override.yml
@@ -1,0 +1,1 @@
+label: 'Suosi ylikirjoituskuvaa'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_phone.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_phone.yml
@@ -1,0 +1,1 @@
+label: 'Näytä puhelinnumero'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_picture.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_picture.yml
@@ -1,0 +1,1 @@
+label: 'Näytä kuva'

--- a/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_postal.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/field.field.paragraph.unit_contact_card.field_unit_contact_use_postal.yml
@@ -1,0 +1,1 @@
+label: 'Näytä postiosoite'

--- a/modules/helfi_tpr_config/config/install/language/fi/paragraphs.paragraphs_type.unit_accessibility_information.yml
+++ b/modules/helfi_tpr_config/config/install/language/fi/paragraphs.paragraphs_type.unit_accessibility_information.yml
@@ -1,0 +1,1 @@
+label: 'Toimipisteen esteettömyystiedot'

--- a/modules/helfi_tpr_config/config/install/paragraphs.paragraphs_type.unit_accessibility_information.yml
+++ b/modules/helfi_tpr_config/config/install/paragraphs.paragraphs_type.unit_accessibility_information.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: unit_accessibility_information
+label: 'Unit accessibility information'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/modules/helfi_tpr_config/config/install/paragraphs.paragraphs_type.unit_contact_card.yml
+++ b/modules/helfi_tpr_config/config/install/paragraphs.paragraphs_type.unit_contact_card.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: unit_contact_card
+label: 'Unit contact card'
+icon_uuid: null
+icon_default: null
+description: 'With unit contact card you can reference to a single unit inside this site. The information about the unit is automatically fetched through the reference. Shown information can be customized and the unit doesn''t need to be published.'
+behavior_plugins: {  }

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -245,8 +245,7 @@ function helfi_tpr_config_update_9041(): void {
 }
 
 /**
- * UHF-8770 Add unit_accessibility_information and unit_contact_card
- * paragraphs.
+ * UHF-8770 tpr_service to include two new paragraphs.
  */
 function helfi_tpr_config_update_9042(): void {
   // Re-import 'helfi_tpr_config' configuration.
@@ -255,10 +254,8 @@ function helfi_tpr_config_update_9042(): void {
 }
 
 /**
- * UHF-8770 Make unit_accessibility_information and unit_contact_card
- * paragraphs usable in TPR Service.
+ * UHF-8770 Make the new paragraphs usable on tpr_service.
  */
 function helfi_tpr_config_update_9043(): void {
   helfi_platform_config_update_paragraph_target_types();
 }
-

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -243,3 +243,22 @@ function helfi_tpr_config_update_9040(): void {
 function helfi_tpr_config_update_9041(): void {
   helfi_platform_config_update_paragraph_target_types();
 }
+
+/**
+ * UHF-8770 Add unit_accessibility_information and unit_contact_card
+ * paragraphs.
+ */
+function helfi_tpr_config_update_9042(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}
+
+/**
+ * UHF-8770 Make unit_accessibility_information and unit_contact_card
+ * paragraphs usable in TPR Service.
+ */
+function helfi_tpr_config_update_9043(): void {
+  helfi_platform_config_update_paragraph_target_types();
+}
+

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -64,6 +64,8 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
           'contact_card_listing',
           'map',
           'event_list',
+          'unit_accessibility_information',
+          'unit_contact_card',
         ],
         'field_sidebar_content' => [
           'sidebar_text',
@@ -85,6 +87,8 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
           'phasing',
           'contact_card_listing',
           'map',
+          'unit_accessibility_information',
+          'unit_contact_card',
         ],
       ],
     ],


### PR DESCRIPTION
# [UHF-8770](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8770)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add the configuration and update hooks that enable the unit contact card and unit accessibility information blocks on all instances where TPR is on for the service pages.

## How to install
* Check instructions from the HDBT PR linked below.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check the testing instructions from the HDBT PR linked below.
* [ ] Check that code follows our standards.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/758
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/573
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/633


[UHF-8870]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-8770]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ