### PR TITLE
UHF-10252 Gin toolbar update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drupal/core": "<10.3",
         "drupal/core-composer-scaffold": "<10.3",
         "drupal/ctools": "<3.11 || ^4.0.1",
-        "drupal/gin_toolbar": ">1.0.0-rc5",
+        "drupal/gin_toolbar": ">1.0.0-rc6",
         "drupal/helfi_media_map": "*",
         "drupal/simple_sitemap": ">4.1.7",
         "drush/drush": "<12"

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -87,3 +87,19 @@ function hdbt_admin_tools_update_9004(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('hdbt_admin_tools');
 }
+
+/**
+ * UHF-10252: Update admin pages language switcher block visibility settings.
+ */
+function hdbt_admin_tools_update_9005(): void {
+  // Alter admin pages language switcher block visibility settings.
+  $language_switcher_block = Drupal::configFactory()
+    ->getEditable('block.block.language_switcher_admin');
+  $raw_data = $language_switcher_block->getRawData();
+
+  if (isset($raw_data['visibility']['request_path']['pages'])) {
+    $raw_data['visibility']['request_path']['pages'] = '/node/*\r\n/admin/content/integrations/*/edit\r\n/group/*/content/create/*';
+    $language_switcher_block->setData($raw_data);
+    $language_switcher_block->save();
+  }
+}

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -98,7 +98,7 @@ function hdbt_admin_tools_update_9005(): void {
   $raw_data = $language_switcher_block->getRawData();
 
   if (isset($raw_data['visibility']['request_path']['pages'])) {
-    $raw_data['visibility']['request_path']['pages'] = '/node/*\r\n/admin/content/integrations/*/edit\r\n/group/*/content/create/*';
+    $raw_data['visibility']['request_path']['pages'] = "/node/*\r\n/admin/content/integrations/*/edit\r\n/group/*/content/create/*";
     $language_switcher_block->setData($raw_data);
     $language_switcher_block->save();
   }


### PR DESCRIPTION
# [UHF-10252](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10252)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated the conflict restriction for the Gin toolbar RC5 -> RC6.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10252 -W`
* Run `make drush-updb drush-cr`

## What was changed in Gin toolbar between rc5 and rc6
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

- [Added condition to avoid adding navigation in maintenance pages ](https://git.drupalcode.org/project/gin_toolbar/-/commit/7a1f2fdd2c8811c7ee982e275f4600689b7a1fec)
- [Bug in data-offset-top logic](https://www.drupal.org/project/gin_toolbar/issues/3440320)
- [Edit page link in secondary navigation does not support content moderation](https://www.drupal.org/project/gin_toolbar/issues/3403332)
- [PHP warning in gin_toolbar_theme()](https://www.drupal.org/i/3445824)
- Various fixes which were added via single commits: 
   - [Add Navigation module Beta support](https://git.drupalcode.org/project/gin_toolbar/-/commit/bec1d4851c1e59b5e4a043efdfdb57561822a0ad)
   - [Remove check for navigation from toolbar](https://git.drupalcode.org/project/gin_toolbar/-/commit/dce5cfcd182f770d6a7cbf21200f9682122567d4)
   - [Fix for test navigation integration](https://git.drupalcode.org/project/gin_toolbar/-/commit/5ef092beac420c0dcad7325db367e9b463d0ff78)
   - [Clean up code for navigation module integration](https://git.drupalcode.org/project/gin_toolbar/-/commit/f7cc1b393657eca0aac9e8fcdc06a629c5992c02)
   - [Add top_bar library in top_bar hook](https://git.drupalcode.org/project/gin_toolbar/-/commit/7d01b86ba9479cafcfa27806ed7122e9706421a7)
   - [Add logo for project browser](https://git.drupalcode.org/project/gin_toolbar/-/commit/aec98364ee435998119bf14db526dd4b57ab42b8)
   - [Add logo for project browser](https://git.drupalcode.org/project/gin_toolbar/-/commit/90f234cebbe0e3a34a3f8894b4251a9f11783811)

## How to test: 
* [ ] Test the admin navigation and see that it works as before.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/288


[UHF-10252]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ