### PR TITLE
UHH-9755: Small fix for tpr unit form default configuration

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -416,5 +416,4 @@ hidden:
   created: true
   hide_description: true
   ontologyword_ids: true
-  show_www: true
   subgroup: true


### PR DESCRIPTION
# [UHF-9755](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9755)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change show_www to be visible on the tpr_unit form, it used to be both visible and hidden according to the configuration

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHH-9755_remove_show_www_from_hidden`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] This fixes the show_www being in two places at the same time in the configuration and this change will fix the configurations next time automatic update is run. The site works correctly on both occasions but the configuration shouldn't be the way it is to avoid confusion.
* [ ] Check that code follows our standards


[UHF-9755]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ