### PR TITLE
UHF-9832 User cancellation form

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -462,3 +462,28 @@ function helfi_platform_config_config_ignore_settings_alter(array &$settings) {
     array_push($settings, $config);
   }
 }
+
+/**
+ * Implements hook_user_cancel_methods_alter().
+ */
+function helfi_platform_config_user_cancel_methods_alter(array &$methods): void {
+  /** @var \Drupal\Core\Session\AccountInterface $account */
+  $account = \Drupal::currentUser();
+
+  // Only allow user to disable user accounts if the user doesn't have
+  // a permission to delete user accounts.
+  $white_listed_methods = [
+    'user_cancel_block',
+    'user_cancel_block_unpublish',
+  ];
+
+  // Deny access to all non-whitelisted methods if user doesn't have
+  // the 'delete user accounts' permission.
+  if (!$account->hasPermission('delete user accounts')) {
+    foreach ($methods as $name => &$method) {
+      if (!in_array($name, $white_listed_methods)) {
+        $method['access'] = FALSE;
+      }
+    }
+  }
+}

--- a/helfi_platform_config.permissions.yml
+++ b/helfi_platform_config.permissions.yml
@@ -1,0 +1,2 @@
+delete user accounts:
+  title: Delete user accounts

--- a/tests/src/Functional/UserCancelFormTest.php
+++ b/tests/src/Functional/UserCancelFormTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_platform_config\Functional;
+
+use Drupal\Tests\helfi_api_base\Functional\BrowserTestBase;
+
+/**
+ * Tests user cancel method form.
+ *
+ * @group helfi_platform_config
+ */
+class UserCancelFormTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'helfi_platform_config',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Tests user cancel method form.
+   */
+  public function testUserCancelForm(): void {
+    // Create user accounts for testing the delete methods.
+    $superAdminUser = $this->drupalCreateUser([], 'superAdminUser', TRUE);
+    $adminUser = $this->drupalCreateUser([
+      'access user profiles',
+      'administer users',
+      'cancel account',
+    ], 'superUser');
+    $editorUser = $this->drupalCreateUser([
+      'access user profiles',
+      'cancel account',
+    ], 'editorUser');
+    $testUser = $this->drupalCreateUser([], 'testUser');
+
+    // Test that the superAdminUser can see all cancellation methods
+    // for the testUser account.
+    $this->drupalLogin($superAdminUser);
+    $this->drupalGet('/user/' . $testUser->id() . '/cancel');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_block"]');
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_block_unpublish"]');
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_reassign"]');
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_delete"]');
+
+    // Test that the adminUser can see all only cancellation methods, but not
+    // deletion methods for the testUser account.
+    $this->drupalLogin($adminUser);
+    $this->drupalGet('/user/' . $testUser->id() . '/cancel');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_block"]');
+    $this->assertSession()->elementExists('xpath', '//input[@value="user_cancel_block_unpublish"]');
+    $this->assertSession()->elementNotExists('xpath', '//input[@value="user_cancel_reassign"]');
+    $this->assertSession()->elementNotExists('xpath', '//input[@value="user_cancel_delete"]');
+
+    // Test that the editorUser cannot access the cancel page.
+    $this->drupalLogin($editorUser);
+    $this->drupalGet('/user/' . $testUser->id() . '/cancel');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}


### PR DESCRIPTION
# [UHF-9832](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9832)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added a new permission 'delete user accounts' and let only user with that permission to delete other users.
* Altered the `user_cancel_methods` to let only users with high enough permissions to delete other users.
* Added test for the user deletion/cancellation form.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9832`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
### User cancellation
* [x] Login with a user with super administrator role
* [x] Go to `/admin/people` and edit a user of your choice. On user edit page click on "Cancel account".
   * [x] Check that there are all four cancellation methods available
* [x] Go to edit your own user, remove the super administrator role and set the administrator role active
* [x] Go to `/admin/people` and edit a user of your choice. On user edit page click on "Cancel account".
   * [x] Check that there are only disabling methods available

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-infofinland/pull/305


[UHF-9832]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ