### PR TITLE
UHF-9497 Word vs. CKEditor5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "drupal/admin_toolbar": "^3.0",
         "drupal/allowed_formats": "^2.0",
         "drupal/ckeditor": "^1.0",
+        "drupal/ckeditor5_paste_filter": "^1.0",
         "drupal/config_filter": "^2.6",
         "drupal/config_ignore": "^3.0",
         "drupal/config_rewrite": "^1.4",

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -50,68 +50,83 @@ settings:
       filters:
         -
           enabled: true
-          weight: -10
+          weight: 0
           search: '<o:p><\/o:p>'
           replace: ''
         -
           enabled: true
-          weight: -9
+          weight: 1
           search: '(<[^>]*) (style="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -8
+          weight: 2
           search: '(<[^>]*) (face="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -7
+          weight: 3
           search: '(<[^>]*) (class="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -6
+          weight: 4
           search: '(<[^>]*) (valign="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -5
+          weight: 5
           search: '<font[^>]*>'
           replace: ''
         -
           enabled: true
-          weight: -4
+          weight: 6
           search: '<\/font>'
           replace: ''
         -
           enabled: true
-          weight: -3
+          weight: 7
           search: '<span(?![^>]*\b(?:dir|lang)="[^"]*")[^>]*>(.*?)<\/span>'
           replace: $1
         -
           enabled: true
-          weight: -1
+          weight: 8
+          search: '<p><span lang="[^"]*"><\/span><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 9
+          search: '<span lang="[^"]*"><\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: 10
           search: '<p>&nbsp;<\/p>'
           replace: ''
         -
           enabled: true
-          weight: 0
+          weight: 11
           search: '<p><\/p>'
           replace: ''
         -
           enabled: true
-          weight: 1
+          weight: 12
           search: '<b><\/b>'
           replace: ''
         -
           enabled: true
-          weight: 2
+          weight: 13
           search: '<i><\/i>'
           replace: ''
         -
           enabled: true
-          weight: 3
+          weight: 14
           search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
+        -
+          enabled: true
+          weight: 15
+          search: '<a name="[^"]*">(.*?)<\/a>'
           replace: $1
     ckeditor5_sourceEditing:
       allowed_tags: {  }

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -5,6 +5,7 @@ dependencies:
     - filter.format.full_html
   module:
     - ckeditor5
+    - ckeditor5_paste_filter
 format: full_html
 editor: ckeditor5
 settings:

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -49,7 +49,7 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span aria-hidden>'
+        - '<span>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -45,27 +45,11 @@ settings:
         startIndex: true
       multiBlock: true
     ckeditor5_sourceEditing:
-      allowed_tags:
-        - '<dl>'
-        - '<dt>'
-        - '<dd>'
-        - '<blockquote role aria-* cite class>'
-        - '<div role aria-* class>'
-        - '<img src alt height width data-entity-type data-entity-uuid data-align data-caption data-responsive-image-style>'
-        - '<span role aria-* class>'
-        - '<ul type>'
-        - '<ol type>'
-        - '<h2 id>'
-        - '<h3 id>'
-        - '<h4 id>'
-        - '<h5 id>'
-        - '<h6 id>'
-        - '<figure tabindex>'
-        - '<figcaption>'
+      allowed_tags: {  }
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
-        - '<a aria-label class data-design data-hds-icon-start data-is-external data-link-text data-protocol data-selected-icon data-hds-component data-hds-variant id rel role target="_blank" title>'
-        - '<span aria-hidden class role>'
+        - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
+        - '<span aria-hidden class>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -85,13 +85,8 @@ settings:
         -
           enabled: true
           weight: -3
-          search: '<span[^>]*>'
-          replace: ''
-        -
-          enabled: true
-          weight: -2
-          search: '<\/span>'
-          replace: ''
+          search: '<span(?![^>]*\b(?:dir|lang)="[^"]*")[^>]*>(.*?)<\/span>'
+          replace: $1
         -
           enabled: true
           weight: -1

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -44,6 +44,79 @@ settings:
         reversed: false
         startIndex: true
       multiBlock: true
+    ckeditor5_paste_filter_pasteFilter:
+      enabled: true
+      filters:
+        -
+          enabled: true
+          weight: -10
+          search: '<o:p><\/o:p>'
+          replace: ''
+        -
+          enabled: true
+          weight: -9
+          search: '(<[^>]*) (style="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -8
+          search: '(<[^>]*) (face="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -7
+          search: '(<[^>]*) (class="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -6
+          search: '(<[^>]*) (valign="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -5
+          search: '<font[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -4
+          search: '<\/font>'
+          replace: ''
+        -
+          enabled: true
+          weight: -3
+          search: '<span[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -2
+          search: '<\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: -1
+          search: '<p>&nbsp;<\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 0
+          search: '<p><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 1
+          search: '<b><\/b>'
+          replace: ''
+        -
+          enabled: true
+          weight: 2
+          search: '<i><\/i>'
+          replace: ''
+        -
+          enabled: true
+          weight: 3
+          search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
     ckeditor5_sourceEditing:
       allowed_tags: {  }
     helfi_ckeditor_helfi_link:

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -49,7 +49,7 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span aria-hidden class>'
+        - '<span aria-hidden>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -48,7 +48,7 @@ settings:
       allowed_tags: {  }
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
-        - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
+        - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
         - '<span aria-hidden>'
     linkit_extension:
       linkit_enabled: true

--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -49,7 +49,6 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -31,7 +31,7 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span aria-hidden class>'
+        - '<span aria-hidden>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -32,68 +32,83 @@ settings:
       filters:
         -
           enabled: true
-          weight: -10
+          weight: 0
           search: '<o:p><\/o:p>'
           replace: ''
         -
           enabled: true
-          weight: -9
+          weight: 1
           search: '(<[^>]*) (style="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -8
+          weight: 2
           search: '(<[^>]*) (face="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -7
+          weight: 3
           search: '(<[^>]*) (class="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -6
+          weight: 4
           search: '(<[^>]*) (valign="[^"]*")'
           replace: $1
         -
           enabled: true
-          weight: -5
+          weight: 5
           search: '<font[^>]*>'
           replace: ''
         -
           enabled: true
-          weight: -4
+          weight: 6
           search: '<\/font>'
           replace: ''
         -
           enabled: true
-          weight: -3
+          weight: 7
           search: '<span(?![^>]*\b(?:dir|lang)="[^"]*")[^>]*>(.*?)<\/span>'
           replace: $1
         -
           enabled: true
-          weight: -1
+          weight: 8
+          search: '<p><span lang="[^"]*"><\/span><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 9
+          search: '<span lang="[^"]*"><\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: 10
           search: '<p>&nbsp;<\/p>'
           replace: ''
         -
           enabled: true
-          weight: 0
+          weight: 11
           search: '<p><\/p>'
           replace: ''
         -
           enabled: true
-          weight: 1
+          weight: 12
           search: '<b><\/b>'
           replace: ''
         -
           enabled: true
-          weight: 2
+          weight: 13
           search: '<i><\/i>'
           replace: ''
         -
           enabled: true
-          weight: 3
+          weight: 14
           search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
+        -
+          enabled: true
+          weight: 15
+          search: '<a name="[^"]*">(.*?)<\/a>'
           replace: $1
     ckeditor5_sourceEditing:
       allowed_tags: {  }

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -30,7 +30,7 @@ settings:
       allowed_tags: {  }
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
-        - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
+        - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
         - '<span aria-hidden>'
     linkit_extension:
       linkit_enabled: true

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -31,7 +31,7 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span aria-hidden>'
+        - '<span>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -27,15 +27,11 @@ settings:
         startIndex: true
       multiBlock: true
     ckeditor5_sourceEditing:
-      allowed_tags:
-        - '<span role aria-* class>'
-        - '<ul type>'
-        - '<ol type>'
-        - '<a hreflang accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol>'
+      allowed_tags: {  }
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
-        - '<a aria-label class data-design data-hds-icon-start data-is-external data-link-text data-protocol data-selected-icon data-hds-component data-hds-variant id rel role target="_blank" title>'
-        - '<span aria-hidden class role>'
+        - '<a class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
+        - '<span aria-hidden class>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -26,6 +26,79 @@ settings:
         reversed: false
         startIndex: true
       multiBlock: true
+    ckeditor5_paste_filter_pasteFilter:
+      enabled: true
+      filters:
+        -
+          enabled: true
+          weight: -10
+          search: '<o:p><\/o:p>'
+          replace: ''
+        -
+          enabled: true
+          weight: -9
+          search: '(<[^>]*) (style="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -8
+          search: '(<[^>]*) (face="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -7
+          search: '(<[^>]*) (class="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -6
+          search: '(<[^>]*) (valign="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: -5
+          search: '<font[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -4
+          search: '<\/font>'
+          replace: ''
+        -
+          enabled: true
+          weight: -3
+          search: '<span[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: -2
+          search: '<\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: -1
+          search: '<p>&nbsp;<\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 0
+          search: '<p><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 1
+          search: '<b><\/b>'
+          replace: ''
+        -
+          enabled: true
+          weight: 2
+          search: '<i><\/i>'
+          replace: ''
+        -
+          enabled: true
+          weight: 3
+          search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
     ckeditor5_sourceEditing:
       allowed_tags: {  }
     helfi_ckeditor_helfi_link:

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -67,13 +67,8 @@ settings:
         -
           enabled: true
           weight: -3
-          search: '<span[^>]*>'
-          replace: ''
-        -
-          enabled: true
-          weight: -2
-          search: '<\/span>'
-          replace: ''
+          search: '<span(?![^>]*\b(?:dir|lang)="[^"]*")[^>]*>(.*?)<\/span>'
+          replace: $1
         -
           enabled: true
           weight: -1

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -5,6 +5,7 @@ dependencies:
     - filter.format.minimal
   module:
     - ckeditor5
+    - ckeditor5_paste_filter
 format: minimal
 editor: ckeditor5
 settings:

--- a/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.minimal.yml
@@ -31,7 +31,6 @@ settings:
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
-        - '<span>'
     linkit_extension:
       linkit_enabled: true
       linkit_profile: helfi

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden class role dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <blockquote data-helfi-quote> <span dir> <ul> <ol start> <li> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <table> <tr> <td> <th> <thead> <tbody> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <blockquote role aria-* cite class data-helfi-quote> <div role aria-* class> <span role aria-* class dir> <ul type> <ol type start> <figure tabindex> <figcaption> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution aria-label class data-design data-hds-icon-start data-is-external data-link-text data-protocol data-selected-icon data-hds-component data-hds-variant rel role target="_blank"> <li> <table> <tr> <td> <th> <thead> <tbody> <tfoot> <caption> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden class role dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <strong> <em> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <span aria-hidden dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden dir>'
+      allowed_html: '<br> <p> <strong> <em> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden dir>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden dir>'
+      allowed_html: '<br> <p> <strong> <em> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span dir>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden class role dir>'
+      allowed_html: '<br> <p> <strong> <em> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden dir>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <span role aria-* class lang dir> <ul type> <ol type start> <a hreflang accesskey id rel target title data-design data-link-text data-selected-icon data-is-external data-protocol href data-entity-type data-entity-uuid data-entity-substitution aria-label class data-hds-icon-start data-hds-component data-hds-variant role> <strong> <em> <li>'
+      allowed_html: '<br> <p> <strong> <em> <a href class data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span aria-hidden class role dir>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <ul> <ol start> <li> <span dir>'
+      allowed_html: '<br> <p> <span dir> <ul> <ol start> <li> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <strong> <em>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.minimal.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p> <strong> <em> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <span dir>'
+      allowed_html: '<br> <p> <strong> <em> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <ul> <ol start> <li> <span dir>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
+++ b/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
@@ -12,8 +12,7 @@ helfi_ckeditor_helfi_link:
     label: Helfi Link
     library: helfi_ckeditor/helfi_link
     elements:
-      - <a class data-design data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">
-      - <span aria-hidden>
+      - <a data-design data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">
     conditions:
       plugins:
         - ckeditor5_link

--- a/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
+++ b/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
@@ -13,7 +13,7 @@ helfi_ckeditor_helfi_link:
     library: helfi_ckeditor/helfi_link
     elements:
       - <a class data-design data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">
-      - <span aria-hidden class>
+      - <span aria-hidden>
     conditions:
       plugins:
         - ckeditor5_link

--- a/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
+++ b/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
@@ -33,7 +33,8 @@ helfi_ckeditor_helfi_language_selector:
       helfiLanguageSelector:
         label: Select language
     elements:
-      - <span dir lang>
+      - <span>
+      - <span lang dir>
     class: Drupal\helfi_ckeditor\Plugin\CKEditor5Plugin\HelfiLanguageSelector
 
 helfi_ckeditor_helfi_quote:

--- a/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
+++ b/modules/helfi_ckeditor/helfi_ckeditor.ckeditor5.yml
@@ -12,8 +12,8 @@ helfi_ckeditor_helfi_link:
     label: Helfi Link
     library: helfi_ckeditor/helfi_link
     elements:
-      - <a aria-label class data-design data-hds-icon-start data-is-external data-link-text data-protocol data-selected-icon data-hds-component data-hds-variant id rel role target="_blank" title>
-      - <span aria-hidden class role>
+      - <a class data-design data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">
+      - <span aria-hidden class>
     conditions:
       plugins:
         - ckeditor5_link

--- a/modules/helfi_ckeditor/helfi_ckeditor.info.yml
+++ b/modules/helfi_ckeditor/helfi_ckeditor.info.yml
@@ -3,6 +3,7 @@ type: module
 core_version_requirement: '^9 || ^10'
 dependencies:
   - drupal:ckeditor5
+  - drupal:ckeditor5_paste_filter
   - drupal:filter
   - helfi_api_base:helfi_api_base
   - helfi_platform_config:helfi_platform_config

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -216,24 +216,33 @@ function helfi_ckeditor_update_9007(): void {
         $count += $update->execute();
       }
 
-      // Search for <a> elements containing data-link-text.
-      $regex = '<a(.*?)data-link-text="[^"]*"(.*?)>';
+      // Fetch the data for <a> elements containing data-link-text.
+      $pattern = '%<a%data-link-text="%"%';
       $query = \Drupal::database()->select($table_name, 'v')
         ->distinct()
         ->fields('v', ['entity_id', $column])
-        ->condition($column, $regex, 'REGEXP');
+        ->condition($column, $pattern, 'LIKE');
       $query_result = $query->execute()->fetchAll();
 
-      if (!empty($query_result)) {
-        $data_link_count += count($query_result);
-        $replacement = '<a\1\2>';
-        $update = \Drupal::database()->update($table_name);
-        $update->expression(
-          $column,
-          "REGEXP_REPLACE($column, :pattern, :replacement)",
-          [':pattern' => $regex, ':replacement' => $replacement]
+      // Process the data and update the database.
+      // The query result is always an array.
+      foreach ($query_result as $result) {
+        if (!str_contains($result->$column, 'data-link-text=')) {
+          continue;
+        }
+        $data_without_link_text = preg_replace(
+          '/data-link-text="[^"]*"/',
+          '', $result->$column
         );
-        $update->execute();
+
+        if ($result->$column != $data_without_link_text) {
+          $data_link_count++;
+          // Update the database
+          $update = \Drupal::database()->update($table_name)
+            ->fields([$column => $data_without_link_text])
+            ->condition('entity_id', $result->entity_id)
+            ->execute();
+        }
       }
     }
   }

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -179,6 +179,7 @@ function helfi_ckeditor_update_9007(): void {
   ];
 
   $count = 0;
+  $data_link_count = 0;
 
   // Load all field configurations.
   /** @var \Drupal\field\Entity\FieldConfig $field_config */
@@ -212,10 +213,33 @@ function helfi_ckeditor_update_9007(): void {
         );
         $count += $update->execute();
       }
+
+      // Search for <a> elements containing data-link-text.
+      $regex = '<a(.*?)data-link-text="[^"]*"(.*?)>';
+      $query = \Drupal::database()->select($table_name, 'v')
+        ->distinct()
+        ->fields('v', ['entity_id', $column])
+        ->condition($column, $regex, 'REGEXP');
+      $query_result = $query->execute()->fetchAll();
+
+      if (!empty($query_result)) {
+        $data_link_count += count($query_result);
+        $replacement = '<a\1\2>';
+        $update = \Drupal::database()->update($table_name);
+        $update->expression(
+          $column,
+          "REGEXP_REPLACE($column, :pattern, :replacement)",
+          [':pattern' => $regex, ':replacement' => $replacement]
+        );
+        $update->execute();
+      }
     }
   }
   // Set messages if there were changes.
   if ($count > 0) {
     \Drupal::messenger()->addMessage(t('Converted @number old CKE4 anchor data-attributes to new HDS button data-attributes.', ['@number' => $count]));
+  }
+  if ($data_link_count > 0) {
+    \Drupal::messenger()->addMessage(t('Removed data-link-text attribute from @number anchor elements.', ['@number' => $data_link_count]));
   }
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -159,7 +159,7 @@ function helfi_ckeditor_update_9006(): void {
 }
 
 /**
- * UHF-9497 Iterate through long text fields and replace anchor data attributes to new format.
+ * UHF-9497 Replace data attributes to HDS data attributes in long text fields.
  */
 function helfi_ckeditor_update_9007(): void {
   $entity_type_manager = Drupal::entityTypeManager();
@@ -197,7 +197,7 @@ function helfi_ckeditor_update_9007(): void {
 
       // Get current field's table name and column.
       $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
-      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+      $column = $table_mapping->getFieldColumnName($field_storage_definition, 'value');
 
       // Go through our data array, treat array key as data to search for
       // and array value as replacement. Use sql replace to replace the data.

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -179,7 +179,6 @@ function helfi_ckeditor_update_9007(): void {
   ];
 
   $count = 0;
-  $data_link_count = 0;
 
   // Load all field configurations.
   /** @var \Drupal\field\Entity\FieldConfig $field_config */
@@ -213,33 +212,10 @@ function helfi_ckeditor_update_9007(): void {
         );
         $count += $update->execute();
       }
-
-      // Search for <a> elements containing data-link-text.
-      $regex = '<a(.*?)data-link-text="[^"]*"(.*?)>';
-      $query = \Drupal::database()->select($table_name, 'v')
-        ->distinct()
-        ->fields('v', ['entity_id', $column])
-        ->condition($column, $regex, 'REGEXP');
-      $query_result = $query->execute()->fetchAll();
-
-      if (!empty($query_result)) {
-        $data_link_count += count($query_result);
-        $replacement = '<a$1$2>';
-        $update = \Drupal::database()->update($table_name);
-        $update->expression(
-          $column,
-          "REGEXP_REPLACE($column, :pattern, :replacement)",
-          [':pattern' => $regex, ':replacement' => $replacement]
-        );
-        $update->execute();
-      }
     }
   }
   // Set messages if there were changes.
   if ($count > 0) {
     \Drupal::messenger()->addMessage(t('Converted @number old CKE4 anchor data-attributes to new HDS button data-attributes.', ['@number' => $count]));
-  }
-  if ($data_link_count > 0) {
-    \Drupal::messenger()->addMessage(t('Removed data-link-text attribute from @number anchor elements.', ['@number' => $data_link_count]));
   }
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -29,6 +29,17 @@ function helfi_ckeditor_grant_permissions() : void {
 }
 
 /**
+ * Installs CKEditor5 plugins and extensions.
+ */
+function helfi_ckeditor_install_ckeditor5_supportive_plugins() : void {
+  $module_installer = \Drupal::service('module_installer');
+
+  if (!\Drupal::moduleHandler()->moduleExists('ckeditor5_paste_filter')) {
+    $module_installer->install(['ckeditor5_paste_filter']);
+  }
+}
+
+/**
  * Implements hook_install().
  */
 function helfi_ckeditor_install($is_syncing) : void {
@@ -39,6 +50,7 @@ function helfi_ckeditor_install($is_syncing) : void {
   }
 
   helfi_ckeditor_grant_permissions();
+  helfi_ckeditor_install_ckeditor5_supportive_plugins();
 }
 
 /**
@@ -154,11 +166,8 @@ function helfi_ckeditor_update_9005(): void {
  * UHF-9497 Install CKEditor5 paste filter and import revised filter formats.
  */
 function helfi_ckeditor_update_9006(): void {
-  $module_installer = \Drupal::service('module_installer');
+  helfi_ckeditor_install_ckeditor5_supportive_plugins();
 
-  if (!\Drupal::moduleHandler()->moduleExists('ckeditor5_paste_filter')) {
-    $module_installer->install(['ckeditor5_paste_filter']);
-  }
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_ckeditor');
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -211,6 +211,8 @@ function helfi_ckeditor_update_9007(): void {
             ':new_value' => $new,
           ]
         );
+        // Note! The execution will return every row, even the ones which data
+        // was not affected.
         $count += $update->execute();
       }
 
@@ -237,7 +239,7 @@ function helfi_ckeditor_update_9007(): void {
   }
   // Set messages if there were changes.
   if ($count > 0) {
-    \Drupal::messenger()->addMessage(t('Converted @number old CKE4 anchor data-attributes to new HDS button data-attributes.', ['@number' => $count]));
+    \Drupal::messenger()->addMessage(t('Converted old link button data-attributes to new HDS button data-attributes.'));
   }
   if ($data_link_count > 0) {
     \Drupal::messenger()->addMessage(t('Removed data-link-text attribute from @number anchor elements.', ['@number' => $data_link_count]));

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -251,7 +251,7 @@ function helfi_ckeditor_update_9007(): void {
 
         if ($result->$column != $data_without_link_text) {
           $data_link_count++;
-          // Update the database
+          // Update the database.
           $update = \Drupal::database()->update($table_name)
             ->fields([$column => $data_without_link_text])
             ->condition('entity_id', $result->entity_id)

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -149,3 +149,97 @@ function helfi_ckeditor_update_9005(): void {
     }
   }
 }
+
+/**
+ * UHF-9497 Import revised filter and editor formats.
+ */
+function helfi_ckeditor_update_9006(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_ckeditor');
+}
+
+/**
+ * UHF-9497 Iterate through long text fields and replace anchor data attributes to new format.
+ */
+function helfi_ckeditor_update_9007(): void {
+  $entity_type_manager = Drupal::entityTypeManager();
+  $field_storage = $entity_type_manager->getStorage('field_config');
+
+  // Search and replace following data.
+  $data_to_be_converted = [
+    'data-selected-icon=' => 'data-hds-icon-start=',
+    'data-design="hds-button hds-button--primary"' => 'data-hds-component="button"',
+    'data-design="hds-button hds-button--secondary"' => 'data-hds-component="button" data-hds-variant="secondary"',
+    'data-design="hds-button hds-button--supplementary"' => 'data-hds-component="button" data-hds-variant="supplementary"',
+    'data-design="link"' => '',
+    'data-design=' => 'data-hds-component="button" data-hds-variant=',
+    'class="hds-button hds-button--primary" ' => '',
+    'class="hds-button hds-button--secondary" ' => '',
+    'class="hds-button hds-button--supplementary" ' => '',
+  ];
+
+  $count = 0;
+  $data_link_count = 0;
+
+  // Load all field configurations.
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  foreach ($field_storage->loadMultiple() as $field_config) {
+
+    // Go through each field and check for long text fields (html formatted).
+    if ($field_config->getType() === 'text_long') {
+      $field_storage_definition = $field_config->getFieldStorageDefinition();
+      $entity_type = $field_config->getTargetEntityTypeId();
+
+      /** @var \Drupal\Core\Entity\Sql\SqlEntityStorageInterface $storage */
+      $storage = $entity_type_manager->getStorage($entity_type);
+      /** @var \Drupal\Core\Entity\Sql\DefaultTableMapping $table_mapping */
+      $table_mapping = $storage->getTableMapping();
+
+      // Get current field's table name and column.
+      $table_name = $table_mapping->getDedicatedDataTableName($field_storage_definition);
+      $column = $table_mapping->getFieldColumnName($field_storage_definition,'value');
+
+      // Go through our data array, treat array key as data to search for
+      // and array value as replacement. Use sql replace to replace the data.
+      foreach ($data_to_be_converted as $old => $new) {
+        $update = Drupal::database()->update($table_name);
+        $update->expression(
+          $column,
+          "REPLACE($column, :old_value, :new_value)",
+          [
+            ':old_value' => $old,
+            ':new_value' => $new,
+          ]
+        );
+        $count += $update->execute();
+      }
+
+      // Search for <a> elements containing data-link-text.
+      $regex = '<a(.*?)data-link-text="[^"]*"(.*?)>';
+      $query = \Drupal::database()->select($table_name, 'v')
+        ->distinct()
+        ->fields('v', ['entity_id', $column])
+        ->condition($column, $regex, 'REGEXP');
+      $query_result = $query->execute()->fetchAll();
+
+      if (!empty($query_result)) {
+        $data_link_count += count($query_result);
+        $replacement = '<a$1$2>';
+        $update = \Drupal::database()->update($table_name);
+        $update->expression(
+          $column,
+          "REGEXP_REPLACE($column, :pattern, :replacement)",
+          [':pattern' => $regex, ':replacement' => $replacement]
+        );
+        $update->execute();
+      }
+    }
+  }
+  // Set messages if there were changes.
+  if ($count > 0) {
+    \Drupal::messenger()->addMessage(t('Converted @number old CKE4 anchor data-attributes to new HDS button data-attributes.', ['@number' => $count]));
+  }
+  if ($data_link_count > 0) {
+    \Drupal::messenger()->addMessage(t('Removed data-link-text attribute from @number anchor elements.', ['@number' => $data_link_count]));
+  }
+}

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -151,9 +151,14 @@ function helfi_ckeditor_update_9005(): void {
 }
 
 /**
- * UHF-9497 Import revised filter and editor formats.
+ * UHF-9497 Install CKEditor5 paste filter and import revised filter formats.
  */
 function helfi_ckeditor_update_9006(): void {
+  $module_installer = \Drupal::service('module_installer');
+
+  if (!\Drupal::moduleHandler()->moduleExists('ckeditor5_paste_filter')) {
+    $module_installer->install(['ckeditor5_paste_filter']);
+  }
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_ckeditor');
 }


### PR DESCRIPTION
# [UHF-9497](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9497)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed obsolete attributes from full and minimal filter formats.
* Added an update hook to convert old link button data-attributes to follow new HDS data-attributes.
* Removed class attributes from anchor tags in filter formats.
* Removed class, aria-hidden and role attributes from span elements in filter formats.
* Removed span from editor configurations.
* Added CKEditor5 paste filter module and configured settings for it.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9497 drupal/hdbt:dev-UHF-9497 -W`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

This PR / Update will affect all `<a>` tags in long text fields (CKEeditor fields). In hel.fi there are more than 2500 links which still have old data attributes and old classes. This update will go through each of these fields and convert the following data attributes: 
```
data-selected-icon --> data-hds-icon-start
data-design="hds-button hds-button--primary" --> data-hds-component="button"
data-design="hds-button hds-button--secondary" --> data-hds-component="button" data-hds-variant="secondary"
data-design="hds-button hds-button--supplementary" --> data-hds-component="button" data-hds-variant="supplementary"
```
Following will be removed: 
```
data-design="link"
data-link-text="*"
class="hds-button hds-button--primary"
class="hds-button hds-button--secondary"
class="hds-button hds-button--supplementary"
```

As going through all of the changed elements/attributes is pointless, I've gathered few links from SOTE which should've been updated after running the updb. If you're interested of a complete list, contact @Arkkimaagi.

After your environment is up and running, open these links:
- https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/vammaispalvelut/tyo-ja-paivatoiminta/tyohonvalmennus
   - There is a "Katso video työhönvalmennuksesta" supplementary button
- https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/seniorikeskukset-etusivu/kivela/osastot   
   - There are several "Siirry yhteystietoihin sivulle numerot.hel.fi" buttons
- https://www.hel.fi/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/kotihoito/kuntouttava-arviointi#kuntouttavan-arviointiyksikon-tiimien-yhteystiedot
   - There are few phone number buttons
- https://www.hel.fi/sv/social-och-halsovardstjanster/tjanster-for-barn-och-familjer/stod-for-barn-unga-och-familjer/stod-for-foraldraskapet-och-familjens-vardag/familjesocialarbete#sa-har-kontaktar-du-oss-i-maisa
   - There is a "Gå till Maisa" link with an extra icon  

Here are the same links to local environment:
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/vammaispalvelut/tyo-ja-paivatoiminta/tyohonvalmennus
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/seniorikeskukset-etusivu/kivela/osastot
- https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/senioripalvelut/kotihoito/kuntouttava-arviointi#kuntouttavan-arviointiyksikon-tiimien-yhteystiedot
- https://helfi-sote.docker.so/sv/social-och-halsovardstjanster/tjanster-for-barn-och-familjer/stod-for-barn-unga-och-familjer/stod-for-foraldraskapet-och-familjens-vardag/familjesocialarbete#sa-har-kontaktar-du-oss-i-maisa

* [x] Go through the links mentioned above and check that the markup has been much more clear now. See source code example below. The upper half is a screenshot of local environment after update hook run and bottom half is from production.
![image](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/assets/1712902/35dfe5d3-0da6-4b68-996e-1e063d50d8cd)
* [x] Create a banner and hearings paragraphs and check that the link buttons still look the same as before. [Their templates have been updated to use data-variables.](https://github.com/City-of-Helsinki/drupal-hdbt/pull/909/files#diff-c9e96b9e3447a59c3b447af7268809af13c11e376951976b9a569f24a40a60cbR22)
* [x] Go to [UHF-9497](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9497) and copy the word document from the issue attachments
   * [x] Paste the word document contents to Text paragraph and check that it's not that messy as it used to be - you can verify it by pasting it to a drupal instance which has a clean install
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/909
* https://github.com/City-of-Helsinki/drupal-helfi-strategia/pull/588
* https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/362
* https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/299
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/577
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/413
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/769
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/803
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/533
* https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen/pull/350


[UHF-9497]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ