### PR TITLE
UHF-9496: Remove dependency to helfi_tpr_config from hdbt_admin_tools

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.module
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.module
@@ -148,24 +148,6 @@ function hdbt_admin_tools_form_node_form_alter(&$form, &$form_state, $form_id): 
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- */
-function hdbt_admin_tools_form_tpr_unit_form_alter(&$form, &$form_state, $form_id): void {
-  $form['field_phone_label']['#states'] = [
-    'visible' => [
-      ':input[name="field_phone_with_contacts[value]"]' => ['checked' => TRUE],
-    ],
-  ];
-
-  // Required state must the widget rather than the form element.
-  $form['field_phone_label']['widget'][0]['value']['#states'] = [
-    'required' => [
-      ':input[name="field_phone_with_contacts[value]"]' => ['checked' => TRUE],
-    ],
-  ];
-}
-
-/**
  * Form submit callback for node forms.
  *
  * Redirect content editor to correct translation after saving the node.

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -445,6 +445,24 @@ function template_preprocess_tpr_service_lower_content(array &$variables) : void
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function helfi_tpr_config_form_tpr_unit_form_alter(&$form, &$form_state, $form_id): void {
+  $form['field_phone_label']['#states'] = [
+    'visible' => [
+      ':input[name="field_phone_with_contacts[value]"]' => ['checked' => TRUE],
+    ],
+  ];
+
+  // Required state must the widget rather than the form element.
+  $form['field_phone_label']['widget'][0]['value']['#states'] = [
+    'required' => [
+      ':input[name="field_phone_with_contacts[value]"]' => ['checked' => TRUE],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function helfi_tpr_config_form_views_exposed_form_alter(&$form, $form_state) : void {
   // Setting high school search form autocompletes to off so that when
   // users returning to the form won't see their previous selections


### PR DESCRIPTION
In kasko tests, `hdbt_admin_tools` and `helfi_tpr` are installed without `helfi_tpr_config`. I believe this causes [an error](https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/actions/runs/8571136924/job/23490709530) in `Drupal\Core\Form\FormHelper::processStates()`.

## Other pull requests: 

- https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/730