### PR TITLE
UHF-9158: language switcher titles visible for unpublished translations

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -24,6 +24,7 @@ use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\Entity\ParagraphsType;
 use Drupal\user\Entity\Role;
 
+
 /**
  * Implements hook_modules_installed().
  */
@@ -419,5 +420,42 @@ function helfi_platform_config_system_breadcrumb_alter(
 function helfi_platform_config_preprocess_react_and_share(&$variables) : void {
   if (Drupal::moduleHandler()->moduleExists('helfi_eu_cookie_compliance')) {
     $variables['privacy_policy_url'] = helfi_eu_cookie_compliance_get_privacy_policy_url();
+  }
+}
+
+/**
+ * Implements hook_language_switch_links_alter().
+ *
+ * #UHF-9158 main languages must be always visible on language switcher.
+ */
+function helfi_platform_config_language_switch_links_alter(array &$links) {
+  $params = \Drupal::routeMatch()->getParameters()->all();
+
+  $entity = NULL;
+  foreach ($params as $param) {
+    if ($param instanceof ContentEntityInterface) {
+      $entity = $param;
+      break;
+    }
+  }
+  if (!$entity) {
+    return;
+  }
+
+  foreach ($links as $langcode => $link) {
+    if (
+      !$entity->hasTranslation($langcode) ||
+      $entity->getTranslation($langcode)->isPublished()
+    ) {
+      continue;
+    }
+
+    // Replace the original unpublished translation link with another one and set it disabled.
+    // Unpublished link won't pass url access check so it must be replaced with published one.
+    unset($links[$langcode]['url']);
+    $url = new Url('<front>');
+    $links[$langcode]['#untranslated'] = TRUE;
+    $links[$langcode]['url'] = $url;
+    $links[$langcode]['attributes']['class'][] = 'language-link--untranslated';
   }
 }

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -427,7 +427,7 @@ function helfi_platform_config_preprocess_react_and_share(&$variables) : void {
  *
  * #UHF-9158 main languages must be always visible on language switcher.
  */
-function helfi_platform_config_language_switch_links_alter(array &$links) {
+function helfi_platform_config_language_switch_links_alter(array &$links): void {
   $params = \Drupal::routeMatch()->getParameters()->all();
 
   $entity = NULL;
@@ -437,18 +437,18 @@ function helfi_platform_config_language_switch_links_alter(array &$links) {
       break;
     }
   }
-  if (!$entity) {
+  if (!$entity || !$entity->isTranslatable()) {
     return;
   }
 
   foreach ($links as $langcode => $link) {
     if (
-      !$entity->isTranslatable() ||
       !$entity->hasTranslation($langcode) ||
       $entity->getTranslation($langcode)->isPublished()
     ) {
       continue;
     }
+
     // Unpublished link won't pass url access check
     // Replace unpublished translation with another one and set it disabled.
     unset($links[$langcode]['url']);

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -443,12 +443,12 @@ function helfi_platform_config_language_switch_links_alter(array &$links) {
 
   foreach ($links as $langcode => $link) {
     if (
+      !$entity->isTranslatable() ||
       !$entity->hasTranslation($langcode) ||
       $entity->getTranslation($langcode)->isPublished()
     ) {
       continue;
     }
-
     // Unpublished link won't pass url access check
     // Replace unpublished translation with another one and set it disabled.
     unset($links[$langcode]['url']);

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -24,7 +24,6 @@ use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 use Drupal\paragraphs\Entity\ParagraphsType;
 use Drupal\user\Entity\Role;
 
-
 /**
  * Implements hook_modules_installed().
  */
@@ -450,12 +449,11 @@ function helfi_platform_config_language_switch_links_alter(array &$links) {
       continue;
     }
 
-    // Replace the original unpublished translation link with another one and set it disabled.
-    // Unpublished link won't pass url access check so it must be replaced with published one.
+    // Unpublished link won't pass url access check
+    // Replace unpublished translation with another one and set it disabled.
     unset($links[$langcode]['url']);
-    $url = new Url('<front>');
     $links[$langcode]['#untranslated'] = TRUE;
-    $links[$langcode]['url'] = $url;
+    $links[$langcode]['url'] = new Url('<nolink>');
     $links[$langcode]['attributes']['class'][] = 'language-link--untranslated';
   }
 }

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -67,38 +67,32 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
     ]);
 
     $this->setActiveProject(Project::ASUMINEN, EnvironmentEnum::Local);
-    $this->createTestData();
-  }
 
-  /**
-   * Create content required by test.
-   */
-  private function createTestData(): void {
     NodeType::create([
       'type' => 'page',
     ])->save();
-
-    $this->node = Node::create(['type' => 'page', 'title' => 'Title en']);
-    $this->node->save();
-
-    foreach (['fi', 'sv'] as $language) {
-      $this->node->addTranslation($language, [
-        'title' => 'Title ' . $language,
-      ]);
-    }
-    $this->node->save();
-
-    $this->node->getTranslation('sv')
-      ->set('status', 0)
-      ->save();
   }
 
   /**
    * Tests that languages are visible in language switcher.
    */
   public function testLanguageSwitcher() : void {
+    $node = Node::create(['type' => 'page', 'title' => 'Title en']);
+    $node->save();
+
+    foreach (['fi', 'sv'] as $language) {
+      $node->addTranslation($language, [
+        'title' => 'Title ' . $language,
+      ]);
+    }
+    $node->save();
+
+    $node->getTranslation('sv')
+      ->set('status', 0)
+      ->save();
+
     foreach (['en', 'fi', 'sv'] as $langcode) {
-      $this->drupalGetWithLanguage("node/{$this->node->id()}", $langcode);
+      $this->drupalGetWithLanguage("node/{$node->id()}", $langcode);
       $elements = $this->xpath('//span|a[@class="language-link"]');
       $this->assertCount(3, $elements);
     }

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -61,6 +61,11 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
       ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
       ->save();
 
+    $this->drupalPlaceBlock('language_switcher_admin', [
+      'region' => 'header_branding',
+      'theme' => $this->defaultTheme,
+    ]);
+
     $this->setActiveProject(Project::ASUMINEN, EnvironmentEnum::Local);
     $this->createTestData();
   }
@@ -72,11 +77,6 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
     NodeType::create([
       'type' => 'page',
     ])->save();
-
-    $this->drupalPlaceBlock('language_switcher_admin', [
-      'region' => 'header_branding',
-      'theme' => $this->defaultTheme,
-    ]);
 
     $this->node = Node::create(['type' => 'page', 'title' => 'Title en']);
     $this->node->save();

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -32,7 +32,7 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
     'node',
     'block',
     'helfi_platform_config',
-    'user'
+    'user',
   ];
 
   /**

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -89,10 +89,11 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
    * Tests that languages are visible in language switcher.
    */
   public function testLanguageSwitcher() : void {
-    $this->drupalLogout();
-    $this->drupalGet('/en/node/' . $this->node->id());
-    $elements = $this->xpath('//span|a[@class="language-link"]');
-    $this->assertCount(3, $elements);
+    foreach(['en', 'fi', 'sv'] as $langocde) {
+      $this->drupalGet("/$langocde/node/", $this->node->id());
+      $elements = $this->xpath('//span|a[@class="language-link"]');
+      $this->assertCount(3, $elements);
+    }
   }
 
 }

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -89,8 +89,8 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
    * Tests that languages are visible in language switcher.
    */
   public function testLanguageSwitcher() : void {
-    foreach(['en', 'fi', 'sv'] as $langocde) {
-      $this->drupalGet("/$langocde/node/", $this->node->id());
+    foreach (['en', 'fi', 'sv'] as $langcode) {
+      $this->drupalGet("/$langcode/node/{$this->node->id()}");
       $elements = $this->xpath('//span|a[@class="language-link"]');
       $this->assertCount(3, $elements);
     }

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -11,6 +11,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\helfi_api_base\Traits\DefaultConfigurationTrait;
 
 /**
  * Tests the language switcher alter changes affecting anonymous user.
@@ -18,6 +19,8 @@ use Drupal\Tests\BrowserTestBase;
  * @group helfi_platform_config
  */
 class LanguageSwitcherAlterTest extends BrowserTestBase {
+
+  use DefaultConfigurationTrait;
 
   /**
    * {@inheritdoc}
@@ -90,7 +93,7 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
    */
   public function testLanguageSwitcher() : void {
     foreach (['en', 'fi', 'sv'] as $langcode) {
-      $this->drupalGet("/$langcode/node/{$this->node->id()}");
+      $this->drupalGetWithLanguage("node/{$this->node->id()}", $langcode);
       $elements = $this->xpath('//span|a[@class="language-link"]');
       $this->assertCount(3, $elements);
     }

--- a/tests/src/Functional/LanguageSwitcherAlterTest.php
+++ b/tests/src/Functional/LanguageSwitcherAlterTest.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_platform_config\Functional;
 
-use Drupal\helfi_api_base\Environment\EnvironmentResolver;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
 use Drupal\helfi_api_base\Environment\Project;
 use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\Node;
@@ -12,6 +12,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\helfi_api_base\Traits\DefaultConfigurationTrait;
+use Drupal\Tests\helfi_api_base\Traits\EnvironmentResolverTrait;
 
 /**
  * Tests the language switcher alter changes affecting anonymous user.
@@ -21,6 +22,7 @@ use Drupal\Tests\helfi_api_base\Traits\DefaultConfigurationTrait;
 class LanguageSwitcherAlterTest extends BrowserTestBase {
 
   use DefaultConfigurationTrait;
+  use EnvironmentResolverTrait;
 
   /**
    * {@inheritdoc}
@@ -52,18 +54,21 @@ class LanguageSwitcherAlterTest extends BrowserTestBase {
    */
   public function setUp() : void {
     parent::setUp();
-
     foreach (['fi', 'sv'] as $langcode) {
       ConfigurableLanguage::createFromLangcode($langcode)->save();
     }
     $this->config('language.negotiation')
       ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
       ->save();
-    $this->config('helfi_api_base.environment_resolver.settings')
-      ->set(EnvironmentResolver::ENVIRONMENT_NAME_KEY, 'local')
-      ->set(EnvironmentResolver::PROJECT_NAME_KEY, Project::ASUMINEN)
-      ->save();
 
+    $this->setActiveProject(Project::ASUMINEN, EnvironmentEnum::Local);
+    $this->createTestData();
+  }
+
+  /**
+   * Create content required by test.
+   */
+  private function createTestData(): void {
     NodeType::create([
       'type' => 'page',
     ])->save();


### PR DESCRIPTION
# [UHF-9158](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9158)
<!-- What problem does this solve? -->
As anonymous user, language switcher would hide a language's title if the node has translation but translation is unpublished.

## What was done
Added language switcher alter which changes the url to another one and sets it disabled. 
- This way the language title will be visible. 
- A disabled switcher link is rendered as span and has no url mentioned in it.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9158`
* Run `make drush-updb drush-cr`

## How to test
Should be preferably tested with multiple sites (kasko requires drush uli --uid=19 to test group content)
**`Etusivu` for other languages and `Kasko` for group content should be preferably tested.**

- Login as admin, open incognito window as well to test both unauthenticated and logged in user.
- Select an existing content or create new one.
- Make sure you test the content while these rules apply:
  - No translations are enabled
  - One translation is enabled, one is disabled, one does not exist
  - All enabled
- In all cases, language switcher should show all 3 main languages
  - Active language should be always underlined no matter the published state.
  - Published translations should be a link (enabled)
  - Unpublished translation should be text (disabled  span)
- Try publishing and unpublishing content to see that the language switcher updates accordingly

Things to test across all sites:
- User page (entity that is not translatable)
- TPR-pages
- Nodes
- Kasko group content
- Other languages (etusivu)
- Anything else that comes in mind


* [x] Check that this feature works
* [x] Check that code follows our standards


[UHF-9158]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ