### PR TITLE
UHF-8875: generate random password for uid 1 user

### DIFF
--- a/modules/helfi_user_roles/helfi_user_roles.install
+++ b/modules/helfi_user_roles/helfi_user_roles.install
@@ -8,6 +8,7 @@
 declare(strict_types = 1);
 
 use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
 
 /**
  * Grants required permissions.
@@ -69,5 +70,32 @@ function helfi_user_roles_update_9001() : void {
     'is_admin' => TRUE,
     'weight' => 7,
   ])
+    ->save();
+}
+
+/**
+ * Randomize password for uid 1 user.
+ */
+function helfi_user_roles_update_9002() : void {
+  try {
+    // Attempt to resolve active environment. If this throws an exception, this
+    // is not running in the main instances, and we don't want to change the
+    // password.
+    \Drupal::service('helfi_api_base.environment_resolver')->getActiveEnvironment();
+  }
+  catch (\InvalidArgumentException) {
+    return;
+  }
+
+  $user = User::load(1);
+  if (empty($user)) {
+    return;
+  }
+
+  // Random password, 192 bits of entropy.
+  $password = base64_encode(random_bytes(24));
+
+  $user
+    ->setPassword($password)
     ->save();
 }


### PR DESCRIPTION
# [UHF-8875](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8875)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Generate randomized password for uid 1 user.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config.
    * `composer require drupal/helfi_platform_config:dev-UHF-8875-randomize-admin-password`
* Set some password for admin user: `drush user:password helfi-admin 123`.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Run the update hook: `drush updb -y`.
* [x] Verify that you are not able to log in anymore with password `123`.
* [x] Check that code follows our standards.

## Other PRs
<!-- For example an related PR in another repository -->

* #566 

[UHF-8875]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ