### PR TITLE
UHF-X Unlock external entities module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/eu_cookie_compliance": "^1.24",
-        "drupal/external_entities": "2.0.0-beta",
+        "drupal/external_entities": "^2.0@beta",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
         "drupal/jquery_ui": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/entity_usage": "^2.0@beta",
         "drupal/eu_cookie_compliance": "^1.24",
-        "drupal/external_entities": "2.0.0-alpha6",
+        "drupal/external_entities": "2.0.0-beta",
         "drupal/field_group": "^3.1",
         "drupal/focal_point": "^2.0",
         "drupal/jquery_ui": "^1.6",


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Unlock external entities module, as the following issue with >= alpha7 might have been solved: ExternalEntityTransformRawDataEvent extends non existent Symfony\Component\EventDispatcher\Event class.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_unlock_external_entities`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that tests pass
* [ ] Check that code follows our standards
