### PR TITLE
UHF-5527: Add missing configuration for helfi_platform_config

### DIFF
--- a/modules/helfi_tpr_config/config/install/views.view.service_list.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.service_list.yml
@@ -797,7 +797,7 @@ display:
             operator: combine_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: combine
+            identifier: service-list-search
             required: false
             remember: false
             multiple: false


### PR DESCRIPTION
# [UHF-5527](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5527)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add indentifier change to the plarform config module configuration as well to avoid overriding of the configuration in the future. This change was already done to the only instance that uses this feature, the Hallinto-instance.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-5527`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] There is nothing to test here really.
* [ ] Check that code follows our standards


[UHF-5527]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ