### PR TITLE
UHF-9682: Add cookie check for siteimprove to be able to see inside accordions

### DIFF
--- a/modules/helfi_eu_cookie_compliance/config/rewrite/eu_cookie_compliance.settings.yml
+++ b/modules/helfi_eu_cookie_compliance/config/rewrite/eu_cookie_compliance.settings.yml
@@ -56,7 +56,7 @@ better_support_for_screen_readers: false
 method: categories
 disabled_javascripts: ''
 automatic_cookies_removal: true
-allowed_cookies: "essential:AWSELBCORS\r\nessential:cookiehub\r\nessential:mtm_cookie_consent\r\nessential:JSESSIONID\r\nessential:COOKIE_SUPPORT\r\nessential:GUEST_LANGUAGE_ID\r\npreference:httpskartta.hel.fi.SWCulture\r\npreference:icareus-device\r\npreference:VISITOR_INFO1_LIVE\r\npreference:CONSENT\r\nstatistics:nmstat\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.141.89f6\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.*\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.*\r\nstatistics:rnsbid\r\nstatistics:rnsbid_ts\r\nstatistics:rns_reaction_*\r\nstatistics:YSC\r\nchat:_genesys.widgets.*\r\nchat:leijuke.*"
+allowed_cookies: "helfi_accordions_open\r\nessential:AWSELBCORS\r\nessential:cookiehub\r\nessential:mtm_cookie_consent\r\nessential:JSESSIONID\r\nessential:COOKIE_SUPPORT\r\nessential:GUEST_LANGUAGE_ID\r\npreference:httpskartta.hel.fi.SWCulture\r\npreference:icareus-device\r\npreference:VISITOR_INFO1_LIVE\r\npreference:CONSENT\r\nstatistics:nmstat\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.141.89f6\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.*\r\nstatistics:_pk_id.*\r\nstatistics:_pk_ses.*\r\nstatistics:rnsbid\r\nstatistics:rnsbid_ts\r\nstatistics:rns_reaction_*\r\nstatistics:YSC\r\nchat:_genesys.widgets.*\r\nchat:leijuke.*"
 consent_storage_method: do_not_store
 withdraw_message:
   value: '<h2>Hel.fi uses cookies</h2><p>You have given your consent for us to set cookies.</p>'

--- a/modules/helfi_eu_cookie_compliance/helfi_eu_cookie_compliance.install
+++ b/modules/helfi_eu_cookie_compliance/helfi_eu_cookie_compliance.install
@@ -70,9 +70,9 @@ function helfi_eu_cookie_compliance_update_9003(): void {
 }
 
 /**
- * Updates statistics cookies for user popup.
+ * UHF-9675: Allow helfi_accordions_open cookie.
  */
-function helfi_eu_cookie_compliance_update_9004(): void {
+function helfi_eu_cookie_compliance_update_9005(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_eu_cookie_compliance');
 }


### PR DESCRIPTION
# [UHF-9682](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9682)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Allow helfi_accordions_open cookie so that it can be used by Siteimprove.

## How to install
* Check installation instructions from the [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/919)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the [HDBT PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/919)
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/919
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/707


[UHF-9675]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-9682]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ