### PR TITLE
Conflict with search_api 1.35

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,8 +69,7 @@
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/simple_sitemap": ">4.1.7",
-        "drush/drush": "<12",
-        "drupal/search_api": "1.35"
+        "drush/drush": "<12"
     },
     "extra": {
         "patches": {
@@ -104,6 +103,9 @@
             },
             "drupal/view_unpublished": {
                 "[#UHF-9256] Fix missing dynamic permission dependencies.": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/cbb944ae79643ba7ed895db3fac7f3b3d90ac850/patches/view_unpublished_permissions_missing_dependencies.patch"
+            },
+            "drupal/elasticsearch_connector": {
+                "https://www.drupal.org/project/elasticsearch_connector/issues/3454977": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/959fd61553c8827b7350e53de4f66b2f6b8c97a1/patches/issue-3454977.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/simple_sitemap": ">4.1.7",
-        "drush/drush": "<12"
+        "drush/drush": "<12",
+        "drupal/search_api": "1.35"
     },
     "extra": {
         "patches": {

--- a/patches/issue-3454977.patch
+++ b/patches/issue-3454977.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+index 50732ba..30fdb79 100644
+--- a/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
++++ b/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php
+@@ -1233,7 +1233,7 @@ class SearchApiElasticsearchBackend extends BackendPluginBase implements PluginF
+    *
+    * Prevents closure serialization error on search_api server add form.
+    */
+-  public function __sleep() {
++  public function __sleep(): array {
+     return [];
+   }
+ 


### PR DESCRIPTION
https://www.drupal.org/project/elasticsearch_connector/issues/3454977

## How to test:

 * `composer require drupal/helfi_platform_config:dev-UHF-X-search_api_issue -W`
 * `composer show drupal/search_api`. Version should be `1.34`.