### PR TITLE
UHF-8255 Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,3 @@ This repository holds configuration for the Hel.fi platform.
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.