### PR TITLE
UHF-X Lock gin toolbar version to RC5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     "conflict": {
         "drupal/core": "<10.2",
         "drupal/ctools": "<3.11 || ^4.0.1",
+        "drupal/gin_toolbar": ">1.0.0-rc5",
         "drupal/helfi_media_map": "*",
         "drupal/simple_sitemap": ">4.1.7",
         "drush/drush": "<12"


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Lock Gin toolbar version to RC5 until we've checked all possible issues from RC6.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_lock_gin_toolbar_rc5 -W`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the RC5 version is installed
