### PR TITLE
UHF-8939: Make all new TPR Unit fields visible in all instances

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -80,6 +80,16 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  contacts:
+    type: readonly_field_widget
+    region: content
+    weight: 36
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   description:
     type: readonly_field_widget
     weight: 13
@@ -162,6 +172,16 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  highlights:
+    type: readonly_field_widget
+    region: content
+    weight: 33
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -173,6 +193,16 @@ content:
     type: readonly_field_widget
     weight: 17
     region: content
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
+  links:
+    type: readonly_field_widget
+    region: content
+    weight: 31
     settings:
       label: above
       formatter_type: null
@@ -207,6 +237,26 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  opening_hours:
+    type: readonly_field_widget
+    region: content
+    weight: 32
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
+  other_info:
+    type: readonly_field_widget
+    region: content
+    weight: 34
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   path:
     type: path
     weight: 11
@@ -239,6 +289,16 @@ content:
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  price_info:
+    type: readonly_field_widget
+    region: content
+    weight: 35
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
     third_party_settings: {  }
   provided_languages:
     type: readonly_field_widget
@@ -292,6 +352,16 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  topical:
+    type: readonly_field_widget
+    region: content
+    weight: 31
+    settings:
+      label: above
+      formatter_type: null
+      formatter_settings: {  }
+      show_description: false
+    third_party_settings: {  }
   translation:
     weight: 5
     region: content
@@ -304,7 +374,7 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: { }
+    third_party_settings: {  }
   www:
     type: readonly_field_widget
     weight: 10

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -27,7 +27,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 15
+    weight: 14
     region: content
   accessibility_phone:
     type: string
@@ -35,14 +35,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 14
+    weight: 13
     region: content
   accessibility_sentences:
     type: tpr_accessibility_sentence
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 20
+    weight: 21
     region: content
   accessibility_www:
     type: link
@@ -54,14 +54,14 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 16
+    weight: 15
     region: content
   address:
     type: address_plain
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   address_postal:
     type: string
@@ -69,14 +69,21 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 10
+    weight: 9
     region: content
   call_charge_info:
     type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 12
+    weight: 11
+    region: content
+  contacts:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 26
     region: content
   description:
     type: text_default
@@ -91,7 +98,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 9
+    weight: 8
     region: content
   field_content:
     type: entity_reference_revisions_entity_view
@@ -100,7 +107,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 19
+    weight: 20
     region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
@@ -109,14 +116,14 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 21
+    weight: 22
     region: content
   field_metatags:
     type: metatag_empty_formatter
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 18
+    weight: 17
     region: content
   highlights:
     type: tpr_connection
@@ -138,8 +145,15 @@ content:
     label: hidden
     settings:
       link_to_entity: false
-    third_party_settings: {  }
+    third_party_settings: { }
     weight: 23
+    region: content
+  links:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 25
     region: content
   name:
     type: string
@@ -162,7 +176,14 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 7
+    region: content
+  other_info:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 18
     region: content
   phone:
     type: telephone_link
@@ -170,7 +191,7 @@ content:
     settings:
       title: ''
     third_party_settings: {  }
-    weight: 7
+    weight: 6
     region: content
   picture_url:
     type: imagecache_external_responsive_image
@@ -190,13 +211,20 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  price_info:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 19
+    region: content
   provided_languages:
     type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 22
+    weight: 23
     region: content
   service_map_embed:
     type: service_map_embed
@@ -206,7 +234,7 @@ content:
       link_title: 'Open larger map'
       target: true
     third_party_settings: {  }
-    weight: 11
+    weight: 10
     region: content
   services:
     type: entity_reference_label
@@ -214,7 +242,14 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 17
+    weight: 16
+    region: content
+  topical:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 27
     region: content
   unit_picture_caption:
     type: basic_string
@@ -233,7 +268,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 13
+    weight: 12
     region: content
 hidden:
   created: true

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -316,3 +316,12 @@ function helfi_tpr_config_update_9046(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-8939: Make all new TPR unit fields visible in form and display.
+ */
+function helfi_tpr_config_update_9047(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-8939](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8939)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Made all five new TPR unit fields visible in all instances.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Test this in the [other PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/157).
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/157)


[UHF-8939]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ