### PR TITLE
UHF-9932: CKeditor5 RTL - LTR bug

### DIFF
--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -59,10 +59,9 @@ function helfi_ckeditor_js_settings_alter(array &$settings) {
   foreach($settings['editor']['formats'] as $name => $array) {
     $settings['editor']['formats'][$name]['editorSettings']['language']['ui'] = $language_id;
     if ($ui_language_direction === 'ltr') {
-      $reversed = array_reverse(
+      $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = array_reverse(
         $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items']
       );
-      $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = $reversed;
     }
   }
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -41,7 +41,6 @@ function helfi_ckeditor_js_settings_alter(array &$settings) {
   // UI language is used to decide the content direction on editor.
   // Therefore, we must override the ui language with content language.
   // Also, header must be turned around to ensure correct alignment.
-
   if (!isset($settings['editor']['formats'])) {
     return;
   }
@@ -56,7 +55,7 @@ function helfi_ckeditor_js_settings_alter(array &$settings) {
 
   $language_id = $content_language->getId();
 
-  foreach($settings['editor']['formats'] as $name => $array) {
+  foreach ($settings['editor']['formats'] as $name => $array) {
     $settings['editor']['formats'][$name]['editorSettings']['language']['ui'] = $language_id;
     if ($ui_language_direction === 'ltr') {
       $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = array_reverse(

--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
+use Drupal\Core\Language\LanguageInterface;
 
 /**
  * Modify the list of available CKEditor 5 plugins.
@@ -30,4 +31,23 @@ function helfi_ckeditor_ckeditor5_plugin_info_alter(array &$plugin_definitions):
 
   // Save ckeditor5_table plugin definitions.
   $plugin_definitions['ckeditor5_table'] = new CKEditor5PluginDefinition($original_table_plugin);
+}
+
+/**
+ * Implements hook_js_settings_alter().
+ */
+function helfi_ckeditor_js_settings_alter(array &$settings) {
+  // Ckeditor uses UI language to decide whether to use LTR or RTL direction on editor.
+  // Overwrite the UI langcode with content langcode to instantiate the ckeditor with correct direction.
+  $content_language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+  $language_id = $content_language->getId();
+  if (isset($settings['editor']['formats']['full_html'])) {
+    $settings['editor']['formats']['full_html']['editorSettings']['language']['ui'] = $language_id;
+  }
+  if (isset($settings['editor']['formats']['simple_html'])) {
+    $settings['editor']['formats']['simple_html']['editorSettings']['language']['ui'] = $language_id;
+  }
+  if (isset($settings['editor']['formats']['minimal'])) {
+    $settings['editor']['formats']['minimal']['editorSettings']['language']['ui'] = $language_id;
+  }
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -37,37 +37,32 @@ function helfi_ckeditor_ckeditor5_plugin_info_alter(array &$plugin_definitions):
  * Implements hook_js_settings_alter().
  */
 function helfi_ckeditor_js_settings_alter(array &$settings) {
+  // Workaround for #UHF-9932
   // UI language is used to decide the content direction on editor.
-  // Overwrite the UI langcode to show correct direction.
-  // Turn editor header around to make it render correctly.
+  // Therefore, we must override the ui language with content language.
+  // Also, header must be turned around to ensure correct alignment.
+
+  if (!isset($settings['editor']['formats'])) {
+    return;
+  }
+
   $language_manager = \Drupal::languageManager();
   $content_language = $language_manager
     ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
-  
+
   $ui_language_direction = $language_manager
     ->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)
     ->getDirection();
 
   $language_id = $content_language->getId();
-  if (isset($settings['editor']['formats']['full_html'])) {
-    $settings['editor']['formats']['full_html']['editorSettings']['language']['ui'] = $language_id;
+
+  foreach($settings['editor']['formats'] as $name => $array) {
+    $settings['editor']['formats'][$name]['editorSettings']['language']['ui'] = $language_id;
     if ($ui_language_direction === 'ltr') {
-      $reversed = array_reverse($settings['editor']['formats']['full_html']['editorSettings']['toolbar']['items']);
-      $settings['editor']['formats']['full_html']['editorSettings']['toolbar']['items'] = $reversed;
-    }
-  }
-  if (isset($settings['editor']['formats']['simple_html'])) {
-    $settings['editor']['formats']['simple_html']['editorSettings']['language']['ui'] = $language_id;
-    if ($ui_language_direction === 'ltr') {
-      $reversed = array_reverse($settings['editor']['formats']['simple_html']['editorSettings']['toolbar']['items']);
-      $settings['editor']['formats']['simple_html']['editorSettings']['toolbar']['items'] = $reversed;
-    }
-  }
-  if (isset($settings['editor']['formats']['minimal'])) {
-    $settings['editor']['formats']['minimal']['editorSettings']['language']['ui'] = $language_id;
-    if ($ui_language_direction === 'ltr') {
-      $reversed = array_reverse($settings['editor']['formats']['minimal']['editorSettings']['toolbar']['items']);
-      $settings['editor']['formats']['minimal']['editorSettings']['toolbar']['items'] = $reversed;
+      $reversed = array_reverse(
+        $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items']
+      );
+      $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = $reversed;
     }
   }
 }

--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -37,17 +37,37 @@ function helfi_ckeditor_ckeditor5_plugin_info_alter(array &$plugin_definitions):
  * Implements hook_js_settings_alter().
  */
 function helfi_ckeditor_js_settings_alter(array &$settings) {
-  // Ckeditor uses UI language to decide whether to use LTR or RTL direction on editor.
-  // Overwrite the UI langcode with content langcode to instantiate the ckeditor with correct direction.
-  $content_language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+  // UI language is used to decide the content direction on editor.
+  // Overwrite the UI langcode to show correct direction.
+  // Turn editor header around to make it render correctly.
+  $language_manager = \Drupal::languageManager();
+  $content_language = $language_manager
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+  
+  $ui_language_direction = $language_manager
+    ->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)
+    ->getDirection();
+
   $language_id = $content_language->getId();
   if (isset($settings['editor']['formats']['full_html'])) {
     $settings['editor']['formats']['full_html']['editorSettings']['language']['ui'] = $language_id;
+    if ($ui_language_direction === 'ltr') {
+      $reversed = array_reverse($settings['editor']['formats']['full_html']['editorSettings']['toolbar']['items']);
+      $settings['editor']['formats']['full_html']['editorSettings']['toolbar']['items'] = $reversed;
+    }
   }
   if (isset($settings['editor']['formats']['simple_html'])) {
     $settings['editor']['formats']['simple_html']['editorSettings']['language']['ui'] = $language_id;
+    if ($ui_language_direction === 'ltr') {
+      $reversed = array_reverse($settings['editor']['formats']['simple_html']['editorSettings']['toolbar']['items']);
+      $settings['editor']['formats']['simple_html']['editorSettings']['toolbar']['items'] = $reversed;
+    }
   }
   if (isset($settings['editor']['formats']['minimal'])) {
     $settings['editor']['formats']['minimal']['editorSettings']['language']['ui'] = $language_id;
+    if ($ui_language_direction === 'ltr') {
+      $reversed = array_reverse($settings['editor']['formats']['minimal']['editorSettings']['toolbar']['items']);
+      $settings['editor']['formats']['minimal']['editorSettings']['toolbar']['items'] = $reversed;
+    }
   }
 }


### PR DESCRIPTION
# [UHF-9932](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9932)
Prevent RTL languages showing up as LTR in ckeditor by overriding the language given to ckeditor.

How to reproduce:
- Setup etusivu-instance
- Make sure your user's ui language is either und or any LTR-language
- Go edit any existing arabic content

Ckeditor should show the arabic as LTR

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9932`
* Run `make drush-updb drush-cr`

## How to test
- Go and edit the arabic content
- See that the content shows up like RTL-language
- See that the editor works as it is expected to work with RLT-language
- See that the page looks OK after saving



[UHF-9932]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ