### PR TITLE
UHF-X: Updated the patch to fix frontpage URLs in simple_sitemap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clone platform
         run: |
-          git clone --depth=1 https://github.com/City-of-Helsinki/drupal-helfi-platform.git $DRUPAL_ROOT
+          git clone --depth=1 --branch=9.x https://github.com/City-of-Helsinki/drupal-helfi-platform.git $DRUPAL_ROOT
           rm -rf $DRUPAL_ROOT/.git
 
       - name: Install required composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
                 "Add missing schema to social media. (https://www.drupal.org/project/social_media/issues/2986819)": "https://git.drupalcode.org/project/social_media/-/commit/1964f42e5a6fb5d7a97fdf8ec5ca259bc6c5b19a.patch"
             },
             "drupal/simple_sitemap": {
-                "[#UHF-8514] Fix frontpage URLs in sitemap. (https://www.drupal.org/project/simple_sitemap/issues/3264573)": "https://www.drupal.org/files/issues/2023-11-03/3264573-5.patch"
+                "[#UHF-8514] Fix frontpage URLs in sitemap. (https://www.drupal.org/i/3264573)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/55722f695264bbaf6062f46e400e905c761fd5b7/patches/simple_sitemap-3264573-respect-frontpage-configuration.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
                 "Add missing schema to social media. (https://www.drupal.org/project/social_media/issues/2986819)": "https://git.drupalcode.org/project/social_media/-/commit/1964f42e5a6fb5d7a97fdf8ec5ca259bc6c5b19a.patch"
             },
             "drupal/simple_sitemap": {
-                "[#UHF-8514] Fix frontpage URLs in sitemap. (https://www.drupal.org/project/simple_sitemap/issues/3264573)": "https://www.drupal.org/files/issues/2022-02-15/3264573-2.patch"
+                "[#UHF-8514] Fix frontpage URLs in sitemap. (https://www.drupal.org/project/simple_sitemap/issues/3264573)": "https://www.drupal.org/files/issues/2023-11-03/3264573-5.patch"
             }
         }
     }

--- a/patches/simple_sitemap-3264573-respect-frontpage-configuration.patch
+++ b/patches/simple_sitemap-3264573-respect-frontpage-configuration.patch
@@ -1,0 +1,344 @@
+diff --git a/modules/simple_sitemap_views/src/Plugin/simple_sitemap/UrlGenerator/ViewsUrlGenerator.php b/modules/simple_sitemap_views/src/Plugin/simple_sitemap/UrlGenerator/ViewsUrlGenerator.php
+index 46fc160..054a2bf 100755
+--- a/modules/simple_sitemap_views/src/Plugin/simple_sitemap/UrlGenerator/ViewsUrlGenerator.php
++++ b/modules/simple_sitemap_views/src/Plugin/simple_sitemap/UrlGenerator/ViewsUrlGenerator.php
+@@ -2,6 +2,7 @@
+
+ namespace Drupal\simple_sitemap_views\Plugin\simple_sitemap\UrlGenerator;
+
++use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\simple_sitemap\Exception\SkipElementException;
+ use Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator\EntityUrlGeneratorBase;
+ use Drupal\simple_sitemap\Plugin\simple_sitemap\SimpleSitemapPluginBase;
+@@ -61,6 +62,8 @@ class ViewsUrlGenerator extends EntityUrlGeneratorBase {
+    *   The entity type manager.
+    * @param \Drupal\simple_sitemap\Entity\EntityHelper $entity_helper
+    *   The simple_sitemap.entity_helper service.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory.
+    * @param \Drupal\simple_sitemap_views\SimpleSitemapViews $sitemap_views
+    *   Views sitemap data.
+    * @param \Drupal\Core\Routing\RouteProviderInterface $route_provider
+@@ -75,6 +78,7 @@ class ViewsUrlGenerator extends EntityUrlGeneratorBase {
+     LanguageManagerInterface $language_manager,
+     EntityTypeManagerInterface $entity_type_manager,
+     EntityHelper $entity_helper,
++    ConfigFactoryInterface $config_factory,
+     SimpleSitemapViews $sitemap_views,
+     RouteProviderInterface $route_provider
+   ) {
+@@ -86,7 +90,8 @@ class ViewsUrlGenerator extends EntityUrlGeneratorBase {
+       $settings,
+       $language_manager,
+       $entity_type_manager,
+-      $entity_helper
++      $entity_helper,
++      $config_factory
+     );
+     $this->sitemapViews = $sitemap_views;
+     $this->routeProvider = $route_provider;
+@@ -105,6 +110,7 @@ class ViewsUrlGenerator extends EntityUrlGeneratorBase {
+       $container->get('language_manager'),
+       $container->get('entity_type.manager'),
+       $container->get('simple_sitemap.entity_helper'),
++      $container->get('config.factory'),
+       $container->get('simple_sitemap.views'),
+       $container->get('router.route_provider')
+     );
+diff --git a/src/Plugin/simple_sitemap/UrlGenerator/CustomUrlGenerator.php b/src/Plugin/simple_sitemap/UrlGenerator/CustomUrlGenerator.php
+index 2710e76..efa1078 100644
+--- a/src/Plugin/simple_sitemap/UrlGenerator/CustomUrlGenerator.php
++++ b/src/Plugin/simple_sitemap/UrlGenerator/CustomUrlGenerator.php
+@@ -2,6 +2,7 @@
+
+ namespace Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator;
+
++use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\Core\Url;
+ use Drupal\Component\Utility\UrlHelper;
+ use Drupal\simple_sitemap\Entity\EntityHelper;
+@@ -68,6 +69,8 @@ class CustomUrlGenerator extends EntityUrlGeneratorBase {
+    *   The entity type manager.
+    * @param \Drupal\simple_sitemap\Entity\EntityHelper $entity_helper
+    *   Helper class for working with entities.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory.
+    * @param \Drupal\simple_sitemap\Manager\CustomLinkManager $custom_links
+    *   The simple_sitemap.custom_link_manager service.
+    * @param \Drupal\Core\Path\PathValidatorInterface $path_validator
+@@ -82,6 +85,7 @@ class CustomUrlGenerator extends EntityUrlGeneratorBase {
+     LanguageManagerInterface $language_manager,
+     EntityTypeManagerInterface $entity_type_manager,
+     EntityHelper $entity_helper,
++    ConfigFactoryInterface $config_factory,
+     CustomLinkManager $custom_links,
+     PathValidatorInterface $path_validator) {
+     parent::__construct(
+@@ -92,7 +96,8 @@ class CustomUrlGenerator extends EntityUrlGeneratorBase {
+       $settings,
+       $language_manager,
+       $entity_type_manager,
+-      $entity_helper
++      $entity_helper,
++      $config_factory
+     );
+     $this->customLinks = $custom_links;
+     $this->pathValidator = $path_validator;
+@@ -115,6 +120,7 @@ class CustomUrlGenerator extends EntityUrlGeneratorBase {
+       $container->get('language_manager'),
+       $container->get('entity_type.manager'),
+       $container->get('simple_sitemap.entity_helper'),
++      $container->get('config.factory'),
+       $container->get('simple_sitemap.custom_link_manager'),
+       $container->get('path.validator')
+     );
+diff --git a/src/Plugin/simple_sitemap/UrlGenerator/EntityMenuLinkContentUrlGenerator.php b/src/Plugin/simple_sitemap/UrlGenerator/EntityMenuLinkContentUrlGenerator.php
+index a3cb618..4712930 100644
+--- a/src/Plugin/simple_sitemap/UrlGenerator/EntityMenuLinkContentUrlGenerator.php
++++ b/src/Plugin/simple_sitemap/UrlGenerator/EntityMenuLinkContentUrlGenerator.php
+@@ -3,6 +3,7 @@
+ namespace Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator;
+
+ use Drupal\Component\Plugin\Exception\PluginException;
++use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\Core\Entity\EntityTypeManagerInterface;
+ use Drupal\Core\Language\LanguageManagerInterface;
+ use Drupal\Core\Menu\MenuLinkManagerInterface;
+@@ -70,6 +71,8 @@ class EntityMenuLinkContentUrlGenerator extends EntityUrlGeneratorBase {
+    *   The entity type manager.
+    * @param \Drupal\simple_sitemap\Entity\EntityHelper $entity_helper
+    *   Helper class for working with entities.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory.
+    * @param \Drupal\simple_sitemap\Manager\EntityManager $entities_manager
+    *   The simple_sitemap.entity_manager service.
+    * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_link_tree
+@@ -86,6 +89,7 @@ class EntityMenuLinkContentUrlGenerator extends EntityUrlGeneratorBase {
+     LanguageManagerInterface $language_manager,
+     EntityTypeManagerInterface $entity_type_manager,
+     EntityHelper $entity_helper,
++    ConfigFactoryInterface $config_factory,
+     EntityManager $entities_manager,
+     MenuLinkTreeInterface $menu_link_tree,
+     MenuLinkManagerInterface $menu_link_manager
+@@ -98,7 +102,8 @@ class EntityMenuLinkContentUrlGenerator extends EntityUrlGeneratorBase {
+       $settings,
+       $language_manager,
+       $entity_type_manager,
+-      $entity_helper
++      $entity_helper,
++      $config_factory
+     );
+     $this->entitiesManager = $entities_manager;
+     $this->menuLinkTree = $menu_link_tree;
+@@ -122,6 +127,7 @@ class EntityMenuLinkContentUrlGenerator extends EntityUrlGeneratorBase {
+       $container->get('language_manager'),
+       $container->get('entity_type.manager'),
+       $container->get('simple_sitemap.entity_helper'),
++      $container->get('config.factory'),
+       $container->get('simple_sitemap.entity_manager'),
+       $container->get('menu.link_tree'),
+       $container->get('plugin.manager.menu.link')
+diff --git a/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGenerator.php b/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGenerator.php
+index d86775b..c6cb784 100644
+--- a/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGenerator.php
++++ b/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGenerator.php
+@@ -2,6 +2,7 @@
+
+ namespace Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator;
+
++use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\Core\Entity\ContentEntityInterface;
+ use Drupal\Core\Url;
+ use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
+@@ -73,6 +74,8 @@ class EntityUrlGenerator extends EntityUrlGeneratorBase {
+    *   The entity type manager.
+    * @param \Drupal\simple_sitemap\Entity\EntityHelper $entity_helper
+    *   Helper class for working with entities.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory.
+    * @param \Drupal\simple_sitemap\Manager\EntityManager $entities_manager
+    *   The simple_sitemap.entity_manager service.
+    * @param \Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator\UrlGeneratorManager $url_generator_manager
+@@ -89,6 +92,7 @@ class EntityUrlGenerator extends EntityUrlGeneratorBase {
+     LanguageManagerInterface $language_manager,
+     EntityTypeManagerInterface $entity_type_manager,
+     EntityHelper $entity_helper,
++    ConfigFactoryInterface $config_factory,
+     EntityManager $entities_manager,
+     UrlGeneratorManager $url_generator_manager,
+     MemoryCacheInterface $memory_cache
+@@ -101,7 +105,8 @@ class EntityUrlGenerator extends EntityUrlGeneratorBase {
+       $settings,
+       $language_manager,
+       $entity_type_manager,
+-      $entity_helper
++      $entity_helper,
++      $config_factory,
+     );
+     $this->entitiesManager = $entities_manager;
+     $this->urlGeneratorManager = $url_generator_manager;
+@@ -126,6 +131,7 @@ class EntityUrlGenerator extends EntityUrlGeneratorBase {
+       $container->get('language_manager'),
+       $container->get('entity_type.manager'),
+       $container->get('simple_sitemap.entity_helper'),
++      $container->get('config.factory'),
+       $container->get('simple_sitemap.entity_manager'),
+       $container->get('plugin.manager.simple_sitemap.url_generator'),
+       $container->get('entity.memory_cache')
+diff --git a/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGeneratorBase.php b/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGeneratorBase.php
+index bc872d0..4ba2fad 100644
+--- a/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGeneratorBase.php
++++ b/src/Plugin/simple_sitemap/UrlGenerator/EntityUrlGeneratorBase.php
+@@ -2,7 +2,9 @@
+
+ namespace Drupal\simple_sitemap\Plugin\simple_sitemap\UrlGenerator;
+
++use Drupal\Core\Config\ConfigFactoryInterface;
+ use Drupal\Core\Language\LanguageInterface;
++use Drupal\language\ConfigurableLanguageManagerInterface;
+ use Drupal\simple_sitemap\Entity\EntityHelper;
+ use Drupal\simple_sitemap\Exception\SkipElementException;
+ use Drupal\simple_sitemap\Plugin\simple_sitemap\SimpleSitemapPluginBase;
+@@ -35,6 +37,13 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+    */
+   protected $defaultLanguageId;
+
++  /**
++   * The language manager.
++   *
++   * @var \Drupal\Core\Language\LanguageManagerInterface
++   */
++  protected $languageManager;
++
+   /**
+    * The entity type manager.
+    *
+@@ -56,6 +65,20 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+    */
+   protected $entityHelper;
+
++  /**
++   * The configuration factory.
++   *
++   * @var \Drupal\Core\Config\ConfigFactoryInterface
++   */
++  protected $configFactory;
++
++  /**
++   * The default front page per language.
++   *
++   * @var string[]
++   */
++  protected $frontPage = [];
++
+   /**
+    * EntityUrlGeneratorBase constructor.
+    *
+@@ -75,6 +98,8 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+    *   The entity type manager.
+    * @param \Drupal\simple_sitemap\Entity\EntityHelper $entity_helper
+    *   Helper class for working with entities.
++   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
++   *   The config factory.
+    */
+   public function __construct(
+     array $configuration,
+@@ -84,14 +109,17 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+     Settings $settings,
+     LanguageManagerInterface $language_manager,
+     EntityTypeManagerInterface $entity_type_manager,
+-    EntityHelper $entity_helper
++    EntityHelper $entity_helper,
++    ConfigFactoryInterface $config_factory
+   ) {
+     parent::__construct($configuration, $plugin_id, $plugin_definition, $logger, $settings);
++    $this->languageManager = $language_manager;
+     $this->languages = $language_manager->getLanguages();
+     $this->defaultLanguageId = $language_manager->getDefaultLanguage()->getId();
+     $this->entityTypeManager = $entity_type_manager;
+     $this->anonUser = new AnonymousUserSession();
+     $this->entityHelper = $entity_helper;
++    $this->configFactory = $config_factory;
+   }
+
+   /**
+@@ -106,7 +134,8 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+       $container->get('simple_sitemap.settings'),
+       $container->get('language_manager'),
+       $container->get('entity_type.manager'),
+-      $container->get('simple_sitemap.entity_helper')
++      $container->get('simple_sitemap.entity_helper'),
++      $container->get('config.factory')
+     );
+   }
+
+@@ -176,6 +205,15 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+    */
+   protected function getAlternateUrlsForDefaultLanguage(Url $url_object): array {
+     $alternate_urls = [];
++
++    // Exchange the url with one pointing to the front route in case the
++    // internal url is configured as the front page.
++    if (($entity = $this->entityHelper->getEntityFromUrlObject($url_object)) instanceof ContentEntityInterface) {
++      if ($this->getFrontPagePath($entity->language()->getId()) === $url_object->getInternalPath()) {
++        $url_object = Url::fromRoute('<front>');
++      }
++    }
++
+     if ($url_object->access($this->anonUser)) {
+       $alternate_urls[$this->defaultLanguageId] = $this->replaceBaseUrlWithCustom($url_object
+         ->setAbsolute()->setOption('language', $this->languages[$this->defaultLanguageId])->toString()
+@@ -200,9 +238,16 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+     $alternate_urls = [];
+
+     foreach ($entity->getTranslationLanguages() as $language) {
+-      if (!isset($this->settings->get('excluded_languages')[$language->getId()]) || $language->isDefault()) {
+-        if ($entity->getTranslation($language->getId())->access('view', $this->anonUser)) {
+-          $alternate_urls[$language->getId()] = $this->replaceBaseUrlWithCustom($url_object
++      $langcode = $language->getId();
++      if (!isset($this->settings->get('excluded_languages')[$langcode]) || $language->isDefault()) {
++        if ($entity->getTranslation($langcode)->access('view', $this->anonUser)) {
++          // Exchange the url with one pointing to the front route in case the
++          // internal url is configured as the front page.
++          if ($this->getFrontPagePath($langcode) === $url_object->getInternalPath()) {
++            $url_object = Url::fromRoute('<front>');
++          }
++
++          $alternate_urls[$langcode] = $this->replaceBaseUrlWithCustom($url_object
+             ->setAbsolute()->setOption('language', $language)->toString()
+           );
+         }
+@@ -291,4 +336,32 @@ abstract class EntityUrlGeneratorBase extends UrlGeneratorBase {
+     return $image_data;
+   }
+
++  /**
++   * Returns the front page path for the given language code.
++   *
++   * @param string $langcode
++   *   The language code.
++   *
++   * @return string
++   *   The front page path.
++   */
++  protected function getFrontPagePath(string $langcode) {
++    if (!isset($this->frontPage[$langcode])) {
++      $path = NULL;
++      if ($this->languageManager instanceof ConfigurableLanguageManagerInterface) {
++        $config = $this->languageManager->getLanguageConfigOverride($langcode, 'system.site');
++        $path = $config->get('page.front');
++      }
++
++      if ($path === NULL) {
++        $config = $this->configFactory->get('system.site');
++        $path = $config->get('page.front');
++      }
++
++      $path = ltrim($path, '/');
++      $this->frontPage[$langcode] = $path;
++    }
++    return $this->frontPage[$langcode];
++  }
++
+ }


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->
A patch for simple_sitemap needed re-rolling since the module updated.

## What was done
<!-- Describe what was done -->

* Updated the applied patch in the composer.json.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_re-rolled-simple-sitemap-patch`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the patch applies nicely.
* [ ] Check that code follows our standards
