### PR TITLE
UHF-9762: Remove the class assigment from the table of contents elements

### DIFF
--- a/modules/helfi_toc/assets/js/tableOfContents.js
+++ b/modules/helfi_toc/assets/js/tableOfContents.js
@@ -182,7 +182,6 @@
           // Create anchor links.
           content.setAttribute('id', anchorName);
           content.setAttribute('tabindex', '-1');  // Set tabindex to -1 to avoid issues with screen readers.
-          content.setAttribute('class', 'toc-focusable');
         });
 
       if (tableOfContents) {

--- a/modules/helfi_toc/helfi_toc.libraries.yml
+++ b/modules/helfi_toc/helfi_toc.libraries.yml
@@ -1,5 +1,5 @@
 table_of_contents:
-  version: 1.0.1
+  version: 1.0.2
   js:
     assets/js/tableOfContents.js: {}
   dependencies:


### PR DESCRIPTION
# [UHF-9762](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9762)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove adding the class selector to all toc-focusable elements. 

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9762_simplification`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9762_simplification`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any page that has table of contents. For example this page in SOTE: https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/asiakkaan-tiedot-ja-oikeudet/palveluiden-laadunvalvonta
* [ ] Check that the accordions are also working on the page.
* [ ] Click any item on the table of contents and the header that gets focused should have focus outline around it.
* [ ] Check with inspector that the header also has the tabindex=-1 attribute.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/733
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/943


[UHF-9762]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ