### PR TITLE
UHF-X External entities alpha6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/eu_cookie_compliance": "^1.24",
-        "drupal/external_entities": "2.0.0-alpha",
+        "drupal/external_entities": "2.0.0-alpha6",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
         "drupal/gin_toolbar": "^1.0@rc",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/eu_cookie_compliance": "^1.24",
-        "drupal/external_entities": "^2.0@alpha",
+        "drupal/external_entities": "2.0.0-alpha",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
         "drupal/gin_toolbar": "^1.0@rc",


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Lock External entities module to 2.0-alpha6 as ExternalEntityTransformRawDataEvent extends non existent Symfony\Component\EventDispatcher\Event class.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_external_entities_alpha6`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards
