### PR TITLE
UHF-9007: add option for 10 results

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -17,6 +17,7 @@ function helfi_react_search_event_list_allowed_values_function(): array {
   return [
     3 => 3,
     5 => 5,
+    10 => 10,
   ];
 }
 


### PR DESCRIPTION
# [UHF-9007](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9007)
## What was done
Added third option for search result count. Tested with different options to see that frontend doesn't break.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9007_event_list_pagination_values`
* Run `make drush-cr`

## How to test
* [x] Go to https://helfi-elo.docker.so/fi/yritykset-ja-tyo/business-helsingin-tapahtumat
* [x] Edit page and confirm that the dropdown contains options 3, 5 and 10
* [x] Set to 10 and check if the listing is acting as expected



[UHF-9007]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ