### PR TITLE
UHF-10466: Prevent suunte js aggregation

### DIFF
--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -12,7 +12,7 @@ clear_localstorage:
     - core/drupal
 
 genesys_suunte:
-  version: 1.0.1
+  version: 1.0.2
   header: true
   js:
     'https://apps.mypurecloud.ie/widgets/9.0/cxbus.min.js' : {
@@ -24,6 +24,7 @@ genesys_suunte:
     }
     assets/js/genesys_suunte.js: {
       attributes: {
+        preprocess: false,
         onload: "javascript:var checkExist = setInterval(function() {if(typeof CXBus != 'undefined') {clearInterval(checkExist);Drupal.behaviors.genesys_suunte.attach();console.log('suunte attaching');}}, 100);"
       }
     }

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -57,7 +57,11 @@ chat_leijuke:
   version: 1.0.2
   header: true
   js:
-    assets/js/chat_leijuke.js: {}
+    assets/js/chat_leijuke.js: {
+      attributes: {
+        preprocess: false
+      }
+    }
   dependencies:
     - core/drupal
     - core/drupalSettings

--- a/helfi_platform_config.libraries.yml
+++ b/helfi_platform_config.libraries.yml
@@ -57,11 +57,7 @@ chat_leijuke:
   version: 1.0.2
   header: true
   js:
-    assets/js/chat_leijuke.js: {
-      attributes: {
-        preprocess: false
-      }
-    }
+    assets/js/chat_leijuke.js: {}
   dependencies:
     - core/drupal
     - core/drupalSettings


### PR DESCRIPTION
# [UHF-10466](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10466)
Drupal aggregation prevented suunte-chat initialization for some reason.

## What was done
Prevent suunte-script aggregation

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10466`
* Run `make drush-updb drush-cr`

## How to test
- Make sure the JS aggregation is enabled
  - (Go check local.settings.php and comment the js preprocess if not commented)
- Go to hammashoita-page as anonymous user FINNISH language
- Hammashoito-chat button should be visible
- Open inspector, check network tab and filter by JS, 
  - Check that the genesys_suunte.js is listed in the loaded JS files list (which means not aggregated)


## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation


[UHF-10466]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ