### PR TITLE
UHF-10000: Patched editoria11y module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,9 @@
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"
             },
+            "drupal/editoria11y": {
+                "[#3442729] Run drupalSettings.editoria11y.css_url through file_url_generator service": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/3a3b005271e7db4476198d822aba1e3ee2e0b8e6/patches/editoria11y-3442729.patch"
+            },
             "drupal/eu_cookie_compliance": {
                 "[#UHF-885] Helfi-specific customizations to EU Cookie Compliance": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/923b35f699820b544397a35b7696570e101cd02c/patches/eu_cookie_compliance_block_8.x-1.24.patch",
                 "[#UHF-8720] Missing config schema for dependencies (https://www.drupal.org/i/3330024)": "https://www.drupal.org/files/issues/2022-12-28/config_dependencies_schema-3330024-2.patch"

--- a/patches/editoria11y-3442729.patch
+++ b/patches/editoria11y-3442729.patch
@@ -1,0 +1,15 @@
+diff --git a/editoria11y.module b/editoria11y.module
+index abcf866144bdefd3cf8e14692612eec3528072a0..2c3e3f538150881858385f07f72833ed0718719e 100644
+--- a/editoria11y.module
++++ b/editoria11y.module
+@@ -280,6 +280,9 @@ function editoria11y_page_attachments(array &$attachments): void {
+   $attachments['#attached']['drupalSettings']['editoria11y']['dismissals'] = $dismissals;
+   $attachments['#attached']['drupalSettings']['editoria11y']['theme'] = $config->get('ed11y_theme');
+   $attachments['#attached']['drupalSettings']['editoria11y']['custom_tests'] = $config->get('custom_tests');
+-  $attachments['#attached']['drupalSettings']['editoria11y']['css_url'] = base_path() . Drupal::service('extension.list.module')->getPath('editoria11y');
++  /** @var \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator */
++  $fileUrlGenerator = \Drupal::service('file_url_generator');
++  $attachments['#attached']['drupalSettings']['editoria11y']['css_url'] =  $fileUrlGenerator
++    ->generateString(Drupal::service('extension.list.module')->getPath('editoria11y'));
+
+ }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,18 +26,23 @@
   <testsuites>
     <testsuite name="unit">
       <directory>./tests/src/Unit</directory>
+      <directory>./modules/*/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="existing-site">
       <directory>./tests/src/ExistingSite</directory>
+      <directory>./modules/*/tests/src/ExistingSite</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>./tests/src/Kernel</directory>
+      <directory>./modules/*/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>./tests/src/Functional</directory>
+      <directory>./modules/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./tests/src/FunctionalJavascript</directory>
+      <directory>./modules/*/tests/src/FunctionalJavascript</directory>
     </testsuite>
   </testsuites>
   <listeners>


### PR DESCRIPTION
## How to install

- Make sure you have 2.11.1 version of editoria11y module: `composer show drupal/editoria11y`
- `composer require drupal/helfi_platform_config:dev-UHF-10000`
- `drush cr`

## How to test

- Open any page as logged in user and make sure `editoria11y.css` is loaded from asset path. For example: `/liikenne-assets/modules/contrib/editoria11y/library/css/editoria11y.css?v=2.2.0` instead of `/modules/contrib/editoria11y/library/css/editoria11y.css?v=2.2.0`.

## Other PRs
- https://www.drupal.org/project/editoria11y/issues/3442729
