### PR TITLE
UHF-9113, UHF-8284: Fix hook_modules_installed breaking database updates

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -12,6 +12,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldConfigBase;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Link;
@@ -129,8 +130,17 @@ function helfi_platform_config_update_paragraph_target_types() : void {
       continue;
     }
     $field = $definitions[$type->field];
+
+    // Base fields use BaseFieldDefinition instances while configurable fields
+    // use FieldConfig instances. Save the BaseFieldOverride to trigger
+    // re-build of target_bundles.
+    if ($field instanceof BaseFieldDefinition) {
+      $field = $field->getConfig($type->bundle);
+    }
+
     // Save the field to trigger re-build of target_bundles.
     // @see helfi_platform_config_field_config_presave().
+    // @see helfi_platform_config_base_field_override_presave().
     $field->save();
   }
 }


### PR DESCRIPTION
# [UHF-9113](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

On kasko and päätökset, update hooks that install modules crash. In päätökset, I have managed to replicate this using a production db dump. In kasko, I can replicate this only using the `latest.sql` artifact from github.

The idea of this fix is to create BaseFieldOverride if it does not exist so the field settings can be edited.

This is a cherry picked commit from https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/617 in a separate PR since I run into the same issue while reviewing https://github.com/City-of-Helsinki/helsinki-paatokset/pull/319.

### How to reproduce the issue

Download the latest SQL dump from github artifacts: https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/actions/runs/6623105851.

Create an update hook that installs a module. For example:

```php
/**
 * Test update hook issue.
 */
function helfi_kasko_content_update_90010() {
  \Drupal::service('module_installer')->install(['dblog']);
}
```

Import the database and run `drush updb -v -y`. The command should crash with the following message:

```
 [error]  Call to undefined method Drupal\Core\Field\BaseFieldDefinition::save() 
```

When testing, if you want to re-run the update hook, you can use following command:

```
drush pmu dblog; drush ev "drupal_set_installed_schema_version('helfi_kasko_content', 9009)"
```

## How to install
* Make sure you have kasko instance up and running on latest dev branch. Download `latest.sql` from [github actions](https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/actions/runs/6623105851). 
    * `git pull origin dev`
    * `make up shell`
    * `drush sql-query --file /app/latest.sql`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9113-UHF-8284-fix-update-hook-crash`
* Run `drush updb -v -y`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Try running an update hook which installs a module.
* [ ] Check that code follows our standards.


[UHF-9113]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ