### PR TITLE
UHF-9551: Telia ACE fixes.

### DIFF
--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -70,14 +70,14 @@ user_consent_functions:
     - core/drupal
 
 telia_ace_widget_loadjs:
-  version: 1.0.x
+  version: 1.0.1
   css:
     theme:
       assets/css/telia_ace.css: {}
   js:
     'https://wds.ace.teliacompany.com/wds/instances/J5XKjqJt/load_ace.js': {
       type: external,
-      minified: true,
+      minified: false,
       attributes: {
         defer: true
       }

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -77,3 +77,17 @@ telia_ace_widget:
       assets/css/telia_ace.css: {}
   dependencies:
     - helfi_platform_config/user_consent_functions
+
+telia_ace_widget_loadjs:
+  version: 1.0.x
+  css:
+    theme:
+      assets/css/telia_ace.css: {}
+  js:
+    'https://wds.ace.teliacompany.com/wds/instances/J5XKjqJt/load_ace.js': {
+      type: external,
+      minified: true,
+      attributes: { defer: true }
+    }
+  dependencies:
+    - helfi_platform_config/user_consent_functions

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -69,15 +69,6 @@ user_consent_functions:
   dependencies:
     - core/drupal
 
-telia_ace_widget:
-  version: 1.0.x
-  header: true
-  css:
-    theme:
-      assets/css/telia_ace.css: {}
-  dependencies:
-    - helfi_platform_config/user_consent_functions
-
 telia_ace_widget_loadjs:
   version: 1.0.x
   css:
@@ -87,7 +78,9 @@ telia_ace_widget_loadjs:
     'https://wds.ace.teliacompany.com/wds/instances/J5XKjqJt/load_ace.js': {
       type: external,
       minified: true,
-      attributes: { defer: true }
+      attributes: {
+        defer: true
+      }
     }
   dependencies:
     - helfi_platform_config/user_consent_functions

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -26,15 +26,15 @@ class TeliaAceWidget extends BlockBase {
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => $this->t('Script URL'),
-      '#description' => $this->t('URL to the chat JS library without the domain, for example: /wds/instances/J5XKjqJt/ACEWebSDK.min.js'),
-      '#default_value' => $config['script_url'] ?? '/wds/instances/J5XKjqJt/ACEWebSDK.min.js',
+      '#description' => $this->t('URL to the chat JS library without the domain, for example: /wds/instances/J5XKjqJt/load_ace.js'),
+      '#default_value' => $config['script_url'] ?? '/wds/instances/J5XKjqJt/load_ace.js',
     ];
 
     $form['chat_id'] = [
       '#type' => 'textfield',
       '#required' => TRUE,
       '#title' => $this->t('Chat Widget ID'),
-      '#description' => $this->t('ID for the chat instance. Example format: example-chat-fin'),
+      '#description' => $this->t('ID for the chat instance, without the humany_ prefix. This value can be translated. Example format: example-chat-fin'),
       '#default_value' => $config['chat_id'] ?? '',
     ];
 
@@ -89,6 +89,8 @@ class TeliaAceWidget extends BlockBase {
         '#type' => 'html_tag',
         '#tag' => 'div',
         '#attributes' => [
+          'role' => 'region',
+          'aria-label' => 'chat',
           'id' => $chat_id,
           'class' => [
             'hidden',

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -22,14 +22,6 @@ class TeliaAceWidget extends BlockBase {
     $form = parent::blockForm($form, $form_state);
     $config = $this->getConfiguration();
 
-    $form['script_url'] = [
-      '#type' => 'textfield',
-      '#required' => TRUE,
-      '#title' => $this->t('Script URL'),
-      '#description' => $this->t('URL to the chat JS library without the domain, for example: /wds/instances/J5XKjqJt/load_ace.js'),
-      '#default_value' => $config['script_url'] ?? '/wds/instances/J5XKjqJt/load_ace.js',
-    ];
-
     $form['chat_id'] = [
       '#type' => 'textfield',
       '#required' => TRUE,
@@ -45,7 +37,6 @@ class TeliaAceWidget extends BlockBase {
    * {@inheritdoc}
    */
   public function blockSubmit($form, FormStateInterface $formState) {
-    $this->configuration['script_url'] = $formState->getValue('script_url');
     $this->configuration['chat_id'] = $formState->getValue('chat_id');
   }
 
@@ -57,32 +48,10 @@ class TeliaAceWidget extends BlockBase {
     $build = [];
 
     $config = $this->getConfiguration();
-    $base_url = 'https://wds.ace.teliacompany.com';
-    $script_url = $base_url . $config['script_url'];
     $chat_id = 'humany_' . $config['chat_id'];
-
-    if ($script_url === 'https://wds.ace.teliacompany.com/wds/instances/J5XKjqJt/load_ace.js') {
-      $attached = [
-        'library' => ['helfi_platform_config/telia_ace_widget_loadjs'],
-      ];
-    }
-    else {
-      $attached = [
-        'library' => ['helfi_platform_config/telia_ace_widget'],
-        'html_head' => [
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'defer' => TRUE,
-                'type' => 'text/javascript',
-                'src' => $script_url,
-              ],
-            ], 'telia_ace_script',
-          ],
-        ],
-      ];
-    }
+    $attached = [
+      'library' => ['helfi_platform_config/telia_ace_widget_loadjs'],
+    ];
 
     $build['ibm_chat_app'] = [
       'button' => [

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -54,14 +54,35 @@ class TeliaAceWidget extends BlockBase {
    */
   public function build() {
 
-    $library = ['helfi_platform_config/telia_ace_widget'];
-
     $build = [];
 
     $config = $this->getConfiguration();
     $base_url = 'https://wds.ace.teliacompany.com';
     $script_url = $base_url . $config['script_url'];
     $chat_id = 'humany_' . $config['chat_id'];
+
+    if ($script_url === 'https://wds.ace.teliacompany.com/wds/instances/J5XKjqJt/load_ace.js') {
+      $attached = [
+        'library' => ['helfi_platform_config/telia_ace_widget_loadjs'],
+      ];
+    }
+    else {
+      $attached = [
+        'library' => ['helfi_platform_config/telia_ace_widget'],
+        'html_head' => [
+          [
+            [
+              '#tag' => 'script',
+              '#attributes' => [
+                'defer' => TRUE,
+                'type' => 'text/javascript',
+                'src' => $script_url,
+              ],
+            ], 'telia_ace_script',
+          ],
+        ],
+      ];
+    }
 
     $build['ibm_chat_app'] = [
       'button' => [
@@ -74,21 +95,7 @@ class TeliaAceWidget extends BlockBase {
           ],
         ],
       ],
-      '#attached' => [
-        'library' => $library,
-        'html_head' => [
-          [
-            [
-              '#tag' => 'script',
-              '#attributes' => [
-                'async' => TRUE,
-                'type' => 'text/javascript',
-                'src' => $script_url,
-              ],
-            ], 'telia_ace_script',
-          ],
-        ],
-      ],
+      '#attached' => $attached,
     ];
 
     return $build;

--- a/src/Plugin/Block/TeliaAceWidget.php
+++ b/src/Plugin/Block/TeliaAceWidget.php
@@ -53,7 +53,7 @@ class TeliaAceWidget extends BlockBase {
       'library' => ['helfi_platform_config/telia_ace_widget_loadjs'],
     ];
 
-    $build['ibm_chat_app'] = [
+    $build['telia_chat_widget'] = [
       'button' => [
         '#type' => 'html_tag',
         '#tag' => 'div',


### PR DESCRIPTION
# [UHF-9551](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9551)

## What was done
Create Telia ACE embed block. Change embed method to always use the load_ace.js script.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9551-telia-ace-fixes`
* Run `make drush-updb drush-cr`

## How to test
- [x] Add a Telia ACE block to a standard or landing page with the following IDs. Use block translation to set up the finnish and swedish IDs. Also add english, finnish and swedish translations for the node.
  - EN: `helsinki-testichat_en`
  - FI: `helsinki-testichat_fi`
  - SV: `helsinki-testichat_sv`
- [x] Before you load the test page, make sure you've only accepted necessary cookies. Chat cookies should be disabled
- [x] When you first load the page the block was added on, make sure it doesn't add any cookies or local- / sessionstorage data (there's a separate ticket for more in depth auditing, but would be good to double check this here too)
- [x] When you click the chat button it should (eventually) load the chat widget and open it automatically
  - It might take a few seconds to load and it might print errors in the console log, but that's expected
- [x] Open different language veresions of the page. Make sure it opens localized versions of the chat widget
- [x] Check the cookie information page. The chat cookies should now be accepted
- [ ] Check that code follows our standards.

[UHF-9551]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ