### PR TITLE
UHF-8564: Remove unwanted and unused allowed html from text-formats

### DIFF
--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -21,7 +21,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote role aria-* cite class=""> <code> <ul type class=""> <ol start type> <li class=""> <dl> <dt> <dd> <h2> <h3> <h4> <h5> <h6> <p class=""> <footer class=""> <br> <div role aria-* class=""> <img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style> <a href hreflang !href accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <pre> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th colspan rowspan> <td colspan rowspan> <tr> <hr> <span role aria-* lang dir class="">'
+      allowed_html: '<em> <strong> <cite> <blockquote aria-* class=""> <ul> <ol start> <li> <h2> <h3> <h4> <h5> <h6> <p class=""> <footer class=""> <br> <a href hreflang !href rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <s> <sup> <sub> <table> <caption> <tbody> <thead> <tfoot> <th colspan rowspan> <td colspan rowspan> <tr> <hr> <span role aria-* lang dir class="">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<em> <strong> <ul type> <ol start type> <li> <p class=""> <a href hreflang !href accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <span role aria-* lang dir class="">'
+      allowed_html: '<em> <strong> <ul> <ol start> <li> <p class=""> <a href hreflang !href rel target title data-design data-link-text data-selected-icon data-is-external data-protocol class=""> <span role aria-* lang dir class="">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -117,3 +117,11 @@ function helfi_ckeditor_update_9003(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_ckeditor');
 }
+
+/**
+ * UHF-8564 Remove unwanted and unused allowed html from text-formats.
+ */
+function helfi_ckeditor_update_9004(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_ckeditor');
+}


### PR DESCRIPTION
# [UHF-8564](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8564)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed unwanted and unused allowed html from text-formats.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8564`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to `/admin/config/content/formats` and check the that the html and minimal text formats are now in line with the new configuration. Its easiest to see what has changed from the diff on "Files changed" tab.
* [x] Testing this thoroughly would require siteimprove searches for the content to see if the things that are removed affect the current content. I think it is up to the tester to decide what to test. There is some content that will be removed if the content that is breaking these new rules is saved but the breaking will be minimal and in places where there is things pasted from other sources without thinking.
* [x] Check that code follows our standards


[UHF-8564]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ