### PR TITLE
UHF-9113: sync changes from main to v4 branch

### DIFF
--- a/.github/workflows/v4-sync.yml
+++ b/.github/workflows/v4-sync.yml
@@ -10,13 +10,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: '4.x'
 
-      - name: Create pull request
+      - name: Rebase 4.x branch
         run: |
-          gh pr create \
-            --base main \
-            --head 4.x \
-            --title "main to 4.x" \
-            --body "Sync changes to 4.x branch" || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Set git user from the latest commit
+          git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+          git rebase origin/main
+          git push --force

--- a/.github/workflows/v4-sync.yml
+++ b/.github/workflows/v4-sync.yml
@@ -1,0 +1,22 @@
+name: v4 sync
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create pull request
+        run: |
+          gh pr create \
+            --base main \
+            --head 4.x \
+            --title "main to 4.x" \
+            --body "Sync changes to 4.x branch" || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "minimum-stability": "dev",
     "require": {
         "ext-curl": "*",
+        "drupal/core": "^9.5",
         "drupal/admin_toolbar": "^3.0",
         "drupal/allowed_formats": "^2.0",
         "drupal/config_ignore": "^2.3",


### PR DESCRIPTION
# [UHF-9113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

We need to release a new major revision for Drupal 10, since most of the patches in this repo are not compatible. My proposal is to have the drupal 10 related changes in a separate branch until we have upgraded everything. This PR adds automation to keep the `4.x` and `main` branches in sync with automatic pull requests, so we don't have to do manual porting.

## How to install
* N/A

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards


[UHF-9113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ