### PR TITLE
UHF-9274: Basic implementation of Telia ACE widget.

### DIFF
--- a/assets/css/telia_ace.css
+++ b/assets/css/telia_ace.css
@@ -1,0 +1,3 @@
+.region--attachments .humany-rendered {
+  visibility: visible;
+}

--- a/config/schema/helfi_platform_config.schema.yml
+++ b/config/schema/helfi_platform_config.schema.yml
@@ -5,3 +5,11 @@ block.settings.chat_leijuke:
     chat_title:
       type: text
       label: 'Chat title'
+
+block.settings.telia_ace_widget:
+  type: block_settings
+  label: 'Block config translation for Telia ACE widget'
+  mapping:
+    chat_id:
+      type: text
+      label: 'Chat widget ID'

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -107,3 +107,12 @@ user_consent_functions:
     assets/js/user_consent_functions.js: {}
   dependencies:
     - core/drupal
+
+telia_ace_widget:
+  version: 1.0.x
+  header: true
+  css:
+    theme:
+      assets/css/telia_ace.css: {}
+  dependencies:
+    - helfi_platform_config/user_consent_functions

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -485,6 +485,8 @@ function helfi_platform_config_config_ignore_settings_alter(array &$settings) {
     'block.block.genesyschat',
     'block.block.genesyschat_*',
     'block.block.smarttichatbot',
+    'block.block.teliaacewidget*',
+    'block.block.hdbt_subtheme_teliaacewidget*'
   ];
 
   foreach ($add_ignore as $config) {

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -486,7 +486,7 @@ function helfi_platform_config_config_ignore_settings_alter(array &$settings) {
     'block.block.genesyschat_*',
     'block.block.smarttichatbot',
     'block.block.teliaacewidget*',
-    'block.block.hdbt_subtheme_teliaacewidget*'
+    'block.block.hdbt_subtheme_teliaacewidget*',
   ];
 
   foreach ($add_ignore as $config) {

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -65,7 +65,7 @@ class TeliaAceWidget extends BlockBase {
 
     $build['ibm_chat_app'] = [
       '#title' => $this->t('Telia ACE Widget'),
-      '#markup' => '<a href="' . $chat_id . '"></a>',
+      '#markup' => '<a class="hidden" href="' . $chat_id . '"></a>',
       '#attached' => [
         'library' => $library,
         'html_head' => [

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -54,7 +54,7 @@ class TeliaAceWidget extends BlockBase {
    */
   public function build() {
 
-    $library = ['helfi_platform_config/user_consent_functions'];
+    $library = ['helfi_platform_config/telia_ace_widget'];
 
     $build = [];
 

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\helfi_platform_config\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a Telia ACE chat widget block.
+ *
+ * @Block(
+ *  id = "telia_ace_widget",
+ *  admin_label = @Translation("Telia ACE Widget"),
+ * )
+ */
+class TeliaAceWidget extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
+
+    $form['script_url'] = [
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#title' => $this->t('Script URL'),
+      '#description' => $this->t('URL to the chat JS library without the domain, for example: /wds/instances/J5XKjqJt/ACEWebSDK.min.js'),
+      '#default_value' => $config['script_url'] ?? '/wds/instances/J5XKjqJt/ACEWebSDK.min.js',
+    ];
+
+    $form['chat_id'] = [
+      '#type' => 'textfield',
+      '#required' => TRUE,
+      '#title' => $this->t('Chat Widget ID'),
+      '#description' => $this->t('ID for the chat instance. Example format: //acewebsdk/example-chat-fin'),
+      '#default_value' => $config['chat_id'] ?? '//acewebsdk/',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $formState) {
+    $this->configuration['script_url'] = $formState->getValue('script_url');
+    $this->configuration['chat_id'] = $formState->getValue('chat_id');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    $library = ['helfi_platform_config/user_consent_functions'];
+
+    $build = [];
+
+    $config = $this->getConfiguration();
+    $base_url = 'https://wds.ace.teliacompany.com';
+    $script_url = $base_url . $config['script_url'];
+    $chat_id = $config['chat_id'];
+
+    $build['ibm_chat_app'] = [
+      '#title' => $this->t('Telia ACE Widget'),
+      '#markup' => '<a href="' . $chat_id . '"></a>',
+      '#attached' => [
+        'library' => $library,
+        'html_head' => [
+          [
+            [
+              '#tag' => 'script',
+              '#attributes' => [
+                'async' => TRUE,
+                'type' => 'text/javascript',
+                'src' => $script_url,
+              ],
+            ], 'telia_ace_script',
+          ],
+        ],
+      ],
+    ];
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
# [UHF-9274](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9274)

## What was done
Creates an embed block for Telia ACE chat widgets. Actual chat functionality can't be tested locally yet because local domains aren't whitelisted on Telia's end, but the widget is visible on the demo site: https://drupal-helfi-drupal-platform-test.test.hel.ninja/fi/new-telia-ace-widget

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9274-telia-ace`
* Run `make drush-cr`
* Create a new page or landing page for testing with swedish and english translations
* Add a new Telia ACE block to the Attachments region with the following values:
  * Hide the title
  * Script URL: `/wds/instances/J5XKjqJt/ACEWebSDK.min.js`
  * Chat ID: //acewebsdk/local-chat-asiointi-eng
  * Translate the block and change the chat ID:
    * Finnish: //acewebsdk/local-chat-asiointi-fin
    * English: //acewebsdk/local-chat-asiointi-sve

## How to test 
* Check that this feature works on the page where the block is visible:
  * [x] View the page source, make sure the `<a class="hidden" href="//acewebsdk//local-chat-asiointi"></a>` element is there
  * [x] The `ACEWebSDK.min.js` script is embedded on the page and has the `async` parameter
  * [x] The `window.chat_user_consent` object is available on the page
* Config ignore functionality:
  * [x] Export the new block's config with `drush cex -y`
  * [ ] Edit the block and translations, then run `drush cim -y`.
  * [x] The config ignore hook should work and the changes you made after the export should not be reverted
* [x] Check that code follows our standards

[UHF-9274]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ