### PR TITLE
UHF-X: Require jquery_ui_draggable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
         "drupal/external_entities": "2.0.0-alpha6",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
+        "drupal/jquery_ui": "^1.6",
+        "drupal/jquery_ui_draggable": "^2.0",
         "drupal/gin_toolbar": "^1.0@rc",
         "drupal/hal": "^2.0",
         "drupal/helfi_api_base": "*",


### PR DESCRIPTION
Focal point 2.0.3 removed jquery_ui_draggable from its dependencies. Our instances have it installed so we need to require it and check later if we have any actual dependency to it.