### PR TITLE
UHF-8955: reconfigure simple_sitemap

### DIFF
--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -266,3 +266,24 @@ function helfi_base_content_update_9004() : void {
   $config_factory->getEditable('block.block.brandingnavigation')->delete();
   $config_factory->getEditable('block.block.hdbt_subtheme_brandingnavigation')->delete();
 }
+
+/**
+ * UHF-8955 simple_sitemap - do not process menu_link_content entities.
+ */
+function helfi_base_content_update_9005() : void {
+  $config_factory = Drupal::configFactory();
+
+  // Remove menu_link_content from enabled entity types:
+  $config = $config_factory->getEditable('simple_sitemap.settings');
+  if (!$config->isNew()) {
+    $enabled_entity_types = $config->get('enabled_entity_types');
+    $enabled_entity_types = array_values(array_filter($enabled_entity_types, static fn ($item) => $item !== 'menu_link_content'));
+    $config->set('enabled_entity_types', $enabled_entity_types);
+    $config->save();
+  }
+
+  // Remove remaining menu_link_content related settings.
+  $config_factory->getEditable('simple_sitemap.bundle_settings.default.menu_link_content.main')->delete();
+  $config_factory->getEditable('simple_sitemap.bundle_settings.default.menu_link_content.branding-navigation')->delete();
+  $config_factory->getEditable('simple_sitemap.bundle_settings.default.menu_link_content.account')->delete();
+}


### PR DESCRIPTION
# [UHF-8955](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8955)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change simple_sitemap configuration so that no sitemap links are generated from menu_link_content entities.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Regenerate sitemap: `drush ssg` 
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8955-simple-sitemap-settings`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Copy old sitemap to a temporary file: `curl -ks https://INSTANCE.docker.so/fi/sitemap.xml > old-sitemap.xml`.
* [x] Regenerate sitemap: `drush ssg`
* [x] Copy new sitemap to a temporary file: `curl -ks https://INSTANCE.docker.so/fi/sitemap.xml > new-sitemap.xml`. Compare changes: `diff old-sitemap.xml new-sitemap.xml`. Did this change break anything? 
* [x] Check that code follows our standards


[UHF-8955]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ