### PR TITLE
UHF-10451: Remove survey contents from table of contents listing

### DIFF
--- a/modules/helfi_toc/assets/js/tableOfContents.js
+++ b/modules/helfi_toc/assets/js/tableOfContents.js
@@ -21,7 +21,8 @@
       ':not(.breadcrumb__container *)' +
       ':not(#helfi-toc-table-of-contents *)' +
       ':not(.embedded-content-cookie-compliance *)' +
-      ':not(.react-and-share-cookie-compliance *)'
+      ':not(.react-and-share-cookie-compliance *)' +
+      ':not(.survey__container *)'
     },
 
     // List of heading tags with exclusions.

--- a/modules/helfi_toc/helfi_toc.libraries.yml
+++ b/modules/helfi_toc/helfi_toc.libraries.yml
@@ -1,5 +1,5 @@
 table_of_contents:
-  version: 1.0.3
+  version: 1.0.4
   js:
     assets/js/tableOfContents.js: {}
   dependencies:


### PR DESCRIPTION
# [UHF-10451](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10451)
<!-- What problem does this solve? -->
The questionnaire heading appears in table of contents

## What was done
<!-- Describe what was done -->

* Questionnaire contents was removed from ToC processing

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10451_questionnaire_heading_in_toc`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add an page with table of contents and a heading on that page.
* [ ] Notice that after this fix, the "Globaali testikysely" no longer appears in ToC
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [X] This change doesn't require updates to the documentation


[UHF-10451]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/679