### PR TITLE
Get field_phasing_title_level value instead offield_phasing_item_title_level value

### DIFF
--- a/modules/helfi_paragraphs_phasing/src/Entity/Phasing.php
+++ b/modules/helfi_paragraphs_phasing/src/Entity/Phasing.php
@@ -17,7 +17,7 @@ class Phasing extends Paragraph implements ParagraphInterface {
    *   heading level.
    */
   public function getHeadingLevel() {
-    $headingLevel = $this->get('field_phasing_item_title_level')
+    $headingLevel = $this->get('field_phasing_title_level')
       ->getString();
 
     return "h$headingLevel";


### PR DESCRIPTION
## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_phasing`
* Run `make drush-updb drush-cr`

## How to test
Edit basic page
- Add toc and a phasing paragraph to the page
- Set phasing paragraphs title level as H2, fill the rest of the phasing paragraph
- Save the page

Go check the content. 
- Toc should have the the phasing paragraphs title as an item
- Phasing paragraph title level should math what you selected earlier
