### PR TITLE
UHF-8908: Convert email field type to email

### DIFF
--- a/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
+++ b/modules/helfi_tpr_config/config/install/core.entity_view_display.tpr_service_channel.tpr_service_channel.default.yml
@@ -69,10 +69,9 @@ content:
     weight: 19
     region: content
   email:
-    type: string
+    type: email_mailto
     label: hidden
-    settings:
-      link_to_entity: false
+    settings: {  }
     third_party_settings: {  }
     weight: 9
     region: content

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -399,9 +399,9 @@ function helfi_tpr_config_update_9057(): void {
 }
 
 /**
- * UHF-9712: Unify metatags with platform config.
+ * UHF-8908: Change service channel email field to use email widget.
  */
-function helfi_tpr_config_update_9058(): void {
+function helfi_tpr_config_update_9059(): void {
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');


### PR DESCRIPTION
# [UHF-8908](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8908)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change service channel email field widget to email

## How to install
* Check testing instructions from the HDBT PR.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the HDBT PR.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-tpr/pull/171
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/155
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/928
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/717


[UHF-8908]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ