### PR TITLE
UHF-8333: Fix LinkedIn share buttons

### DIFF
--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -297,4 +297,17 @@ function helfi_base_content_update_9007() : void {
   Drupal::configFactory()->getEditable('social_media.settings')
     ->set('social_media.linkedin.api_url', 'https://www.linkedin.com/sharing/share-offsite/?url=[current-page:url]')
     ->save();
+
+  /** @var \Drupal\language\ConfigurableLanguageManagerInterface $language_manager */
+  $language_manager = \Drupal::languageManager();
+
+  foreach (['fi', 'sv'] as $langcode) {
+    $config_translation = $language_manager->getLanguageConfigOverride($langcode, 'social_media.settings');
+
+    if (!$config_translation->isNew()) {
+      $config_translation
+        ->set('social_media.linkedin.api_url', 'https://www.linkedin.com/sharing/share-offsite/?url=[current-page:url]')
+        ->save();
+    }
+  }
 }

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -289,3 +289,12 @@ function helfi_base_content_update_9006() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_base_content');
 }
+
+/**
+ * UHF-8333 Change the LinkedIn API url to correct.
+ */
+function helfi_base_content_update_9007() : void {
+  Drupal::configFactory()->getEditable('social_media.settings')
+    ->set('social_media.linkedin.api_url', 'https://www.linkedin.com/sharing/share-offsite/?url=[current-page:url]')
+    ->save();
+}


### PR DESCRIPTION
# [UHF-8333](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8333)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add update hook that changes the social media modules linkedin api url to the new correct version

## How to install
* Make sure your instance (ETUSIVU or REKRY is good) is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8333`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any news or job listing node and check the url on the LinkedIn share button. It should now link to `https://www.linkedin.com/sharing/share-offsite/?url=[current-page:url]` instead of the old `http://www.linkedin.com/shareArticle?mini=true&url=[current-page:url]...`. Copy the url and instead of your local domain n the url attribute change it to hel.fi and go to the page. LinkedIn shouldn't give error anymore but instead it should open the "Share this webpage" page correctly. 
* [ ] Check that code follows our standards


[UHF-8333]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ