### PR TITLE
UHF-9440: Add new field called information for the service channels

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
@@ -103,6 +103,13 @@ content:
     third_party_settings: {  }
     weight: 22
     region: content
+  information:
+    type: text_default
+    label: hidden
+    settings: { }
+    third_party_settings: { }
+    weight: 4
+    region: content
   langcode:
     type: language
     label: hidden

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -390,9 +390,9 @@ function helfi_tpr_config_update_9054(): void {
 }
 
 /**
- * UHF-9327: Update unit search paragraph pager configuration.
+ * UHF-9440: Add new field information for service channels.
  */
-function helfi_tpr_config_update_9056(): void {
+function helfi_tpr_config_update_9057(): void {
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');


### PR DESCRIPTION
# [UHF-9440](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9440)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add configuration related to the new information field on service channel.

## How to install
* Check installation instructions from the [TPR PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check testing instructions from the [TPR PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168)
* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/703
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/915
* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/168

[UHF-9440]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ