### PR TITLE
UHF-8717: Add field for hiding automatic service point listing

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_service.tpr_service.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_service.tpr_service.default.yml
@@ -30,7 +30,7 @@ content:
     third_party_settings: {  }
   errand_services:
     type: readonly_field_widget
-    weight: 7
+    weight: 8
     region: content
     settings:
       label: above
@@ -39,25 +39,6 @@ content:
       show_description: false
     third_party_settings: {  }
   field_content:
-    type: paragraphs
-    weight: 9
-    region: content
-    settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: open
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: text
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
-    third_party_settings: {  }
-  field_lower_content:
     type: paragraphs
     weight: 11
     region: content
@@ -76,16 +57,35 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
+  field_lower_content:
+    type: paragraphs
+    weight: 15
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: text
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 8
+    weight: 10
     region: content
     settings:
       sidebar: false
     third_party_settings: {  }
   field_sidebar_content:
     type: paragraphs
-    weight: 10
+    weight: 12
     region: content
     settings:
       title: Paragraph
@@ -104,7 +104,7 @@ content:
     third_party_settings: {  }
   has_unit:
     type: readonly_field_widget
-    weight: 27
+    weight: 18
     region: content
     settings:
       label: above
@@ -112,9 +112,16 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  hide_service_points:
+    type: boolean_checkbox
+    weight: 14
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   hide_sidebar_navigation:
     type: boolean_checkbox
-    weight: 21
+    weight: 16
     region: content
     settings:
       display_label: true
@@ -128,7 +135,7 @@ content:
     third_party_settings: {  }
   links:
     type: readonly_field_widget
-    weight: 6
+    weight: 7
     region: content
     settings:
       label: above
@@ -156,7 +163,7 @@ content:
     third_party_settings: {  }
   name_synonyms:
     type: readonly_field_widget
-    weight: 26
+    weight: 17
     region: content
     settings:
       label: above
@@ -166,13 +173,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   service_id:
     type: readonly_field_widget
-    weight: 28
+    weight: 19
     region: content
     settings:
       label: above
@@ -181,7 +188,7 @@ content:
       show_description: false
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.default.yml
@@ -108,6 +108,7 @@ content:
 hidden:
   created: true
   has_unit: true
+  hide_service_points: true
   langcode: true
   name_synonyms: true
   service_id: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.teaser.yml
@@ -46,6 +46,7 @@ hidden:
   field_metatags: true
   field_sidebar_content: true
   has_unit: true
+  hide_service_points: true
   langcode: true
   links: true
   name_synonyms: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.teaser_search_result.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service.tpr_service.teaser_search_result.yml
@@ -90,6 +90,7 @@ hidden:
   field_metatags: true
   field_sidebar_content: true
   has_unit: true
+  hide_service_points: true
   langcode: true
   links: true
   name_override: true

--- a/modules/helfi_tpr_config/helfi_tpr_config.info.yml
+++ b/modules/helfi_tpr_config/helfi_tpr_config.info.yml
@@ -15,4 +15,4 @@ dependencies:
   - 'views_bulk_edit:views_bulk_edit'
   - 'views_bulk_operations:views_bulk_operations'
 'interface translation project': helfi_tpr_config
-'interface translation server pattern': modules/contrib/helfi_platform_config/helfi_features/helfi_tpr_config/translations/%language.po
+'interface translation server pattern': modules/contrib/helfi_platform_config/modules/helfi_tpr_config/translations/%language.po

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -7,7 +7,6 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\linkit\Entity\Profile;
@@ -275,5 +274,5 @@ function helfi_tpr_config_update_9043() : void {
 
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
-  ->update('helfi_tpr_config');
+    ->update('helfi_tpr_config');
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -7,6 +7,9 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\linkit\Entity\Profile;
 
 /**
@@ -251,4 +254,26 @@ function helfi_tpr_config_update_9042(): void {
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
+}
+
+/**
+ * UHF-8717: Add a field to tpr_service and re-import configs.
+ */
+function helfi_tpr_config_update_9043() : void {
+  $fields = [];
+  $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(new TranslatableMarkup('Hide service points'))
+    ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
+    ->setTranslatable(TRUE)
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+
+  foreach ($fields as $name => $field) {
+    \Drupal::entityDefinitionUpdateManager()
+      ->installFieldStorageDefinition($name, 'tpr_service', 'helfi_tpr_config', $field);
+  }
+
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+  ->update('helfi_tpr_config');
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -261,8 +261,8 @@ function helfi_tpr_config_update_9042(): void {
 function helfi_tpr_config_update_9043() : void {
   $fields = [];
   $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
-    ->setLabel(new TranslatableMarkup('Hide service points'))
-    ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
+    ->setLabel(new TranslatableMarkup('Hide service units listing'))
+    ->setDescription(new TranslatableMarkup('Select this if you link from the page to a filter search or another listing.'))
     ->setTranslatable(TRUE)
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE);

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -424,6 +424,9 @@ function template_preprocess_tpr_service_lower_content(array &$variables) : void
   }
   if (isset($variables['elements']['#tpr_service'])) {
     $variables['entity'] = $variables['elements']['#tpr_service'];
+    // Get 'hide_service_points' field value and pass it to the template.
+    $hide_service_points = $variables['entity']->get('hide_service_points')->value;
+    $variables['hide_service_points'] = boolval($hide_service_points);
   }
 }
 

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -7,7 +7,10 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Render\Element;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\helfi_tpr_config\Entity\ServiceList;
@@ -474,4 +477,21 @@ function helfi_tpr_config_form_views_exposed_form_alter(&$form, $form_state) : v
       ->get('field_unit_search_meta_placehold')
       ->value;
   }
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_type) : array {
+  $fields = [];
+
+  if ($entity_type->id() === 'tpr_service') {
+    $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
+    ->setLabel(new TranslatableMarkup('Hide service points'))
+    ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
+    ->setTranslatable(TRUE)
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE);
+  }
+  return $fields;
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -487,11 +487,11 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
 
   if ($entity_type->id() === 'tpr_service') {
     $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
-    ->setLabel(new TranslatableMarkup('Hide service points'))
-    ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
-    ->setTranslatable(TRUE)
-    ->setDisplayConfigurable('form', TRUE)
-    ->setDisplayConfigurable('view', TRUE);
+      ->setLabel(new TranslatableMarkup('Hide service points'))
+      ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
+      ->setTranslatable(TRUE)
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
   }
   return $fields;
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -487,8 +487,8 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
 
   if ($entity_type->id() === 'tpr_service') {
     $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
-      ->setLabel(new TranslatableMarkup('Hide service points'))
-      ->setDescription(new TranslatableMarkup('Hide automatic service units listing'))
+      ->setLabel(new TranslatableMarkup('Hide service units listing'))
+      ->setDescription(new TranslatableMarkup('Select this if you link from the page to a filter search or another listing.'))
       ->setTranslatable(TRUE)
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);

--- a/modules/helfi_tpr_config/translations/fi.po
+++ b/modules/helfi_tpr_config/translations/fi.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+
+msgid "Hide service units listing"
+msgstr "Piilota palvelupaikkojen listaus"
+
+msgid "Select this if you link from the page to a filter search or another listing."
+msgstr "Valitse tämä, jos linkität sivulta palvelupaikkojen suodatushakuun tai muuhun listaukseen."

--- a/modules/helfi_tpr_config/translations/sv.po
+++ b/modules/helfi_tpr_config/translations/sv.po
@@ -1,0 +1,8 @@
+msgid ""
+msgstr ""
+
+msgid "Hide service units listing"
+msgstr "Dölj listan om serviceställen"
+
+msgid "Select this if you link from the page to a filter search or another listing."
+msgstr "Välj detta om du länkar från sidan till en filtersökning eller till en separat lista."


### PR DESCRIPTION
# [UHF-8717](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8717)
A feature to hide service points is needed.

## What was done
- Added a checkbox field for hiding the service points.
- Added translations for the new field label and description.
- Added a helper variable for use in the twigs.

## How to install

* Make sure your instance (any instance with tpr_service content) is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the hdbt theme and platform config
    * `composer require drupal/hdbt:dev-UHF-8717_Hiding-service-points`
    * `composer require drupal/helfi_platform_config:dev-UHF-8717_Hiding-service-points`
* Run `make drush-updb drush-cr drush-local-update`

## How to test

- [x] Check that the `updb` runs nicely.
- [x] Open a tpr service page that has a list of services in the bottom of the page. Go edit the page and see the new checkbox "Hide service points".
- [x] Check that the translations for the checkbox label and description work (might need to change the UI language from the user's settings)
- [x] Check that code follows our standards.
- [ ] Check the [other PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/771).

## Troubleshooting
1. Translations don't apply? Try running `drush cr; drush locale:update` separately without the `locale:check` etc.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/771


[UHF-8717]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ