### PR TITLE
UHF-8988 fix

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -330,7 +330,11 @@
       let leijukeInstance = document.createElement('button');
       leijukeInstance.id = this.static.selector;
       leijukeInstance.classList.add('chat-leijuke')
-      leijukeInstance.classList.add(this.static.selector);
+
+      if (this.static.selector === 'chat-leijuke-user_inquiry') {
+        leijukeInstance.classList.add('is-hidden');
+      }
+
       leijukeWrapper.append(leijukeInstance);
 
       this.prepButton(leijukeInstance);

--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -330,6 +330,7 @@
       let leijukeInstance = document.createElement('button');
       leijukeInstance.id = this.static.selector;
       leijukeInstance.classList.add('chat-leijuke')
+      leijukeInstance.classList.add(this.static.selector);
       leijukeWrapper.append(leijukeInstance);
 
       this.prepButton(leijukeInstance);

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -97,6 +97,7 @@ function helfi_platform_config_update_9305() : void {
     'id' => 'hdbt_subtheme_user_inquiry',
     'plugin' => 'chat_leijuke',
     'provider' => 'helfi_platform_config',
+    'weight' => -19,
     'settings' => [
       'label' => 'User inquiry',
       'label_display' => FALSE,


### PR DESCRIPTION
# [UHF-8988 ](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8988)
Problem when you have multiple leijuke blocks on a page. Also, hide the button for leijuke.

## What was done
Force the block weight low enough to make sure it's the first attachment block.
Hide the button for user inquiry leijuke

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8988_fix`
* Run `make drush-updb drush-cr`

## How to test
[check this out ](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/693)

