### PR TITLE
UHF-9932: Additional checks to prevent notices/errors

### DIFF
--- a/modules/helfi_ckeditor/helfi_ckeditor.module
+++ b/modules/helfi_ckeditor/helfi_ckeditor.module
@@ -57,7 +57,12 @@ function helfi_ckeditor_js_settings_alter(array &$settings) {
 
   foreach ($settings['editor']['formats'] as $name => $array) {
     $settings['editor']['formats'][$name]['editorSettings']['language']['ui'] = $language_id;
-    if ($ui_language_direction === 'ltr') {
+    if (
+      $ui_language_direction === 'ltr' &&
+      $content_language->getDirection() == 'rtl' &&
+      isset($settings['editor']['formats'][$name]['editorSettings']['toolbar']['items']) &&
+      is_array($settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'])
+    ) {
       $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = array_reverse(
         $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items']
       );


### PR DESCRIPTION
# [UHF-9932](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9932)
Prevent RTL languages showing up as LTR in ckeditor by overriding the language given to ckeditor.

How to reproduce:
- Setup etusivu-instance
- Make sure your user's ui language is either und or any LTR-language
- Go edit any existing arabic content

Ckeditor should show the arabic as LTR

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9932`
* Run `make drush-updb drush-cr`

## How to test
- Go and edit the arabic content
- See that the content shows up like RTL-language
- See that the editor works as it is expected to work with RLT-language
- See that the page looks OK after saving
