### PR TITLE
UHF-9099: Install and enable stomp module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "drupal/simple_sitemap": "^4.1",
         "drupal/siteimprove": "^2.0",
         "drupal/social_media": "^2.0",
-        "drupal/stomp": "^1.0",
+        "drupal/stomp": "^2.0",
         "drupal/token": "^1.9",
         "drupal/translatable_menu_link_uri": "^2.0",
         "drupal/view_unpublished": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "drupal/simple_sitemap": "^4.1",
         "drupal/siteimprove": "^2.0",
         "drupal/social_media": "^2.0",
+        "drupal/stomp": "^1.0",
         "drupal/token": "^1.9",
         "drupal/translatable_menu_link_uri": "^2.0",
         "drupal/view_unpublished": "^1.0",

--- a/modules/helfi_platform_config_base/helfi_platform_config_base.info.yml
+++ b/modules/helfi_platform_config_base/helfi_platform_config_base.info.yml
@@ -35,3 +35,4 @@ dependencies:
   - helfi_react_search:helfi_react_search
   - helfi_user_roles:helfi_user_roles
   - publication_date:publication_date
+  - stomp:stomp

--- a/modules/helfi_platform_config_base/helfi_platform_config_base.install
+++ b/modules/helfi_platform_config_base/helfi_platform_config_base.install
@@ -73,3 +73,11 @@ function helfi_platform_config_base_update_9001() : void {
     'helfi_paragraphs_hearings',
   ]);
 }
+
+/**
+ * Enable STOMP module.
+ */
+function helfi_platform_config_base_update_9002() : void {
+  $module_installer = Drupal::service('module_installer');
+  $module_installer->install(['stomp']);
+}


### PR DESCRIPTION
# [UHF-9099](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9099)
<!-- What problem does this solve? -->

## How to install
* `composer require drupal/helfi_platform_config:dev-UHF-9099`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run database updates and export config (`drush updb`, `drush cex`)
* [ ] Make sure drupal/stomp module was installed and enabled



[UHF-9099]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ