### PR TITLE
UHF-10063: enable help_topics module to prevent error

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -114,3 +114,14 @@ function helfi_platform_config_update_9307() : void {
     }
   }
 }
+
+/**
+ * Enable help_topics module to prevent missing help_route_link function -error.
+ */
+function helfi_platform_config_update_9308() : void {
+  $module_installer = \Drupal::service('module_installer');
+
+  if (!\Drupal::moduleHandler()->moduleExists('help_topics')) {
+    $module_installer->install(['help_topics']);
+  }
+}


### PR DESCRIPTION
# [UHF-10063](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10063)
Fixes 'Unknown "help_route_link" function' -error by enabling help_topic module

## How to reproduce
- Setup any project
- run drush twig:compile
see the error

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10063`
* Run `make drush-updb drush-cr`

## How to test

- Run drush twig:compile
You should see no errors.


[UHF-10063]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ