### PR TITLE
UHF-9361: Add translation context to email field in social media module

### DIFF
--- a/documentation/translations.md
+++ b/documentation/translations.md
@@ -21,6 +21,21 @@ Create and update hook for your module to import the translations.
 
 See [Development](/documents/development.md) for more information.
 
+### Translation context for configuration
+
+We might want to customize some strings from contrib modules without overriding the string globally. Contrib modules can specify translation context for translatable strings in [configuration schema](https://www.drupal.org/docs/drupal-apis/configuration-api/configuration-schemametadata). However, not all contrib modules use translation contexts. To customize the context, use `hook_config_schema_info_alter()`:
+
+```
+/**
+ * Implements hook_config_schema_info_alter().
+ */
+function my_module_config_schema_info_alter(array &$definitions) : void {
+  if (isset($definitions['social_media.item.email'])) {
+    $definitions['social_media.item.email']['mapping']['text']['translation context'] = 'Social media: email';
+  }
+}
+```
+
 ## Creating custom/helfi module UI translations
 Make sure the translations are imported during locale import (`drush locale:update`) by checking
 the module/theme has the following information in `module_name.info.yml`. For an example, check [helfi_content.info.yml](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/blob/main/helfi_features/helfi_content/helfi_content.info.yml#L46).

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -495,3 +495,13 @@ function helfi_platform_config_user_cancel_methods_alter(array &$methods): void 
     }
   }
 }
+
+/**
+ * Implements hook_config_schema_info_alter().
+ */
+function helfi_platform_config_config_schema_info_alter(array &$definitions) : void {
+  // Add translation contexts to contrib modules.
+  if (isset($definitions['social_media.item.email'])) {
+    $definitions['social_media.item.email']['mapping']['text']['translation context'] = 'Social media: email';
+  }
+}

--- a/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
+++ b/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.install
@@ -14,3 +14,11 @@ function helfi_paragraphs_contact_card_listing_update_9003() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_paragraphs_contact_card_listing');
 }
+
+/**
+ * Fix email translations.
+ */
+function helfi_paragraphs_contact_card_listing_update_9004() : void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_paragraphs_contact_card_listing');
+}

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -414,3 +414,11 @@ function helfi_tpr_config_update_9065(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * Fix email translations.
+ */
+function helfi_tpr_config_update_9066(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}


### PR DESCRIPTION
# [UHF-9361](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9361)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

- This should allow fixing email field label in contact card paragraph. The field label is overridden by [`social_media.settings`](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/blob/dev/conf/cmi/language/fi/social_media.settings.yml#L14-L15).

![image](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/assets/732227/2e9d2e04-5dea-4d2c-8831-0b54bd02b6ba)

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * Import artifact from github (or create it locally: `drush si -y --existing-config; drush cim -y`)
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9361`
* Simulate `update-config` workflow
  * ```
    drush cr;
    drush locale:check; drush locale:update;
    drush updb -y;
    drush helfi:locale-import helfi_platform_config;
    drush cex
    ```

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that code follows our standards
* [x] Check that config changes look ok


[UHF-9361]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ