### PR TITLE
UHF-9159: Subgroup field display configs

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -406,3 +406,4 @@ hidden:
   hide_description: true
   ontologyword_ids: true
   show_www: true
+  subgroup: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -287,3 +287,4 @@ hidden:
   langcode: true
   show_www: true
   streetview_entrance_url: true
+  subgroup: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
@@ -66,6 +66,7 @@ hidden:
   services: true
   show_www: true
   streetview_entrance_url: true
+  subgroup: true
   toc_enabled: true
   unit_picture_caption: true
   www: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
@@ -84,6 +84,7 @@ hidden:
   services: true
   show_www: true
   streetview_entrance_url: true
+  subgroup: true
   toc_enabled: true
   unit_picture_caption: true
   www: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
@@ -85,5 +85,6 @@ hidden:
   services: true
   show_www: true
   streetview_entrance_url: true
+  subgroup: true
   toc_enabled: true
   www: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
@@ -98,5 +98,6 @@ hidden:
   services: true
   show_www: true
   streetview_entrance_url: true
+  subgroup: true
   toc_enabled: true
   www: true

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -342,3 +342,12 @@ function helfi_tpr_config_update_9049(): void {
     'update tpr_unit',
   ]);
 }
+
+/**
+ * UHF-9159: Subgroup field display configs.
+ */
+function helfi_tpr_config_update_9050(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-9159](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159)
<!-- What problem does this solve? -->
The subgroup field should be hidden on all instances except KASKO.

## What was done
<!-- Describe what was done -->

* Hide the subgroup field of TPR units.

## How to install
* Follow instructions in: https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/481.

## How to test
* The subgroup field should be hidden after these configs are applied.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/481

[UHF-9159]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ