### PR TITLE
UHF-8061: added description for langcode field if it exists

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1053,3 +1053,16 @@ function hdbt_admin_tools_entity_operation(EntityInterface $entity): array {
   }
   return $operations;
 }
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ */
+function helfi_platform_config_entity_base_field_info_alter(&$fields, \Drupal\Core\Entity\EntityTypeInterface $entity_type) {
+  // #UHF-8061 Add description for langcode-field.
+  if (isset($fields['langcode'])) {
+    $translation = \Drupal::translation()->translate(
+      'If you want to translate this page, do not change this value. You can translate this content from the \'Translate\' -tab'
+    );
+    $fields['langcode']->setDescription($translation);
+  }
+}

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -1057,7 +1057,7 @@ function hdbt_admin_tools_entity_operation(EntityInterface $entity): array {
 /**
  * Implements hook_entity_base_field_info_alter().
  */
-function helfi_platform_config_entity_base_field_info_alter(&$fields, \Drupal\Core\Entity\EntityTypeInterface $entity_type) {
+function hdbt_admin_tools_entity_base_field_info_alter(&$fields) {
   // #UHF-8061 Add description for langcode-field.
   if (isset($fields['langcode'])) {
     $translation = \Drupal::translation()->translate(

--- a/modules/hdbt_admin_tools/translations/fi.po
+++ b/modules/hdbt_admin_tools/translations/fi.po
@@ -126,3 +126,6 @@ msgstr "Päivitä käyttäjän salasana"
 
 msgid "Hero paragraph is mandatory if the Hero checkbox has been selected. Either unselect the checkbox or create the hero paragraph by clicking the Add Hero button."
 msgstr "Hero-lohko on pakollinen jos Hero-lohko -valintaruutu on valittuna. Poista valintaruudun valinta tai luo Hero-lohko klikkaamalla \"Lisää hero\" -painiketta."
+
+msgid "If you want to translate this page, do not change this value. You can translate this content from the 'Translate' -tab"
+msgstr "Jos haluat luoda tästä sivusta uuden käännöksen, älä vaihda tätä arvoa, vaan luo uusi käännös 'Käännä'-välilehdeltä"


### PR DESCRIPTION
# [UHF-8061](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8061)
Added description for langcode dropdown

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8061`
* Run `make drush-updb drush-cr`

## How to test
- Go to content edit pages where there is a langcode dropdown
  - It should have a description text (either finnish or english description)
- Content pages without langcode dropdown should be unaffected

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-8061]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ