### PR TITLE
UHF-9471 Revoke 'assign admin role' permission

### DIFF
--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -76,3 +76,8 @@ services:
       - '@file_url_generator'
     tags:
       - { name: helfi_platform_config.og_image_builder, priority: -100 }
+
+  helfi_platform_config.user_create_route_subscriber:
+    class: Drupal\helfi_platform_config\Routing\UserCreateRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\user\Entity\Role;
 
 /**
  * Grants required permissions.
@@ -69,7 +70,6 @@ function helfi_base_content_grant_permissions() : void {
       // @redirect.
       'administer redirects',
       // @role_delegation.
-      'assign admin role',
       'assign content_producer role',
       'assign editor role',
       'assign read_only role',
@@ -306,4 +306,15 @@ function helfi_base_content_update_9007() : void {
 function helfi_base_content_update_9010() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_base_content');
+}
+
+/**
+ * UHF-9471 revoke the admin user's permission for adding admin role to users.
+ */
+function helfi_base_content_update_9011(): void {
+  if (!$role = Role::load('admin')) {
+    return;
+  }
+  $role->revokePermission('assign admin role');
+  $role->save();
 }

--- a/src/Routing/UserCreateRouteSubscriber.php
+++ b/src/Routing/UserCreateRouteSubscriber.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_platform_config\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * A simple RouteSubscriber to alter user.admin_create route.
+ */
+class UserCreateRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Let only super administrators create users.
+    if ($route = $collection->get('user.admin_create')) {
+      $route->addRequirements([
+        '_role' => 'super_administrator',
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-9471](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9471)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added UserCreateRouteSubscriber to allow only users with super administrator role to create a local user.
* Revoked the admin user's permission for adding admin role to other users.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9471`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Login as a UID1 and find your own user from Users list. Remove all roles other roles from your user account and leave only `admin` role. Make a note of your user UID.
* [x] Login with your own user (f.e.`drush uli --uid=222`) and go to edit any other user. Check that there is no `admin` role in the user's role list.
* [x] Try to go to `/admin/people/create`. This shouldn't be allowed as now only users with `super administrator` role can create users.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-9471]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ