### PR TITLE
UHF-8910 menu publish

### DIFF
--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -45,3 +45,11 @@ services:
     class: Drupal\helfi_platform_config\Routing\TermRouteSubscriber
     tags:
       - { name: event_subscriber }
+
+  helfi_platform_config.filter_disabled_translations:
+    class: Drupal\helfi_platform_config\Menu\FilterDisabledTranslations
+    arguments:
+      - '@entity_type.manager'
+      - '@language_manager'
+    tags:
+      - { name: event_subscriber }

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_platform_config\Menu;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\menu_block_current_language\Event\Events;
+use Drupal\menu_block_current_language\Event\HasTranslationEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * #UHF-8910 Filter menu items without enabled translation on current langcode.
+ */
+final class FilterDisabledTranslations implements EventSubscriberInterface {
+
+
+  /**
+   * The constructor.
+   *
+   * @param EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param LanguageManagerInterface $languageManager
+   *   The language manager.
+   */
+  public function __construct(
+    readonly private EntityTypeManagerInterface $entityTypeManager,
+    readonly private LanguageManagerInterface $languageManager
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array
+  {
+    return [
+      Events::HAS_TRANSLATION => [
+        ['filter'],
+      ],
+    ];
+  }
+
+  /**
+   * Responds to Events::HAS_TRANSLATION event.
+   *
+   * @param Drupal\menu_block_current_language\Event\Events $event
+   *   The event subscribed to.
+   */
+  public function filter(HasTranslationEvent $event): void {
+    $link = $event->getLink();
+    $metadata = $link->getMetaData();
+
+    if (empty($metadata['entity_id'])) {
+      return;
+    }
+
+    $entity = $this->entityTypeManager->getStorage('menu_link_content')
+      ->load($metadata['entity_id']);
+    $current_language = $this->languageManager
+      ->getCurrentLanguage()
+      ->getId();
+
+    // Entity has translation but it is not enabled, hide it.
+    if (
+      $entity->getMenuName() == 'main' &&
+      $entity->hasTranslation($current_language)
+    ) {
+      $translation_enabled = (bool) $entity->getTranslation($current_language)
+        ->content_translation_status
+        ->value;
+      if (!$translation_enabled) {
+        $event->setHasTranslation(FALSE);
+      }
+    }
+  }
+
+}

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -62,20 +62,7 @@ final class FilterDisabledTranslations implements EventSubscriberInterface {
     $current_language = $this->languageManager
       ->getCurrentLanguage()
       ->getId();
-
-    // Hide links with node translation unpublished
-    if ($link->getRouteName() == 'entity.node.canonical') {
-      $params = $link->getRouteParameters();
-      $nid = $params['node'];
-      $node = Node::load($nid);
-
-      if ($node->hasTranslation($current_language)) {
-          $translated_node = $node->getTranslation($current_language);
-          $event->setHasTranslation($translated_node->isPublished());
-          return;
-      }
-    }
-
+    
     $entity = $this->entityTypeManager->getStorage('menu_link_content')
       ->load($metadata['entity_id']);
 

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -6,7 +6,6 @@ namespace Drupal\helfi_platform_config\Menu;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
-use Drupal\node\Entity\Node;
 use Drupal\menu_block_current_language\Event\Events;
 use Drupal\menu_block_current_language\Event\HasTranslationEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -62,7 +61,7 @@ final class FilterDisabledTranslations implements EventSubscriberInterface {
     $current_language = $this->languageManager
       ->getCurrentLanguage()
       ->getId();
-    
+
     $entity = $this->entityTypeManager->getStorage('menu_link_content')
       ->load($metadata['entity_id']);
 

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -15,7 +15,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 final class FilterDisabledTranslations implements EventSubscriberInterface {
 
-
   /**
    * The constructor.
    *

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -11,16 +11,16 @@ use Drupal\menu_block_current_language\Event\HasTranslationEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * #UHF-8910 Filter menu items without enabled translation on current langcode.
+ * UHF-8910 Filter menu items without enabled translation on current langcode.
  */
 final class FilterDisabledTranslations implements EventSubscriberInterface {
 
   /**
    * The constructor.
    *
-   * @param EntityTypeManagerInterface $entityTypeManager
+   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
-   * @param LanguageManagerInterface $languageManager
+   * @param Drupal\Core\Language\LanguageManagerInterface $languageManager
    *   The language manager.
    */
   public function __construct(
@@ -32,8 +32,7 @@ final class FilterDisabledTranslations implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents(): array
-  {
+  public static function getSubscribedEvents(): array {
     return [
       Events::HAS_TRANSLATION => [
         ['filter'],

--- a/src/Menu/FilterDisabledTranslations.php
+++ b/src/Menu/FilterDisabledTranslations.php
@@ -47,6 +47,10 @@ final class FilterDisabledTranslations implements EventSubscriberInterface {
    *   The event subscribed to.
    */
   public function filter(HasTranslationEvent $event): void {
+    if (!$event->hasTranslation()) {
+      return;
+    }
+
     $link = $event->getLink();
     $metadata = $link->getMetaData();
 


### PR DESCRIPTION
# [UHF-8910](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8910)
Local main navigation can have menu items with wrong translation (swedish navigation has finnish links)
Local main navigation shows links to unpublished nodes
`Sote is a great candidate` for testing due to bunch of bad links under "disability services"-link in main menu

## What was done
Filter out links without proper translation from main navigation when incognito.
Filter out links related to unpublished node from main navigation when incognito.

`How to recreate:`
1. go to sote test-environment and check the english main navigation(incognito):  you should see bad links under "disablity services" link 

## How to install

* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8910_menu_publish`
* Run `make drush-updb drush-cr`

## How to test

### Using SOTE:
- Setup the site 
  - The menu should have bad links by default under 'disability services'-link
- Before the fix is installed, there should be 6 links under disability services
- After installing the fix to sote, disability services should have only 1 link under it

- Go and edit english main navigation. Check the links under disability services. `(#UHF-9012)`
  - Make sure the related nodes' translations are published.
  - Make sure the menu items' translations are published.

After publishing the nodes and menu links, incognito user should see correct links in main navigation


### Manually test adding new item to main navigation:
- Create a new node with all main languages (fi, en, sv). Add the node  to main navigation. Remember to set the node and translations published
  - Remember to translate node title and menu title
  - While creating translations for the node, make sure you add "julkaistu päävalikossa" for finnish and `one other translation`  
- Go and see the main navigation `incognito`
- Go through the translations: NOTE: You might need to refresh the page after switching language before the menu changes

`Result while browsing the translations:`
- Finnish should be seen as finnish
- The translation you added the "julkaistu päävalikossa" selection should be seen with correct translation
- For the third language, the menu link shouldn't be visible at all.


### Node status
- Unpublish any of the nodes translations which is currently visible in main navigation, other than finnish preferably (You should test finnish separately)

The unpublished node should not be visible in the main navigation


[UHF-8910]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ