### PR TITLE
UHF-X: Fix TypeError: getPictureUri(): Return value must be of type ?string

### DIFF
--- a/modules/helfi_tpr_config/src/Entity/Unit.php
+++ b/modules/helfi_tpr_config/src/Entity/Unit.php
@@ -28,7 +28,11 @@ class Unit extends BaseUnit {
       // to apply image styles later. This method is in a bundle class
       // so that helfi_tpr does not have to add dependency to
       // imagecache_external.
-      return $url ? imagecache_external_generate_path($url) : NULL;
+      if ($url) {
+        return imagecache_external_generate_path($url) ?: NULL;
+      }
+
+      return NULL;
     }
 
     if ($file = $picture_url->get('field_media_image')->entity) {


### PR DESCRIPTION
`imagecache_external_generate_path()` returns `FALSE` on errors. `getPictureUri()` should return `NULL` on error.