### PR TITLE
UHF-10159 Convert fields to translatable fields

### DIFF
--- a/modules/helfi_node_announcement/config/install/field.field.node.announcement.field_announcement_title.yml
+++ b/modules/helfi_node_announcement/config/install/field.field.node.announcement.field_announcement_title.yml
@@ -12,7 +12,7 @@ bundle: announcement
 label: 'Announcement title'
 description: 'This title is only available to users of assistive technology. '
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/helfi_node_announcement/helfi_node_announcement.install
+++ b/modules/helfi_node_announcement/helfi_node_announcement.install
@@ -88,18 +88,9 @@ function helfi_node_announcement_update_9001() : void {
 }
 
 /**
- * Set node as unpublished on default.
+ * UHF-10159 Convert the announcement title field to a translatable field.
  */
-function helfi_node_announcement_update_9002() : void {
-  // Re-import configuration.
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_node_announcement');
-}
-
-/**
- * Add new field announcement_title for screenreaders.
- */
-function helfi_node_announcement_update_9003() : void {
+function helfi_node_announcement_update_9004() : void {
   // Re-import configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_node_announcement');

--- a/modules/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_phone_label.yml
+++ b/modules/helfi_tpr_config/config/install/field.field.tpr_unit.tpr_unit.field_phone_label.yml
@@ -13,7 +13,7 @@ bundle: tpr_unit
 label: 'Phone label'
 description: 'The label shown above the phone number when displayed in other contact info accordion.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -381,44 +381,9 @@ function helfi_tpr_config_update_9052() : void {
 }
 
 /**
- * UHF-9088: Updated configuration translations.
+ * UHF-10159 Convert the phone label field to a translatable field.
  */
-function helfi_tpr_config_update_9061(): void {
-  // Re-import 'helfi_tpr_config' configuration.
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_tpr_config');
-}
-
-/**
- * UHF-9562: Updated email field formatter.
- */
-function helfi_tpr_config_update_9062(): void {
-  // Re-import 'helfi_tpr_config' configuration.
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_tpr_config');
-}
-
-/**
- * UHF-9496: Move phone number option.
- */
-function helfi_tpr_config_update_9064(): void {
-  // Re-import 'helfi_tpr_config' configuration.
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_tpr_config');
-}
-
-/**
- * UHF-9704 Fix article_modified_time metatag.
- */
-function helfi_tpr_config_update_9065(): void {
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_tpr_config');
-}
-
-/**
- * Fix email translations.
- */
-function helfi_tpr_config_update_9066(): void {
+function helfi_tpr_config_update_9067(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }


### PR DESCRIPTION
# [UHF-10159](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10159)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Make the announcement title and TPR unit phone label translatable

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10159`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that the assistive title for the announcement (field name: Announcement title) is translatable
* [x] Check that the phone label under the TPR unit's "Move phone to Other contact information accordion" boolean field is also translatable
* [x] Check that code follows our standards



[UHF-10159]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ