### PR TITLE
UHF-10060: Fix system error pages

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -429,7 +429,7 @@ function helfi_platform_config_language_switch_links_alter(array &$links): void 
   if (!$entity || !$entity->isTranslatable()) {
     // UHF-10060: Disable the language links on 404-pages so that /system/404
     // route is not accessible for crawlers etc.
-    if ($route_match->getRouteName() === 'system.404') {
+    if (in_array($route_match->getRouteName(), ['system.401', 'system.403', 'system.404'])) {
       $language = Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
 
       foreach ($links as $langcode => &$link) {

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldConfigBase;
+use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -147,6 +148,7 @@ function helfi_platform_config_update_paragraph_target_types() : void {
     // Save the field to trigger re-build of target_bundles.
     // @see helfi_platform_config_field_config_presave().
     // @see helfi_platform_config_base_field_override_presave().
+    /** @var \Drupal\Core\Field\FieldConfigInterface $field */
     $field->save();
   }
 }
@@ -413,7 +415,8 @@ function helfi_platform_config_preprocess_react_and_share(&$variables) : void {
  * #UHF-9158 main languages must be always visible on language switcher.
  */
 function helfi_platform_config_language_switch_links_alter(array &$links): void {
-  $params = \Drupal::routeMatch()->getParameters()->all();
+  $route_match = \Drupal::routeMatch();
+  $params = $route_match->getParameters()->all();
 
   $entity = NULL;
   foreach ($params as $param) {
@@ -422,11 +425,25 @@ function helfi_platform_config_language_switch_links_alter(array &$links): void 
       break;
     }
   }
+
   if (!$entity || !$entity->isTranslatable()) {
+    // UHF-10060: Disable the language links on 404-pages so that /system/404
+    // route is not accessible for crawlers etc.
+    if ($route_match->getRouteName() === 'system.404') {
+      $language = Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+
+      foreach ($links as $langcode => &$link) {
+        helfi_platform_config_set_language_link_disabled($link);
+        if ($language->getId() === $langcode) {
+          $link['#nolink'] = TRUE;
+        }
+      }
+    }
+
     return;
   }
 
-  foreach ($links as $langcode => $link) {
+  foreach ($links as $langcode => &$link) {
     if (!$entity->hasTranslation($langcode)) {
       continue;
     }
@@ -436,13 +453,23 @@ function helfi_platform_config_language_switch_links_alter(array &$links): void 
       continue;
     }
 
-    // Unpublished link won't pass url access check
-    // Replace unpublished translation with another one and set it disabled.
-    unset($links[$langcode]['url']);
-    $links[$langcode]['#untranslated'] = TRUE;
-    $links[$langcode]['url'] = new Url('<nolink>');
-    $links[$langcode]['attributes']['class'][] = 'language-link--untranslated';
+    helfi_platform_config_set_language_link_disabled($link);
   }
+}
+
+/**
+ * Set language link disabled.
+ *
+ * @param array $link
+ *   Language link for language switcher.
+ */
+function helfi_platform_config_set_language_link_disabled(array &$link): void {
+  // Unpublished link won't pass url access check
+  // Replace unpublished translation with another one and set it disabled.
+  unset($link['url']);
+  $link['#untranslated'] = TRUE;
+  $link['url'] = new Url('<nolink>');
+  $link['attributes']['class'][] = 'language-link--untranslated';
 }
 
 /**

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -147,7 +147,7 @@ function helfi_platform_config_update_paragraph_target_types() : void {
     // Save the field to trigger re-build of target_bundles.
     // @see helfi_platform_config_field_config_presave().
     // @see helfi_platform_config_base_field_override_presave().
-    /** @var \Drupal\Core\Field\FieldConfigInterface $field */
+    /** @var \Drupal\Core\Field\FieldConfigBase $field */
     $field->save();
   }
 }

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -15,7 +15,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldConfigBase;
-use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -147,7 +147,6 @@ function helfi_platform_config_update_paragraph_target_types() : void {
     // Save the field to trigger re-build of target_bundles.
     // @see helfi_platform_config_field_config_presave().
     // @see helfi_platform_config_base_field_override_presave().
-    /** @var \Drupal\Core\Field\FieldConfigBase $field */
     $field->save();
   }
 }


### PR DESCRIPTION
# [UHF-10060](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10060)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Disabled the language switcher links on 401/403/404 error pages so that crawlers and others are not able to access the 200 code returning `system/401/403/404` pages.

## How to install
* Check installation instructions from the [hdbt PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/1005).

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check testing instructions from the [hdbt PR](https://github.com/City-of-Helsinki/drupal-hdbt/pull/1005).
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1005
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/771


[UHF-10060]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ