### PR TITLE
UHF-9081 Lead in token

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.tokens.inc
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.tokens.inc
@@ -9,6 +9,7 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\MediaInterface;
+use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Implements hook_token_info().
@@ -23,6 +24,13 @@ function hdbt_admin_tools_token_info() {
   $info['tokens']['node']['shareable-image'] = [
     'name' => t('Shareable image'),
     'description' => t('Shareable image is used as a thumbnail in social networks and other services.'),
+  ];
+
+  $info['tokens']['node']['lead-in'] = [
+    'name' => t('Lead in'),
+    'description' => t(
+      'Lead in will try to use the hero paragraph description if it exists. If not, it will use the node lead in field.'
+    ),
   ];
 
   return $info;
@@ -115,6 +123,47 @@ function hdbt_admin_tools_tokens(
       }
 
       $replacements[$original] = $image_url;
+    }
+
+    // Custom token for lead in.
+    if ($name === 'lead-in' && !empty($data['node'])) {
+      /** @var \Drupal\node\NodeInterface $node */
+      $node = $data['node'];
+      $lead_in_text = '';
+
+      // Check if lead in field exists.
+      if (
+        $node->hasField('field_lead_in') &&
+        !$node?->get('field_lead_in')?->isEmpty()
+      ) {
+        // Use lead in field as lead in text.
+        $lead_in_text = $node->get('field_lead_in')->value;
+      }
+
+      // Check if hero paragraph and hero paragraph description exists.
+      if (
+        $node->hasField('field_hero') &&
+        !$node->get('field_hero')?->first()?->isEmpty()
+      ) {
+        // Get hero paragraph.
+        $hero = $node->get('field_hero')
+          ?->first()
+          ?->get('entity')
+          ?->getTarget()
+          ?->getValue();
+
+        if (
+          $hero instanceof ParagraphInterface &&
+          $hero->hasField('field_hero_desc') &&
+          !$hero->get('field_hero_desc')->isEmpty()
+        ) {
+          // Use hero paragraph description as lead in text.
+          $lead_in_text = $hero->get('field_hero_desc')->value;
+        }
+      }
+
+      // Add lead in text to replacements.
+      $replacements[$original] = $lead_in_text;
     }
   }
 

--- a/modules/helfi_base_content/config/rewrite/metatag.metatag_defaults.node.yml
+++ b/modules/helfi_base_content/config/rewrite/metatag.metatag_defaults.node.yml
@@ -5,12 +5,13 @@ id: node
 label: Content
 tags:
   title: '[node:title] | [site:page-title-suffix]'
-  description: '[node:field_lead_in]'
+  description: '[node:lead-in]'
   canonical_url: '[node:url]'
   article_modified_time: '[node:created:html_datetime]'
   article_published_time: '[node:created:html_datetime]'
   content_language: '[node:langcode]'
   og_title: '[node:title]'
+  og_description: '[node:lead-in]'
   og_updated_time: '[node:changed:html_datetime]'
   og_url: '[current-page:url:absolute]'
   twitter_cards_image: '[node:shareable-image]'

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -281,3 +281,11 @@ function helfi_base_content_update_9005() : void {
   $config_factory->getEditable('simple_sitemap.bundle_settings.default.menu_link_content.branding-navigation')->delete();
   $config_factory->getEditable('simple_sitemap.bundle_settings.default.menu_link_content.account')->delete();
 }
+
+/**
+ * UHF-9081 Update og_description and description meta tags.
+ */
+function helfi_base_content_update_9006() : void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_base_content');
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -77,5 +77,8 @@ parameters:
       message: '#^Call to an undefined method Drupal\\Core\\Entity\\EntityInterface::get\(\).#'
       path: modules/hdbt_admin_tools/hdbt_admin_tools.tokens.inc
     -
+      message: '#^Call to an undefined method Drupal\\Core\\TypedData\\TypedDataInterface::getTarget\(\).#'
+      path: modules/hdbt_admin_tools/hdbt_admin_tools.tokens.inc
+    -
       message: '#^Call to an undefined method Drupal\\Core\\Field\\FieldDefinitionInterface::save\(\).#'
       path: helfi_platform_config.module


### PR DESCRIPTION
# [UHF-9081](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9081)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added custom token 'lead-in'. The token will use field_lead_in field value if it exists. However if Hero description is available, it will be used instead.
* Use [node:lead-in] for nodes' metatag description and og:description.

## How to install in KYMP
* Make sure the kymp-instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9081_lead_in_token`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to [this page](https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/miten-suunnittelu-etenee) and check that there are `<meta name="description" content="...">` and `<meta property="og:description" content="...">` tags in the `<head>`
* [x] Edit the page and add a hero with a description
* [x] Check that the description meta tags have changed to match the hero description.
* [x] Remove the hero and save the page. Re-check the description meta tags. They should now have been reverted to `field_lead_in` text.
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/763


[UHF-9081]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ