### PR TITLE
Updated genesys chat domains.

### DIFF
--- a/assets/js/genesys_auth_redirect.js
+++ b/assets/js/genesys_auth_redirect.js
@@ -31,9 +31,9 @@ function callShibboleth()
     interactionId = getCookieChat("gcReturnSessionId");
 	//Current url without querystring:
 	var currentPage = location.toString().replace(location.search, "");
-	var shibbolethString = "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+	var shibbolethString = "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
 	shibbolethString += "target=";
-    shibbolethString += "https://asiointi.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
+    shibbolethString += "https://chat-proxy.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
 	console.log('currentPage:'+currentPage);
     shibbolethString += "%3ForigPage%3D" + currentPage + "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
 	shibbolethString += "%26" + "interactionId" + "%3D" + interactionId;
@@ -44,13 +44,13 @@ var _genesys = {
     onReady: [],
     chat: {
         registration: false,
-        localization : 'https://asiointi.hel.fi/chat/sote/custom/chat-suunte-fi.json',
+        localization : 'https://chat-proxy.hel.fi/chat/sote/custom/chat-suunte-fi.json',
         onReady: [],
         ui: {
             onBeforeChat: function (chat) {
                 _genesys.chat.onReady.push(function (chatWidgetApi) {
                     chatWidgetApi.restoreChat({
-                        serverUrl: "https://asiointi.hel.fi/chat/sote/cobrowse",
+                        serverUrl: "https://chat-proxy.hel.fi/chat/sote/cobrowse",
                         registration: function (done) {
                             done({
                                  service: 'SUUNTE'

--- a/assets/js/genesys_kymp.js
+++ b/assets/js/genesys_kymp.js
@@ -253,7 +253,7 @@
           preload: ["webchat"],
         },
         webchat: {
-          dataURL: "https://asiointi.hel.fi/gms/sote/genesys/2/chat/prod",
+          dataURL: "https://chat-proxy.hel.fi/gms/sote/genesys/2/chat/prod",
           confirmFormCloseEnabled: false,
           userData: {
             service: helFiChat_service,

--- a/assets/js/genesys_neuvonta.js
+++ b/assets/js/genesys_neuvonta.js
@@ -80,7 +80,7 @@
       /* CHAT START BUTTON ICONS */
       var helFiChat_button = "";
 
-      // https://asiointi.hel.fi/chat/kanslia/custom/chat-virkainfo-fi.json
+      // https://chat-proxy.hel.fi/chat/kanslia/custom/chat-virkainfo-fi.json
 
       switch (helfiChat_lang) {
         case 'fi':
@@ -296,7 +296,7 @@
           preload: ["webchat"],
         },
         webchat: {
-          dataURL: "https://asiointi.hel.fi/gms/kanslia/genesys/2/chat/prod",
+          dataURL: "https://chat-proxy.hel.fi/gms/kanslia/genesys/2/chat/prod",
           confirmFormCloseEnabled: false,
           userData: {
             service: helFiChat_service,

--- a/assets/js/genesys_suunte.js
+++ b/assets/js/genesys_suunte.js
@@ -253,7 +253,7 @@ var gcReturnSessionId = '';
           preload: ["webchat"],
         },
         webchat: {
-          dataURL: "https://asiointi.hel.fi/gms/sote/genesys/2/chat/prod",
+          dataURL: "https://chat-proxy.hel.fi/gms/sote/genesys/2/chat/prod",
           confirmFormCloseEnabled: false,
           userData: {
             service: helFiChat_service,


### PR DESCRIPTION
# [UHF-8915](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8915)
<!-- What problem does this solve? -->
Domains used in Genesys chat APIs is changing.

## What was done
<!-- Describe what was done -->

* Updated the domains used in Genesys chat.

## How to install
* Make sure your _etusivu_, _kymp_ and _sote_ instances are up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config on each of those instances
    * `composer require drupal/helfi_platform_config:dev-UHF-8915_Genesys-domain-change`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the chat still works on following pages:
- https://helfi-etusivu.docker.so/fi
- https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/pysakointi
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/hammashoito
* [x] If you want to be sure that the updated domains are in use, open the Network tab in the developer tools and try writing something on the chat.
* [x] Check that code follows our standards


[UHF-8915]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ