### PR TITLE
UHF-9497: Missing figure and figcaption

### DIFF
--- a/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/editor.editor.full_html.yml
@@ -129,7 +129,9 @@ settings:
           search: '<a name="[^"]*">(.*?)<\/a>'
           replace: $1
     ckeditor5_sourceEditing:
-      allowed_tags: {  }
+      allowed_tags:
+        - '<figure tabindex>'
+        - '<figcaption>'
     helfi_ckeditor_helfi_link:
       helfi_link_attributes:
         - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'

--- a/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
+++ b/modules/helfi_ckeditor/config/install/filter.format.full_html.yml
@@ -39,7 +39,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <blockquote data-helfi-quote> <span dir> <ul> <ol start> <li> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <table> <tr> <td> <th> <thead> <tbody> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <blockquote data-helfi-quote> <span dir> <ul> <ol start> <li> <strong> <em> <s> <sub> <sup> <a href data-entity-type data-entity-uuid data-entity-substitution data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank"> <table> <tr> <td> <th> <thead> <tbody> <footer data-helfi-quote-author> <cite> <figure tabindex> <figcaption>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/helfi_ckeditor/helfi_ckeditor.install
+++ b/modules/helfi_ckeditor/helfi_ckeditor.install
@@ -268,3 +268,11 @@ function helfi_ckeditor_update_9007(): void {
     \Drupal::messenger()->addMessage(t('Removed data-link-text attribute from @number anchor elements.', ['@number' => $data_link_count]));
   }
 }
+
+/**
+ * UHF-9497 Added missing figcaption and figure elements.
+ */
+function helfi_ckeditor_update_9008(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_ckeditor');
+}


### PR DESCRIPTION
# [UHF-9497](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9497)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added figure and figcaption tags as these tags was accidentally removed during tags cleanup.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9497_figure`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the figure and figcaption has been added to HTML filter formats
* [ ] Check that code follows our standards


[UHF-9497]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ