### PR TITLE
UHF-X Fix missing dependency

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.info.yml
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - drupal:config_translation
   - drupal:editor
   - drupal:options
+  - drupal:views
   - linkit:linkit
 'interface translation project': hdbt_admin_tools
 'interface translation server pattern': modules/contrib/helfi_platform_config/modules/hdbt_admin_tools/translations/%language.po

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.info.yml
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - config_ignore:config_ignore
   - drupal:config_translation
   - drupal:editor
+  - drupal:node
   - drupal:options
   - drupal:views
   - linkit:linkit


### PR DESCRIPTION
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added `drupal:views` as a dependency for the `hdbt_admin_tools` module.
