### PR TITLE
UHF-8936: Enable text and map paragraphs for lower content of TPR units

### DIFF
--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -351,3 +351,10 @@ function helfi_tpr_config_update_9050(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-8936 Update tpr_unit to include map and text paragraphs in lower content.
+ */
+function helfi_tpr_config_update_9051(): void {
+  helfi_platform_config_update_paragraph_target_types();
+}

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -66,6 +66,8 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
           'contact_card_listing',
           'remote_video',
           'event_list',
+          'map',
+          'text',
         ],
       ],
     ],


### PR DESCRIPTION
# [UHF-8936](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8936)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Enabled text and map paragraphs for the lower content of TPR units

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8936_tpr-unit-text-and-map`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add text and map paragraphs to any TPR page.
* [ ] Check that the text and map paragraphs look like they should.
* [ ] Check that code follows our standards


[UHF-8936]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ