### PR TITLE
UHF-9020 hearing api url

### DIFF
--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -45,3 +45,8 @@ services:
     class: Drupal\helfi_platform_config\Routing\TermRouteSubscriber
     tags:
       - { name: event_subscriber }
+
+  logger.channel.helfi_platform_config:
+    parent: logger.channel_base
+    arguments:
+      - 'helfi_platform_config'

--- a/modules/helfi_paragraphs_hearings/README.md
+++ b/modules/helfi_paragraphs_hearings/README.md
@@ -2,7 +2,7 @@
 
 Get hearings from "Kerrokantasi" service
 Site: https://kerrokantasi.hel.fi/hearings/list?lang=en
-Api: https://api.hel.fi/kerrokantasi/v1/hearing?format=json&langcode=fi&open=true (with query parameters)
+Api: https://kerrokantasi.api.hel.fi/v1/hearing?format=json&langcode=fi&open=true (with query parameters)
 
 ## Helfi_hearings
 - Uses external entity to fetch hearings

--- a/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
+++ b/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\InvalidArgumentException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Utils;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,7 +29,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 final class Hearings extends ExternalEntityStorageClientBase {
 
-  public const API_URL = 'https://api.hel.fi/kerrokantasi/v1/hearing?';
+  public const API_URL = 'https://kerrokantasi.api.hel.fi/v1/hearing?';
 
   public const HEARING_URL = 'https://kerrokantasi.hel.fi/';
 
@@ -47,6 +48,13 @@ final class Hearings extends ExternalEntityStorageClientBase {
   private ClientInterface $client;
 
   /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  private LoggerInterface $logger;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(
@@ -58,7 +66,7 @@ final class Hearings extends ExternalEntityStorageClientBase {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->languageManager = $container->get('language_manager');
     $instance->client = $container->get('http_client');
-
+    $instance->logger = $container->get('logger.channel.helfi_platform_config');
     return $instance;
   }
 
@@ -114,7 +122,7 @@ final class Hearings extends ExternalEntityStorageClientBase {
       }
     }
     catch (RequestException | GuzzleException | InvalidArgumentException $e) {
-      watchdog_exception('helfi_paragraphs_hearings', $e);
+      $this->logger->error('Hearings request failed with error: ' . $e->getMessage());
       return [];
     }
 


### PR DESCRIPTION
# [UHF-9020](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9020)
Hearings api was moved and the url changed. 

## What was done
Updated the api url.
Updated logging.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9020`
* Run `make drush-updb drush-cr`

## How to test
- Add a hearings paragraph to any landing page and save it
- Load the landing page
- The page should load normally and the paragraph should be visible with either:  
  - a list of active hearings
  - "no hearings found" -message

- Check the updated url from the readme, copy the api url and see that the url works on your browser 
- Compare the url to the one in `Hearings.php` `API_URL` constant
  - the constant's value should match the url you tried in your browser   
 
* [ ] Check that this feature works
* [ ] Check that code follows our standards


[UHF-9020]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ