### PR TITLE
Reverted the chat domain change.

### DIFF
--- a/assets/js/genesys_auth_redirect.js
+++ b/assets/js/genesys_auth_redirect.js
@@ -31,9 +31,9 @@ function callShibboleth()
     interactionId = getCookieChat("gcReturnSessionId");
 	//Current url without querystring:
 	var currentPage = location.toString().replace(location.search, "");
-	var shibbolethString = "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+	var shibbolethString = "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
 	shibbolethString += "target=";
-    shibbolethString += "https://chat-proxy.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
+    shibbolethString += "https://asiointi.hel.fi/chat/tunnistus/MagicPagePlain/ReturnProcessor";
 	console.log('currentPage:'+currentPage);
     shibbolethString += "%3ForigPage%3D" + currentPage + "?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
 	shibbolethString += "%26" + "interactionId" + "%3D" + interactionId;
@@ -44,7 +44,7 @@ var _genesys = {
     onReady: [],
     chat: {
         registration: false,
-        localization : 'https://chat-proxy.hel.fi/chat/sote/custom/chat-suunte-fi.json',
+        localization : 'https://asiointi.hel.fi/chat/sote/custom/chat-suunte-fi.json',
         onReady: [],
         ui: {
             onBeforeChat: function (chat) {


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
The new domain for genesys chat services doesn't work in the authentication URLs.

## What was done
<!-- Describe what was done -->

* Reverted the changed domains.

## How to install
* Make sure your sote instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_Revert-genesys-chat-domain-change`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/hammashoito and check that the chat still works and the login link inside the chat goes to a login page.
* [ ] Check that code follows our standards
