### PR TITLE
UHF-X Calculator configuration

### DIFF
--- a/modules/helfi_calculator/helfi_calculator.module
+++ b/modules/helfi_calculator/helfi_calculator.module
@@ -17,8 +17,9 @@ use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
  *   - view_mode: View mode; e.g., 'full', 'teaser'...
  */
 function helfi_calculator_preprocess_paragraph__calculator(array &$variables) {
-  $config = Drupal::config('helfi_calculator.settings');
-  $calculator_settings = $config->get('calculators');
+  // Get calculator data without applying module overrides for the calculators.
+  $config = \Drupal::configFactory()->getEditable('helfi_calculator.settings');
+  $calculator_settings = $config->getOriginal('calculators', FALSE);
   $active = [];
   foreach ($calculator_settings as $key => $value) {
     $variables['#attached']['drupalSettings'][$key] = $value['json'];


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Changed the retrieval of calculator json data to use non-overridden data.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_calculator_configuration_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to: https://helfi-kasko.docker.so/en/childhood-and-education/admin/tools/calculator-settings
   * [x] Change data to Early childhood education fee and save it
* [x] Go to https://helfi-kasko.docker.so/fi/kasvatus-ja-koulutus/varhaiskasvatus/mita-varhaiskasvatus-maksaa/varhaiskasvatusmaksun-laskuri
   * [x] Check that the changed data was updated to the `drupalSettings.early_childhood_education_fee` variable
* [x] Check that code follows our standards

