### PR TITLE
UHF-9542: Proof of concept for LinkedEvents getPlacesList improvements

### DIFF
--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -233,6 +233,11 @@ class LinkedEvents extends EventsApiBase {
       $options['division'] = $parsed_url['query']['division'];
     }
 
+    // Add locations to URL for caching purposes.
+    if (isset($parsed_url['query']['locations'])) {
+      $options['locations'] = $parsed_url['query']['locations'];
+    }
+
     $options = array_merge($defaultOptions, $options);
     $url->setOption('query', $options);
 

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -134,7 +134,7 @@ class LinkedEvents extends EventsApiBase {
   /**
    * Return places from cache or generate list of them.
    *
-   * @param string $url
+   * @param string $event_url
    *   The Api url for events.
    *
    * @return array
@@ -204,11 +204,11 @@ class LinkedEvents extends EventsApiBase {
 
   /**
    * Format places API URL with query options from events API URL.
+   *
    * - Currently only 'division' option is useful.
    * - 'has_upcoming_events' option is used to limit results (from 2k to 700).
    * - Places API doesn't accept a list of IDs, so we have to get all results.
    * - This is usually still faster than querying each place individually.
-   *
    *
    * @param string $event_url
    *   Event API URL.


### PR DESCRIPTION
# [UHF-9542](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9542)

## DO NOT MERGE!
## What was done
* Creates a Places API (https://api.hel.fi/linkedevents/v1/place/) request based on Events API URL instead of looping through all events
* Limits:
  * Places API doesn't support a list of IDs, so we have to get all locations with upcoming events. However, since this does around 7 or 8 requests (with around 700 locations total), these take about the same time. 
  * Places list has to be added to the Event API URL, otherwise all 700 locations are added to the filter

## Benchmark with SOTE instance before fetching this branch
* Make sure your SOTE instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
    * `make drush-cr` 
* Go to https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset
  * Check how long the page takes to load after caches are cleared
* Edit the page and change the events list API URL to: https://tapahtumat.hel.fi/fi/haku?text=seniorikeskus%2Fpalvelukeskus&division=kunta:helsinki&places=tprek:48547,tprek:48591,tprek:33179,tprek:30036,tprek:47695,tprek:48762,tprek:11407
  * Run `make drush-cr` again and check if this has an effect on the load time 

## How to install
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9542-linkedevents-places-poc`
* Run `make drush-cr`
* Reload the page and check if the load times are improved
* Compare the location filter list and amount of events to the live version: https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/palvelukeskukset
  * The locations should be the same (maybe in a different order), and the amount of events should be the same

## How to test
* [ ] Check that this feature works and is generally faster
* [x] Check that code follows our standards

[UHF-9542]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ