### PR TITLE
UHF-10255: Add module for X-Robots-Tag handling if helfi_proxy can't be used

### DIFF
--- a/modules/helfi_robots_header/README.md
+++ b/modules/helfi_robots_header/README.md
@@ -1,0 +1,8 @@
+# Helfi Robots Header
+
+Handles robots-tag header if `helfi_proxy` module can't be installed.
+
+This module adds `X-Robots-Tag: noindex, nofollow` to all page responses if `DRUPAL_X_ROBOTS_TAG_HEADER` if set to 1.
+
+**NOTE:** Because this duplicates some functionality from `helfi_proxy` module, both modules should not be enabled at the same time.
+

--- a/modules/helfi_robots_header/helfi_robots_header.info.yml
+++ b/modules/helfi_robots_header/helfi_robots_header.info.yml
@@ -1,0 +1,5 @@
+name: 'HELfi Robots headers'
+type: module
+description: Adds noindex and nofollow robots tags to headers.
+package: Custom
+core_version_requirement: ^9 || ^10

--- a/modules/helfi_robots_header/helfi_robots_header.services.yml
+++ b/modules/helfi_robots_header/helfi_robots_header.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\helfi_robots_header\EventSubscriber\RobotsResponseSubscriber:
+    tags:
+      - { name: event_subscriber }

--- a/modules/helfi_robots_header/src/EventSubscriber/RobotsResponseSubscriber.php
+++ b/modules/helfi_robots_header/src/EventSubscriber/RobotsResponseSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_robots_header\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds an X-Robots-Tag to response headers.
+ */
+final class RobotsResponseSubscriber implements EventSubscriberInterface {
+
+  public const X_ROBOTS_TAG_HEADER_NAME = 'DRUPAL_X_ROBOTS_TAG_HEADER';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse', -100];
+    return $events;
+  }
+
+  /**
+   * Adds an X-Robots-Tag response header.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to respond to.
+   */
+  public function onResponse(ResponseEvent $event) : void {
+    $response = $event->getResponse();
+
+    if ((bool) getenv(self::X_ROBOTS_TAG_HEADER_NAME)) {
+      $response->headers->add(['X-Robots-Tag' => 'noindex, nofollow']);
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-10255](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255)

## What was done
* Add a new module that adds the `X-Robots-Tag: noindex, nofollow` header when `DRUPAL_X_ROBOTS_TAG_HEADER` environment variable is set to true.

## How to install
* Set up [Palvelukeskus](https://github.com/City-of-Helsinki/drupal-palvelukeskus)
  * `git checkout dev`
  * `make fresh shell`
  * `composer require drupal/helfi_platform_config:dev-UHF-10255-add-module-for-robots-header`
  * `drush en helfi_robots_header`
* Run `make drush-cr`

## How to test
* [x] Open any page and check that the `x-robots-tag` header is not set.
* Add `DRUPAL_X_ROBOTS_TAG_HEADER: 1` to `compose.yaml` under `services` -> `app` -> `environment`, then run `make up drush-cr`
  * [x] Reload the page. The header should be set now
* Remove the env variable line from `compose.yaml`, then run `make up drush-cr`
  * [x] Reload the page. The header should be gone.
* [x] Check that code follows our standards

## Test if this breaks anything on another instance
* [x] Set up a second instance, doesn't matter which one, but it should have `helfi_proxy` enabled (for example KYMP, SOTE, etc)
* [x] Follow the same installation instructions, see if anything breaks
* [x] Follow the test instructions, see if anything breaks or something weird happens

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated

[UHF-10255]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ