### PR TITLE
UHF-9704: Fix article_modified_time metatag

### DIFF
--- a/modules/helfi_base_content/config/rewrite/metatag.metatag_defaults.node.yml
+++ b/modules/helfi_base_content/config/rewrite/metatag.metatag_defaults.node.yml
@@ -7,7 +7,7 @@ tags:
   title: '[node:title] | [site:page-title-suffix]'
   description: '[node:lead-in]'
   canonical_url: '[node:url]'
-  article_modified_time: '[node:created:html_datetime]'
+  article_modified_time: '[node:changed:html_datetime]'
   article_published_time: '[node:created:html_datetime]'
   content_language: '[node:langcode]'
   og_title: '[node:title]'

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -318,3 +318,11 @@ function helfi_base_content_update_9011(): void {
   $role->revokePermission('assign admin role');
   $role->save();
 }
+
+/**
+ * UHF-9704 Fix article_modified_time metatag.
+ */
+function helfi_base_content_update_9012(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_base_content');
+}

--- a/modules/helfi_tpr_config/config/install/metatag.metatag_defaults.tpr_service.yml
+++ b/modules/helfi_tpr_config/config/install/metatag.metatag_defaults.tpr_service.yml
@@ -9,7 +9,7 @@ tags:
   content_language: '[tpr_service:langcode]'
   description: '[tpr_service:description:summary]'
   title: '[tpr_service:label] | [site:page-title-suffix]'
-  article_modified_time: '[tpr_service:created:html_datetime]'
+  article_modified_time: '[tpr_service:changed:html_datetime]'
   article_published_time: '[tpr_service:created:html_datetime]'
   og_title: '[tpr_service:label]'
   og_description: '[tpr_service:description:summary]'

--- a/modules/helfi_tpr_config/config/install/metatag.metatag_defaults.tpr_unit.yml
+++ b/modules/helfi_tpr_config/config/install/metatag.metatag_defaults.tpr_unit.yml
@@ -9,7 +9,7 @@ tags:
   content_language: '[tpr_unit:langcode]'
   description: '[tpr_unit:description:summary]'
   title: '[tpr_unit:label] | [site:page-title-suffix]'
-  article_modified_time: '[tpr_unit:created:html_datetime]'
+  article_modified_time: '[tpr_unit:changed:html_datetime]'
   article_published_time: '[tpr_unit:created:html_datetime]'
   og_description: '[tpr_unit:description:summary]'
   og_email: '[tpr_unit:email]'

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -406,3 +406,11 @@ function helfi_tpr_config_update_9064(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-9704 Fix article_modified_time metatag.
+ */
+function helfi_tpr_config_update_9065(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-9704](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9704)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix typo in `article_modified_time` metatag.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9704-fix-time-metatags`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that this feature works
* [x] Check that code follows our standards

[UHF-9704]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ