### PR TITLE
UHF-8988 user inquiry popup

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -29,7 +29,9 @@
       return new GenesysAdapter;
     }
     if (chatSelection.indexOf('user_inquiry') != -1) {
-      return new UserInquiryAdapter;
+      if (UserInquiryAdapter.scheduler()) {
+        return new UserInquiryAdapter;
+      }
     }
     console.warn(`No adapter found for ${chatSelection}!`);
   }
@@ -100,6 +102,29 @@
     open(callback) {}
     onClosed(callback) {}
     onLoaded(callback) {}
+
+    // Return true or false based on hardcoded dates or value in localstorage.
+    static scheduler() {
+      const now = new Date();
+
+      const dates = [
+        {start: '2024-02-26', end: '2024-03-01'},
+        {start: '2024-03-04', end: '2024-03-08'},
+      ]
+
+      // Run the code below in browser to activate the popup for a minute
+      // localStorage.setItem('user_inquiry_debug', `{"start": "${new Date((Date.now()-60000)).toString()}", "end": "${new Date((Date.now()+60000))}"}`);
+      let debug = localStorage.getItem('user_inquiry_debug');
+      if (debug) {
+        dates.push(JSON.parse(debug));
+      }
+
+      const date= dates.find((object)=>{
+        return now >= new Date(object.start) && now < new Date(object.end);
+      });
+
+      return date ? true : false;
+    }
   }
 
   class Leijuke {

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -93,7 +93,7 @@
    */
   class UserInquiryAdapter {
     constructor() {
-      this.requiredCookies = ['chat'];
+      this.requiredCookies = ['statistics'];
       this.bot = false;
       this.persist = false;
       this.hasButton = false;

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -114,7 +114,7 @@
 
       // Run the code below in browser to activate the popup for a minute
       // localStorage.setItem('user_inquiry_debug', `{"start": "${new Date((Date.now()-60000)).toString()}", "end": "${new Date((Date.now()+60000))}"}`);
-      let debug = localStorage.getItem('user_inquiry_debug');
+      const debug = localStorage.getItem('user_inquiry_debug');
       if (debug) {
         dates.push(JSON.parse(debug));
       }

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -119,11 +119,11 @@
         dates.push(JSON.parse(debug));
       }
 
-      const date= dates.find((object)=>{
+      const date = dates.find((object)=>{
         return now >= new Date(object.start) && now < new Date(object.end);
       });
 
-      return date ? true : false;
+      return !!date;
     }
   }
 

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -29,7 +29,7 @@
       return new GenesysAdapter;
     }
     if (chatSelection.indexOf('user_inquiry') != -1) {
-      if (UserInquiryAdapter.scheduler()) {
+      if (UserInquiryAdapter.idScheduled()) {
         return new UserInquiryAdapter;
       }
     }
@@ -104,7 +104,7 @@
     onLoaded(callback) {}
 
     // Return true or false based on hardcoded dates or value in localstorage.
-    static scheduler() {
+    static idScheduled() {
       const now = new Date();
 
       const dates = [

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -107,7 +107,7 @@ function helfi_platform_config_update_9305() : void {
       'language' => [
         'id' => 'language',
         'context_mapping' => [
-          'language' => '@language.current_language_context:language_interface'
+          'language' => '@language.current_language_context:language_interface',
         ],
         'langcodes' => ['fi' => 'fi', 'en' => 'en', 'sv' => 'sv'],
       ],

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -66,3 +66,55 @@ function helfi_platform_config_update_9304() : void {
   $config->set('links', $links)
     ->save();
 }
+
+function helfi_platform_config_update_9305() : void {
+  if (!\Drupal::moduleHandler()->moduleExists('helfi_api_base')) {
+    return;
+  }
+
+  $environment_resolver = \Drupal::service('helfi_api_base.environment_resolver');
+  try {
+    $environment_resolver->getActiveProject();
+  }
+  catch(Exception $exception) {
+    // No active project found, stop execution.
+    return;
+  }
+
+  $block_installer = Drupal::service('helfi_platform_config.helper.block_installer');
+  $theme_handler = \Drupal::service('theme_handler');
+  if (!str_starts_with($theme_handler->getDefault(), 'hdbt_subtheme')) {
+    return;
+  }
+
+  $block = [
+    'id' => 'hdbt_subtheme_user_inquiry',
+    'plugin' => 'chat_leijuke',
+    'provider' => 'helfi_platform_config',
+    'settings' => [
+      'label' => 'User inquiry',
+      'label_display' => FALSE,
+      'chat_title' => '',
+      'chat_selection' => 'user_inquiry',
+    ],
+    'visibility' => [
+      'language' => [
+        'id' => 'language',
+        'langcodes' => ['fi' => 'fi', 'en' => 'en', 'sv' => 'sv']
+      ],
+      'user_role' => [
+        'id' => 'user_role',
+        'roles' => ['anonymous' => 'anonymous']
+      ],
+    ],
+  ];
+
+  $variations = [
+    [
+      'theme' => 'hdbt_subtheme',
+      'region' => 'attachments'
+    ]
+  ];
+
+  $block_installer->install($block, $variations);
+}

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -106,6 +106,9 @@ function helfi_platform_config_update_9305() : void {
     'visibility' => [
       'language' => [
         'id' => 'language',
+        'context_mapping' => [
+          'language' => '@language.current_language_context:language_interface'
+        ],
         'langcodes' => ['fi' => 'fi', 'en' => 'en', 'sv' => 'sv'],
       ],
       'user_role' => [

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -111,6 +111,7 @@ function helfi_platform_config_update_9305() : void {
       'user_role' => [
         'id' => 'user_role',
         'roles' => ['anonymous' => 'anonymous'],
+        'context_mapping' => ['user' => '@user.current_user_context:current_user'],
       ],
     ],
   ];

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -67,7 +67,11 @@ function helfi_platform_config_update_9304() : void {
     ->save();
 }
 
+/**
+ * Enable leijuke-block which contains the user inquiry -popup
+ */
 function helfi_platform_config_update_9305() : void {
+
   if (!\Drupal::moduleHandler()->moduleExists('helfi_api_base')) {
     return;
   }
@@ -76,16 +80,18 @@ function helfi_platform_config_update_9305() : void {
   try {
     $environment_resolver->getActiveProject();
   }
-  catch(Exception $exception) {
+  catch (Exception $exception) {
     // No active project found, stop execution.
     return;
   }
 
   $block_installer = Drupal::service('helfi_platform_config.helper.block_installer');
   $theme_handler = \Drupal::service('theme_handler');
-  if (!str_starts_with($theme_handler->getDefault(), 'hdbt_subtheme')) {
+  if (!str_starts_with($theme_handler->getDefault(), 'hdbt')) {
     return;
   }
+
+  $theme = $theme_handler->getDefault() === 'hdbt_subtheme' ? 'hdbt_subtheme' : 'hdbt';
 
   $block = [
     'id' => 'hdbt_subtheme_user_inquiry',
@@ -111,7 +117,7 @@ function helfi_platform_config_update_9305() : void {
 
   $variations = [
     [
-      'theme' => 'hdbt_subtheme',
+      'theme' => $theme,
       'region' => 'attachments'
     ]
   ];

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -68,7 +68,7 @@ function helfi_platform_config_update_9304() : void {
 }
 
 /**
- * Enable leijuke-block which contains the user inquiry -popup
+ * Enable leijuke-block which contains the user inquiry -popup.
  */
 function helfi_platform_config_update_9305() : void {
 
@@ -106,11 +106,11 @@ function helfi_platform_config_update_9305() : void {
     'visibility' => [
       'language' => [
         'id' => 'language',
-        'langcodes' => ['fi' => 'fi', 'en' => 'en', 'sv' => 'sv']
+        'langcodes' => ['fi' => 'fi', 'en' => 'en', 'sv' => 'sv'],
       ],
       'user_role' => [
         'id' => 'user_role',
-        'roles' => ['anonymous' => 'anonymous']
+        'roles' => ['anonymous' => 'anonymous'],
       ],
     ],
   ];
@@ -118,8 +118,8 @@ function helfi_platform_config_update_9305() : void {
   $variations = [
     [
       'theme' => $theme,
-      'region' => 'attachments'
-    ]
+      'region' => 'attachments',
+    ],
   ];
 
   $block_installer->install($block, $variations);

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -64,7 +64,7 @@ genesys_auth_redirect:
     - core/drupalSettings
 
 chat_leijuke:
-  version: 1.0.x
+  version: 1.0.1
   header: true
   js:
     assets/js/chat_leijuke.js: {}


### PR DESCRIPTION
# [UHF-8988](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8988)
Adds and configures chat-leijuke with käyttäjäkysely-popup

## What was done
- Adds and enables the block
- Added scheduler to the javascript
  - Loads the javascript only if the pageload is within given date 


## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8988`
* Run `make drush-updb drush-cr`

## How to test
- Log in as admin and go to /admin/structure/block
  - user inquiry block should be in attachments
  - It should have correct configurations: käyttäjätutkimus-provider, on fi,en,sv languages, only for unauthenticated users
- Log out, since this only works for unauthenticated user

- (the debug feature does not work incognito)
- Go to any content page and accept all cookies
- After page reload the popup-script should not be loaded (search for digitalfeedback)
- The next steps must be done quite quickly:
- There is a commented code snippet in the leijuke-js file line 116. Run this code snippet in browser inspector to activate the popup locally for 1 minute: 

localStorage.setItem('user_inquiry_debug', `{"start": "${new Date((Date.now()-60000)).toString()}", "end": "${new Date((Date.now()+60000))}"}`);

-  Refresh the page
- Popup should appear (if you have never closed it before)
  - if popup doesn't appear, you most likely have already closed it once. you should at least see the loaded script (digitalfeedback) 
- It he popup appears, do not close it. Wait for a minute (or five) and refresh the page.
  - the popup-javascript wont be loaded (and the script won't be loaded at all)


* [x] Check that this feature works
* [ ] Check that code follows our standards


[UHF-8988]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ