### PR TITLE
UHF-9493: Fix tests

### DIFF
--- a/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
@@ -54,14 +54,19 @@ class LinkedEventsTest extends UnitTestCase {
   protected function setUp() : void {
     parent::setUp();
 
-    $this->cache = new MemoryBackend();
+    // Create a mock container.
+    $container = new ContainerBuilder();
+
+    // Register the TimeInterface service.
+    $time = $this->createMock(TimeInterface::class);
+    $container->set('datetime.time', $time);
+
+    // MemoryBackend needs a time object, so create one.
+    $this->cache = new MemoryBackend($time);
     $this->environmentResolverConfiguration = [
       EnvironmentResolver::PROJECT_NAME_KEY => Project::ASUMINEN,
       EnvironmentResolver::ENVIRONMENT_NAME_KEY => 'local',
     ];
-
-    // Create a mock container.
-    $container = new ContainerBuilder();
 
     // Register services what LinkedEvents uses.
     $urlAssembler = $this->createMock('Drupal\Core\Utility\UnroutedUrlAssemblerInterface');


### PR DESCRIPTION
# [UHF-9493](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Mocked datetime service for memorybackend.
## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that tests pass



[UHF-9493]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ