### PR TITLE
UHF-10090: Fixed translations for news tags.

### DIFF
--- a/modules/helfi_paragraphs_news_list/config/optional/language/fi/external_entities.external_entity_type.helfi_news_tags.yml
+++ b/modules/helfi_paragraphs_news_list/config/optional/language/fi/external_entities.external_entity_type.helfi_news_tags.yml
@@ -1,2 +1,2 @@
-label: 'Uutisten kaupunginosat'
-label_plural: 'Uutisten kaupunginosat'
+label: 'Uutisten tagit'
+label_plural: 'Uutisten tagit'

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
@@ -115,7 +115,7 @@ function helfi_paragraphs_news_list_update_9004() : void {
 /**
  * UHF-8974 Update the translations for the news list paragraph type.
  */
-function helfi_paragraphs_news_list_update_9006() : void {
+function helfi_paragraphs_news_list_update_9007() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_paragraphs_news_list');
 }


### PR DESCRIPTION
# [UHF-10090](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10090)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed translations for news tags.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10090`
* Run `make drush-updb drush-cr`

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR


[UHF-10090]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ