### PR TITLE
Conflict on Drupal 10.2 for now.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "drupal/scheduler": "^1.3",
         "drupal/search_api": "^1.0",
         "drupal/select2": "^1.12",
-        "drupal/simple_sitemap": "^4.1.7",
+        "drupal/simple_sitemap": "^4.1",
         "drupal/siteimprove": "^2.0",
         "drupal/social_media": "^2.0",
         "drupal/stomp": "^2.0",
@@ -65,6 +65,7 @@
         "drupal/core": "<10.1 || >=10.2",
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
+        "drupal/simple_sitemap": ">4.1.7",
         "drush/drush": "<12"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "php": "^8.1"
     },
     "conflict": {
-        "drupal/core": "<10.1 || >10.1",
+        "drupal/core": "<10.1 || >=10.2",
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drush/drush": "<12"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "drupal/scheduler": "^1.3",
         "drupal/search_api": "^1.0",
         "drupal/select2": "^1.12",
-        "drupal/simple_sitemap": "^4.1",
+        "drupal/simple_sitemap": "^4.1.7",
         "drupal/siteimprove": "^2.0",
         "drupal/social_media": "^2.0",
         "drupal/stomp": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "php": "^8.1"
     },
     "conflict": {
-        "drupal/core": "<10.1",
+        "drupal/core": "<10.1 || >10.1",
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drush/drush": "<12"


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Conflict on Drupal 10.2 until further notice
* Lock simple sitemap to 4.1.7 as there is a task for removing the patch.
