### PR TITLE
UHF-9249: Description override field for tpr units

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -100,14 +100,6 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
-  description_override:
-    type: text_textarea
-    weight: 19
-    region: content
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
   email:
     type: readonly_field_widget
     weight: 10
@@ -117,6 +109,14 @@ content:
       formatter_type: null
       formatter_settings: {  }
       show_description: false
+    third_party_settings: {  }
+  enrich_description:
+    type: text_textarea
+    weight: 19
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   field_content:
     type: paragraphs
@@ -411,7 +411,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  description_override: true
   hide_description: true
   ontologyword_ids: true
   show_www: true

--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -117,7 +117,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
   field_content:
     type: paragraphs
     weight: 28

--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -403,6 +403,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  description_override: true
   hide_description: true
   ontologyword_ids: true
   show_www: true

--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -52,7 +52,7 @@ content:
     third_party_settings: {  }
   address:
     type: readonly_field_widget
-    weight: 19
+    weight: 20
     region: content
     settings:
       label: above

--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -100,6 +100,14 @@ content:
       formatter_settings: {  }
       show_description: false
     third_party_settings: {  }
+  description_override:
+    type: text_textarea
+    weight: 19
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   email:
     type: readonly_field_widget
     weight: 10

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -282,6 +282,7 @@ content:
     region: content
 hidden:
   created: true
+  description_override: true
   field_unit_type: true
   hide_description: true
   langcode: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -92,6 +92,13 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  description_override:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
   email:
     type: string
     label: hidden

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -92,13 +92,6 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
-  description_override:
-    type: text_default
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 3
-    region: content
   email:
     type: string
     label: hidden
@@ -106,6 +99,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 8
+    region: content
+  enrich_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_content:
     type: entity_reference_revisions_entity_view
@@ -289,7 +289,6 @@ content:
     region: content
 hidden:
   created: true
-  description_override: true
   field_unit_type: true
   hide_description: true
   langcode: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
@@ -47,8 +47,8 @@ hidden:
   call_charge_info: true
   created: true
   description: true
-  description_override: true
   email: true
+  enrich_description: true
   field_content: true
   field_lower_content: true
   field_metatags: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.minimal.yml
@@ -47,6 +47,7 @@ hidden:
   call_charge_info: true
   created: true
   description: true
+  description_override: true
   email: true
   field_content: true
   field_lower_content: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
@@ -67,8 +67,8 @@ hidden:
   call_charge_info: true
   created: true
   description: true
-  description_override: true
   email: true
+  enrich_description: true
   field_content: true
   field_lower_content: true
   field_metatags: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser.yml
@@ -67,6 +67,7 @@ hidden:
   call_charge_info: true
   created: true
   description: true
+  description_override: true
   email: true
   field_content: true
   field_lower_content: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
@@ -68,6 +68,7 @@ hidden:
   call_charge_info: true
   created: true
   description: true
+  description_override: true
   email: true
   field_content: true
   field_lower_content: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.teaser_with_image.yml
@@ -68,8 +68,8 @@ hidden:
   call_charge_info: true
   created: true
   description: true
-  description_override: true
   email: true
+  enrich_description: true
   field_content: true
   field_lower_content: true
   field_metatags: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
@@ -83,6 +83,7 @@ hidden:
   call_charge_info: true
   created: true
   description: true
+  description_override: true
   email: true
   field_content: true
   field_lower_content: true

--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_unit.tpr_unit.wide_teaser.yml
@@ -83,8 +83,8 @@ hidden:
   call_charge_info: true
   created: true
   description: true
-  description_override: true
   email: true
+  enrich_description: true
   field_content: true
   field_lower_content: true
   field_metatags: true

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -358,3 +358,24 @@ function helfi_tpr_config_update_9050(): void {
 function helfi_tpr_config_update_9051(): void {
   helfi_platform_config_update_paragraph_target_types();
 }
+
+/**
+ * UHF-9249: Add an override field for description.
+ */
+function helfi_tpr_config_update_9052() : void {
+  $description_override = BaseFieldDefinition::create('text_long')
+    ->setTranslatable(TRUE)
+    ->setRevisionable(FALSE)
+    ->setLabel(new TranslatableMarkup('Description override'))
+    ->setDescription(new TranslatableMarkup('Overrides the description.'))
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDisplayConfigurable('view', TRUE)
+    ->setSetting('allowed_formats', [0 => 'full_html']);
+
+  \Drupal::entityDefinitionUpdateManager()
+    ->installFieldStorageDefinition('description_override', 'tpr_unit', 'helfi_tpr_config', $description_override);
+
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -360,7 +360,7 @@ function helfi_tpr_config_update_9051(): void {
 }
 
 /**
- * UHF-9249: Add an override field for description.
+ * UHF-9249: Add an long description field for filling missing data.
  */
 function helfi_tpr_config_update_9052() : void {
   $enrich_description = BaseFieldDefinition::create('text_with_summary')

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -363,7 +363,7 @@ function helfi_tpr_config_update_9051(): void {
  * UHF-9249: Add an override field for description.
  */
 function helfi_tpr_config_update_9052() : void {
-  $description_override = BaseFieldDefinition::create('text_long')
+  $description_override = BaseFieldDefinition::create('text_with_summary')
     ->setTranslatable(TRUE)
     ->setRevisionable(FALSE)
     ->setLabel(new TranslatableMarkup('Description override'))

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -363,17 +363,17 @@ function helfi_tpr_config_update_9051(): void {
  * UHF-9249: Add an override field for description.
  */
 function helfi_tpr_config_update_9052() : void {
-  $description_override = BaseFieldDefinition::create('text_with_summary')
+  $enrich_description = BaseFieldDefinition::create('text_with_summary')
     ->setTranslatable(TRUE)
     ->setRevisionable(FALSE)
-    ->setLabel(new TranslatableMarkup('Override: Description'))
-    ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this will overwrite it.'))
+    ->setLabel(new TranslatableMarkup('Long description (replacing missing information'))
+    ->setDescription(new TranslatableMarkup('Note! The content is displayed on the website only if the long description is missing from the data source.'))
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE)
     ->setSetting('allowed_formats', [0 => 'plain_text']);
 
   \Drupal::entityDefinitionUpdateManager()
-    ->installFieldStorageDefinition('description_override', 'tpr_unit', 'helfi_tpr_config', $description_override);
+    ->installFieldStorageDefinition('enrich_description', 'tpr_unit', 'helfi_tpr_config', $enrich_description);
 
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -370,7 +370,7 @@ function helfi_tpr_config_update_9052() : void {
     ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this will overwrite it.'))
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE)
-    ->setSetting('allowed_formats', [0 => 'full_html']);
+    ->setSetting('allowed_formats', [0 => 'plain_text']);
 
   \Drupal::entityDefinitionUpdateManager()
     ->installFieldStorageDefinition('description_override', 'tpr_unit', 'helfi_tpr_config', $description_override);

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -366,8 +366,8 @@ function helfi_tpr_config_update_9052() : void {
   $description_override = BaseFieldDefinition::create('text_with_summary')
     ->setTranslatable(TRUE)
     ->setRevisionable(FALSE)
-    ->setLabel(new TranslatableMarkup('Description override'))
-    ->setDescription(new TranslatableMarkup('Overrides the description.'))
+    ->setLabel(new TranslatableMarkup('Override: Description'))
+    ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this will overwrite it.'))
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayConfigurable('view', TRUE)
     ->setSetting('allowed_formats', [0 => 'full_html']);

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -507,7 +507,7 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
       ->setDisplayConfigurable('view', TRUE)
       ->setSetting('allowed_formats', [0 => 'plain_text']);
 
-    $fields['description_override'] = BaseFieldDefinition::create('text_long')
+    $fields['description_override'] = BaseFieldDefinition::create('text_with_summary')
       ->setTranslatable(TRUE)
       ->setRevisionable(FALSE)
       ->setLabel(new TranslatableMarkup('Description override'))

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -510,8 +510,8 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
     $fields['description_override'] = BaseFieldDefinition::create('text_with_summary')
       ->setTranslatable(TRUE)
       ->setRevisionable(FALSE)
-      ->setLabel(new TranslatableMarkup('Description override'))
-      ->setDescription(new TranslatableMarkup('Overrides the description.'))
+      ->setLabel(new TranslatableMarkup('Override: Description'))
+      ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this will overwrite it.'))
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE)
       ->setSetting('allowed_formats', [0 => 'full_html']);

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -504,7 +504,17 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
         'weight' => 5,
       ])
       ->setDisplayConfigurable('form', TRUE)
-      ->setDisplayConfigurable('view', TRUE);
+      ->setDisplayConfigurable('view', TRUE)
+      ->setSetting('allowed_formats', [0 => 'plain_text']);
+
+    $fields['description_override'] = BaseFieldDefinition::create('text_long')
+      ->setTranslatable(TRUE)
+      ->setRevisionable(FALSE)
+      ->setLabel(new TranslatableMarkup('Description override'))
+      ->setDescription(new TranslatableMarkup('Overrides the description.'))
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE)
+      ->setSetting('allowed_formats', [0 => 'full_html']);
   }
   return $fields;
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -507,11 +507,11 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
       ->setDisplayConfigurable('view', TRUE)
       ->setSetting('allowed_formats', [0 => 'plain_text']);
 
-    $fields['description_override'] = BaseFieldDefinition::create('text_with_summary')
+    $fields['enrich_description'] = BaseFieldDefinition::create('text_with_summary')
       ->setTranslatable(TRUE)
       ->setRevisionable(FALSE)
-      ->setLabel(new TranslatableMarkup('Override: Description'))
-      ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this field does not do anything.'))
+      ->setLabel(new TranslatableMarkup('Long description (replacing missing information)'))
+      ->setDescription(new TranslatableMarkup('Note! The content is displayed on the website only if the long description is missing from the data source.'))
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE)
       ->setSetting('allowed_formats', [0 => 'plain_text']);

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -511,10 +511,10 @@ function helfi_tpr_config_entity_base_field_info(EntityTypeInterface $entity_typ
       ->setTranslatable(TRUE)
       ->setRevisionable(FALSE)
       ->setLabel(new TranslatableMarkup('Override: Description'))
-      ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this will overwrite it.'))
+      ->setDescription(new TranslatableMarkup('Add or overwrite the description text. If a description is provided by TPR, this field does not do anything.'))
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE)
-      ->setSetting('allowed_formats', [0 => 'full_html']);
+      ->setSetting('allowed_formats', [0 => 'plain_text']);
   }
   return $fields;
 }

--- a/modules/helfi_tpr_config/translations/fi.po
+++ b/modules/helfi_tpr_config/translations/fi.po
@@ -7,8 +7,8 @@ msgstr "Piilota palvelupaikkojen listaus"
 msgid "Select this if you link from the page to a filter search or another listing."
 msgstr "Valitse tämä, jos linkität sivulta palvelupaikkojen suodatushakuun tai muuhun listaukseen."
 
-msgid "Override: Description"
-msgstr "Ylikirjoita: Kuvaus"
+msgid "Long description (replacing missing information)"
+msgstr "Pitkä kuvaus (vain puuttuvalle tiedolle)"
 
-msgid "Add or overwrite the description text. If a description is provided by TPR, this will overwrite it."
-msgstr "Lisää tai ylikirjoita kuvausteksti. Jos TPR:stä tulee kuvausteksti, tämä ylikirjoittaa sen."
+msgid "Note! The content is displayed on the website only if the long description is missing from the data source."
+msgstr "Huom! Kentän sisältö näytetään verkkosivulla vain, jos pitkä kuvaus puuttuu kokonaan lähdejärjestelmästä."

--- a/modules/helfi_tpr_config/translations/fi.po
+++ b/modules/helfi_tpr_config/translations/fi.po
@@ -6,3 +6,9 @@ msgstr "Piilota palvelupaikkojen listaus"
 
 msgid "Select this if you link from the page to a filter search or another listing."
 msgstr "Valitse tämä, jos linkität sivulta palvelupaikkojen suodatushakuun tai muuhun listaukseen."
+
+msgid "Override: Description"
+msgstr "Ylikirjoita: Kuvaus"
+
+msgid "Add or overwrite the description text. If a description is provided by TPR, this will overwrite it."
+msgstr "Lisää tai ylikirjoita kuvausteksti. Jos TPR:stä tulee kuvausteksti, tämä ylikirjoittaa sen."

--- a/modules/helfi_tpr_config/translations/sv.po
+++ b/modules/helfi_tpr_config/translations/sv.po
@@ -8,7 +8,7 @@ msgid "Select this if you link from the page to a filter search or another listi
 msgstr "Välj detta om du länkar från sidan till en filtersökning eller till en separat lista."
 
 msgid "Override: Description"
-msgstr "Skriv över: Beskrivning"
+msgstr "Lång beskrivning (ersätter saknad information)"
 
 msgid "Add or overwrite the description text. If a description is provided by TPR, this will overwrite it."
-msgstr "Lägg till eller skriv över beskrivningstexten. Om en beskrivning finns från TPR kommer den att skrivas över av denna."
+msgstr "Observera! Innehållet visas på webbplatsen endast om den långa beskrivningen saknas från datakäll."

--- a/modules/helfi_tpr_config/translations/sv.po
+++ b/modules/helfi_tpr_config/translations/sv.po
@@ -6,3 +6,9 @@ msgstr "Dölj listan om serviceställen"
 
 msgid "Select this if you link from the page to a filter search or another listing."
 msgstr "Välj detta om du länkar från sidan till en filtersökning eller till en separat lista."
+
+msgid "Override: Description"
+msgstr "Skriv över: Beskrivning"
+
+msgid "Add or overwrite the description text. If a description is provided by TPR, this will overwrite it."
+msgstr "Lägg till eller skriv över beskrivningstexten. Om en beskrivning finns från TPR kommer den att skrivas över av denna."

--- a/modules/helfi_tpr_config/translations/sv.po
+++ b/modules/helfi_tpr_config/translations/sv.po
@@ -7,8 +7,8 @@ msgstr "Dölj listan om serviceställen"
 msgid "Select this if you link from the page to a filter search or another listing."
 msgstr "Välj detta om du länkar från sidan till en filtersökning eller till en separat lista."
 
-msgid "Override: Description"
+msgid "Long description (replacing missing information)"
 msgstr "Lång beskrivning (ersätter saknad information)"
 
-msgid "Add or overwrite the description text. If a description is provided by TPR, this will overwrite it."
+msgid "Note! The content is displayed on the website only if the long description is missing from the data source."
 msgstr "Observera! Innehållet visas på webbplatsen endast om den långa beskrivningen saknas från datakäll."


### PR DESCRIPTION
# [UHF-9249](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249)
<!-- What problem does this solve? -->
School don't have description field coming from TPR so they need a new field for adding the description in the Drupal.

## What was done
<!-- Describe what was done -->

* New field, `enrich_description`, has been added in all instances.

## How to install

* Make sure your instance (preferably kasko) is up and running on latest `dev `branch.
  * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9249_description-override`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9249_description-override`
* Run `make drush-updb drush-cr drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go edit any school (e.g. https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/aleksis-kiven-peruskoulu) and check that there is a new field `Long description (replacing missing information)`.
* [x] Check that the field label and description is translated correctly to Finnish and Swedish, probably need to switch user's preferred UI language. For some reason updating translations work randomly, so this might be a tough step.
* [x] Add text to the _Long description (replacing missing information)_ field and save the page. Check that the field content is displayed like a description normally on the unit's page.
* [x] Test also other TPR unit than school, e.g. this [daycare unit](https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/paivakoti-eira). The new description field **should not** override what is coming from the TPR. Instead, the new description field should be displayed only if the data from TPR is missing.
* [x] Check that code follows our standards.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/841


[UHF-9249]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ