### PR TITLE
UHF-10059 Remote video via media library

### DIFF
--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -118,6 +118,7 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
 
   $user_input = $form_state->getUserInput();
   $video_url = FALSE;
+  $skip_url_validation = FALSE;
 
   // Helsinki-kanava video can be added via media library or as a new media
   // entity. Handle the URL in both cases.
@@ -133,6 +134,7 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
   ) {
     $oembed_video_field = 'url';
     $video_url = &$user_input[$oembed_video_field];
+    $skip_url_validation = TRUE;
   }
 
   // Convert the video url if needed.
@@ -140,7 +142,8 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
     try {
       $converted_url = _helfi_media_remote_video_remote_video_url_handler($video_url);
     }
-    catch (ResourceException $e) {
+    catch (Exception $e) {
+      $form_state->setErrorByName('url', $e->getMessage());
       return $form;
     }
 
@@ -148,6 +151,14 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
       $video_url = $converted_url;
       $form_state->setUserInput($user_input);
       $form_state->setValue($oembed_video_field, $user_input[$oembed_video_field]);
+
+      // Do not validate the media library form from this point forward.
+      // The user inserted URL is cached by media library form and the Oembed
+      // provider would try to validate the unconverted URL. Set the form
+      // validation complete to avoid this.
+      if ($skip_url_validation) {
+        $form_state->setValidationComplete();
+      }
     }
   }
 
@@ -167,6 +178,9 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
  *
  * @return false|string
  *   Returns FALSE or converted video URL.
+ *
+ * @throws \Exception
+ *   If the URL is missing asset ID.
  */
 function _helfi_media_remote_video_remote_video_url_handler(string $video_url): false|string {
   $converted_url = FALSE;
@@ -197,18 +211,15 @@ function _helfi_media_remote_video_remote_video_url_handler(string $video_url): 
 
   // Try to convert the URL if it's of form 'web/helsinkikanava/player/webcast'.
   if (str_contains($video_url, '/web/helsinkikanava/player/webcast')) {
-    $lang_code = '';
     preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
     $asset_id = $asset_id_matches[1];
 
     if (empty($asset_id)) {
-      return $converted_url;
+      throw new Exception('URL is missing asset ID parameter.');
     }
 
-    // @todo figure out if this is needed.
-    // $lang_code = empty($lang_code) ? 'fi' : $lang_code;
     $url_parts = explode('*', $helsinki_kanava_url_pattern);
-    $converted_url = $url_parts[0] . $lang_code . $url_parts[1] . $asset_id;
+    $converted_url = $url_parts[0] . 'fi' . $url_parts[1] . $asset_id;
   }
 
   // Return the converted URL.

--- a/translations/override/fi.po
+++ b/translations/override/fi.po
@@ -62,6 +62,12 @@ msgstr "Käyttäjä"
 msgid "Yes"
 msgstr "Kyllä"
 
+msgid "Add @type via URL"
+msgstr "Lisää @type"
+
+msgid "No matching provider found."
+msgstr "Tarkista URL-osoite. Osoitteen perusteella ei voitu määrittää palveluntarjoajaa."
+
 # Content lock
 msgid "Break Lock for content @label"
 msgstr "Vahvista lukituksen poisto sivulta @label"
@@ -95,6 +101,10 @@ msgstr "Korvaa alkuperäinen tiedosto (@originalExtension)"
 
 msgid "Replace file"
 msgstr "Korvaa tiedosto"
+
+# Media library
+msgid "The media item has been created but has not yet been saved. Fill in any required fields and save to add it to the media library."
+msgstr "Media on luotu, mutta sitä ei ole vielä tallennettu. Täytä kaikki pakolliset kentät ja tallenna lisätäksesi se mediakirjastoon."
 
 # Menu
 msgid "Parent link"


### PR DESCRIPTION
# [UHF-10059](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10059)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed the media library form validation bug when inserting remote videos via modal.
* Added few Finnish translations.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10059`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that adding the following remote videos work (via media library)
   * [x] https://www.helsinkikanava.fi/fi/web/helsinkikanava/player/webcast?eventId=293460504&assetId=293497301
   * [x] https://www.helsinkikanava.fi/fi/web/helsinkikanava/player/event/view?eventId=291155401&assetId=292845801
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR



[UHF-10059]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ