### PR TITLE
Uhf 9767 preview revision form fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,9 @@
                 "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/923b35f699820b544397a35b7696570e101cd02c/patches/eu_cookie_compliance_block_8.x-1.24.patch",
                 "[#UHF-8720] Missing config schema for dependencies (https://www.drupal.org/i/3330024)": "https://www.drupal.org/files/issues/2022-12-28/config_dependencies_schema-3330024-2.patch"
             },
+            "drupal/diff": {
+                "Revision overview form problem, issue 3390329": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/5100132105528b7047b154787afd6459e5e10e18/patches/revision_overview_form.patch"
+            },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2904705#comment-13836790": "https://www.drupal.org/files/issues/2020-09-25/2904705-115.patch",
                 "[#UHF-2059] Enhancements for the Admin UI": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fdccb32397cc6fa19b4d0077b21a2b18aa6be297/patches/helfi_customizations_for_paragraphs_widget_8.x-1.12.patch"

--- a/patches/revision_overview_form.patch
+++ b/patches/revision_overview_form.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Form/RevisionOverviewForm.php b/src/Form/RevisionOverviewForm.php
+index 45c2c66..4ff4f3b 100755
+--- a/src/Form/RevisionOverviewForm.php
++++ b/src/Form/RevisionOverviewForm.php
+@@ -209,7 +209,12 @@ class RevisionOverviewForm extends FormBase {
+       }
+       /** @var \Drupal\Core\Entity\ContentEntityInterface $revision */
+       if ($revision = $node_storage->loadRevision($vid)) {
+-        if ($revision->hasTranslation($langcode) && $revision->getTranslation($langcode)->isRevisionTranslationAffected()) {
++        // Added key-check to always show the current revision on revision list.
++        // Check this issue: https://www.drupal.org/project/drupal/issues/3390329.
++        if (
++          $revision->hasTranslation($langcode) && $revision->getTranslation($langcode)->isRevisionTranslationAffected() ||
++          $key === 0 && $revision->hasTranslation($langcode)
++        ) {
+           $username = array(
+             '#theme' => 'username',
+             '#account' => $revision->getRevisionUser(),


### PR DESCRIPTION
# [UHF-9767](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9767)
Revision overview form is missing current revision. 
Check this issue https://www.drupal.org/project/drupal/issues/3390329

## What was done
Force the first revision to be visible.

## How to reproduce bug before you apply the fix:
Create new content, add a field, save
Create a translation for the content and save
Add a new paragraph to the translation and save as new revision
Go check the original language revision overview form. You should be missing "current revision" row from the table

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9767_preview_revision_form_fix`
* Run `composer install` to apply the patch
* Run `make drush-updb drush-cr`

## How to test
Follow the reproduction steps. Now all translations should have the current revision visible always.
Try rollbacking revisions and saving and rollbacking again and see that it always shows correct revision as first (for all languages)

[UHF-9767]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ