### PR TITLE
UHF-X Search API does not exist

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.install
+++ b/modules/helfi_react_search/helfi_react_search.install
@@ -47,6 +47,10 @@ function helfi_react_search_update_9003(): void {
  * Mark indexes to require reindexing.
  */
 function helfi_react_search_update_9004() {
+  if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
+    return;
+  }
+
   $schoolsIndex = Index::load('schools');
   $healthStationsIndex = Index::load('health_stations');
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Exit early if search api module is not enabled. Like in KUVA instance, where the module `helfi_react_search` is enabled (for some reason).

![image](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/assets/1712902/91a9afa3-3a78-4a15-b131-fe8ddd230f35)


## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Just check the code

