### PR TITLE
Use old domains for auth URLs in chats

### DIFF
--- a/assets/js/genesys_kymp.js
+++ b/assets/js/genesys_kymp.js
@@ -96,10 +96,10 @@
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://asiointi.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */

--- a/assets/js/genesys_neuvonta.js
+++ b/assets/js/genesys_neuvonta.js
@@ -112,10 +112,10 @@
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://asiointi.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */

--- a/assets/js/genesys_suunte.js
+++ b/assets/js/genesys_suunte.js
@@ -145,10 +145,10 @@ var gcReturnSessionId = '';
         );
         var currentPage = window.location;
         var shibbolethString =
-          "https://chat-proxy.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
+          "https://asiointi.hel.fi/chat/tunnistus/Shibboleth.sso/KAPALogin?";
         shibbolethString += "target=";
         shibbolethString +=
-          "https://chat-proxy.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
+          "https://asiointi.hel.fi/chat/tunnistus/MagicPage/ReturnProcessor";
         /*
               shibbolethString += "%3ForigPage%3D" + "https://www.hel.fi/helsinki/fi/sosiaali-ja-terveyspalvelut/terveyspalvelut/hammashoito/transfer?dir%3Din%26gcLoginButtonState%3D1%26errcode%3d0";
               */

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -19,7 +19,7 @@ smartti_chatbot:
       assets/css/smartti_chat.css: {}
 
 genesys_kymp:
-  version: 1.0.x
+  version: 1.0.1
   header: true
   js:
     'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
@@ -51,7 +51,7 @@ clear_localstorage:
     - core/drupal
 
 genesys_suunte:
-  version: 1.0.x
+  version: 1.0.1
   header: true
   js:
     'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
@@ -92,7 +92,7 @@ genesys_auth_redirect:
     - core/drupalSettings
 
 genesys_neuvonta:
-  version: 1.0.x
+  version: 1.0.1
   header: true
   js:
     'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {


### PR DESCRIPTION
# [UHF-8981](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8981)
<!-- What problem does this solve? -->
The new domain for genesys chat services doesn't work in the authentication URLs.

## What was done
<!-- Describe what was done -->

* Reverted the changed domains but only the URLs that have `/chat/tunnistus` in them.

## How to install
* Make sure your sote instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8981_Use-old-chat-auth-domains`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check the code changes: `chat-proxy.hel.fi` domains should have been changed to `asiointi.hel.fi`.


[UHF-8981]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ