### PR TITLE
UHF-9113 clear invalid permissions

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains installation hooks for HELfi platform config module.
+ */
+
+/**
+ * UHF-9113: Remove obsolete hotjar permission.
+ */
+function helfi_platform_config_update_9301(): void {
+  helfi_platform_config_remove_permissions_from_all_roles([
+    'administer hotjar settings',
+  ]);
+}

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -304,6 +304,24 @@ function helfi_platform_config_grant_permissions(array $map): void {
 }
 
 /**
+ * Removes permissions from all roles.
+ *
+ * This function can be used in update hooks to ensure that deprecated
+ * permissions are removed.
+ *
+ * @param string[] $permissions
+ *   The list of permissions to remove.
+ */
+function helfi_platform_config_remove_permissions_from_all_roles(array $permissions): void {
+  $config_factory = \Drupal::configFactory();
+  foreach ($config_factory->listAll('user.role.') as $config_name) {
+    $role = $config_factory->getEditable($config_name);
+    $role->set('permissions', array_values(array_diff($role->get('permissions'), $permissions)));
+    $role->save(TRUE);
+  }
+}
+
+/**
  * Implements hook_tokens().
  */
 function helfi_platform_config_tokens(

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -39,8 +39,6 @@ function helfi_tpr_config_grant_permissions() : void {
       'update any tpr_unit',
       'update own tpr_service',
       'update own tpr_unit',
-      'update tpr_service',
-      'update tpr_unit',
       'view all tpr_service revisions',
       'view all tpr_unit revisions',
       'view unpublished tpr_errand_service',
@@ -333,4 +331,14 @@ function helfi_tpr_config_update_9048(): void {
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
+}
+
+/**
+ * UHF-9113: Remove invalid permissions.
+ */
+function helfi_tpr_config_update_9049(): void {
+  helfi_platform_config_remove_permissions_from_all_roles([
+    'update tpr_service',
+    'update tpr_unit',
+  ]);
 }


### PR DESCRIPTION
# [UHF-9113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove invalid/unused permissions.

Drupal 10 does not allow roles to have permissions that do not exists.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9113-clear-invalid-permissions`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/800
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/462
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/617


[UHF-9113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ