### PR TITLE
UHF-8652: Add hdbt cookie banner site settings controller

### DIFF
--- a/modules/hdbt_cookie_banner/assets/hdbt_cookie_banner.js
+++ b/modules/hdbt_cookie_banner/assets/hdbt_cookie_banner.js
@@ -1,0 +1,12 @@
+(function (Drupal, drupalSettings) {
+  Drupal.behaviors.hdbt_cookie_banner = {
+    attach: function (context, settings) {
+
+      // Todo initialize hdbt cookie banner.
+      fetch(drupalSettings.hdbt_cookie_banner.apiUrl)
+        .then(response => response.json())
+        .then(console.log)
+        .catch(console.error)
+    }
+  }
+})(Drupal, drupalSettings);

--- a/modules/hdbt_cookie_banner/config/schema/hdbt_cookie_banner.schema.yml
+++ b/modules/hdbt_cookie_banner/config/schema/hdbt_cookie_banner.schema.yml
@@ -1,0 +1,8 @@
+hdbt_cookie_banner.settings:
+  type: config_object
+  label: HDBT cookie banner
+  mapping:
+    site_settings:
+      type: string
+      label: Site settings
+      nullable: true

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.info.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.info.yml
@@ -1,0 +1,6 @@
+name: 'HDBT cookie banner'
+type: module
+description: 'Drupal module for hdbt cookie banner.'
+core_version_requirement: ^10 || ^11
+dependencies:
+  - helfi_api_base:helfi_api_base

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.libraries.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.libraries.yml
@@ -1,0 +1,3 @@
+hdbt_cookie_banner:
+  js:
+    assets/hdbt_cookie_banner.js: {}

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.links.menu.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.links.menu.yml
@@ -1,0 +1,6 @@
+hdbt_cookie_banner.form:
+  title: 'HDBT Cookie Banner'
+  route_name: hdbt_cookie_banner.form
+  parent: system.admin_config_system
+  description: 'Configure HDBT Cookie Banner'
+  weight: -10

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -28,7 +28,7 @@ function hdbt_cookie_banner_page_attachments(array &$attachments) : void {
   ];
 
   $config = \Drupal::configFactory()->get(HdbtCookieBannerForm::SETTINGS);
-  $attachments['#cache']['tags'] = $config->getCacheTags();
+  $attachments['#cache']['tags'] = array_merge($attachments['#cache']['tags'] ?? [], $config->getCacheTags());
 }
 
 /**

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -6,6 +6,7 @@
  */
 
 declare(strict_types=1);
+
 use Drupal\Core\Url;
 use Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
@@ -24,7 +25,7 @@ function hdbt_cookie_banner_config_ignore_settings_alter(array &$settings): void
 function hdbt_cookie_banner_page_attachments(array &$attachments) : void {
   $attachments['#attached']['library'][] = 'hdbt_cookie_banner/hdbt_cookie_banner';
   $attachments['#attached']['drupalSettings']['hdbt_cookie_banner'] = [
-    'apiUrl' => _hdbt_cookie_banner_get_api_url()
+    'apiUrl' => _hdbt_cookie_banner_get_api_url(),
   ];
 
   $config = \Drupal::configFactory()->get(HdbtCookieBannerForm::SETTINGS);
@@ -32,7 +33,7 @@ function hdbt_cookie_banner_page_attachments(array &$attachments) : void {
 }
 
 /**
- * Gets HDBT cookie banner api url
+ * Gets HDBT cookie banner api url.
  */
 function _hdbt_cookie_banner_get_api_url(): string {
   $config = \Drupal::configFactory()->get(HdbtCookieBannerForm::SETTINGS);
@@ -47,7 +48,7 @@ function _hdbt_cookie_banner_get_api_url(): string {
         ->getEnvironment(Project::ETUSIVU, $resolver->getActiveEnvironmentName());
 
       return vsprintf("%s/api/cookie-banner", [
-        $environment->getUrl($language->getId())
+        $environment->getUrl($language->getId()),
       ]);
     }
     catch (InvalidArgumentException) {

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -12,6 +12,13 @@ use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_api_base\Environment\Project;
 
 /**
+ * Implements hook_config_ignore_settings_alter().
+ */
+function hdbt_cookie_banner_config_ignore_settings_alter(array &$settings): void {
+  $settings[] = HdbtCookieBannerForm::SETTINGS;
+}
+
+/**
  * Implements hook_page_attachments().
  */
 function hdbt_cookie_banner_page_attachments(array &$attachments) : void {

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Contains module hooks for hdbt cookie banner.
+ */
+
+declare(strict_types=1);
+use Drupal\Core\Url;
+use Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\helfi_api_base\Environment\Project;
+
+/**
+ * Implements hook_page_attachments().
+ */
+function hdbt_cookie_banner_page_attachments(array &$attachments) : void {
+  $attachments['#attached']['library'][] = 'hdbt_cookie_banner/hdbt_cookie_banner';
+  $attachments['#attached']['drupalSettings']['hdbt_cookie_banner'] = [
+    'apiUrl' => _hdbt_cookie_banner_get_api_url()
+  ];
+
+  $config = \Drupal::configFactory()->get(HdbtCookieBannerForm::SETTINGS);
+  $attachments['#cache']['tags'] = $config->getCacheTags();
+}
+
+/**
+ * Gets HDBT cookie banner api url
+ */
+function _hdbt_cookie_banner_get_api_url(): string {
+  $config = \Drupal::configFactory()->get(HdbtCookieBannerForm::SETTINGS);
+  $language = \Drupal::languageManager()->getDefaultLanguage();
+
+  // Default to etusivu api url.
+  if (empty($config->get('site_settings'))) {
+    /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $resolver */
+    $resolver = \Drupal::service(EnvironmentResolverInterface::class);
+    try {
+      $environment = $resolver
+        ->getEnvironment(Project::ETUSIVU, $resolver->getActiveEnvironmentName());
+
+      return vsprintf("%s/api/cookie-banner", [
+        $environment->getUrl($language->getId())
+      ]);
+    }
+    catch (InvalidArgumentException) {
+    }
+  }
+
+  return Url::fromRoute('hdbt_cookie_banner.site_settings', options: [
+    'language' => $language,
+  ])->toString();
+}

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.permissions.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.permissions.yml
@@ -1,0 +1,2 @@
+administer hdbt_cookie_banner:
+  title: 'Administer hdbt cookie banner'

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.routing.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.routing.yml
@@ -1,0 +1,14 @@
+hdbt_cookie_banner.form:
+  path: '/admin/structure/hdbt-cookie-banner'
+  defaults:
+    _form: '\Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm'
+    _title: 'Administer hdbt cookie banner'
+  requirements:
+    _permission: 'administer hdbt_cookie_banner'
+
+hdbt_cookie_banner.site_settings:
+  path: '/api/cookie-banner'
+  defaults:
+    _controller: '\Drupal\hdbt_cookie_banner\Controller\HdbtCookieBannerController::siteSettings'
+  requirements:
+    _access: 'TRUE'

--- a/modules/hdbt_cookie_banner/src/Controller/HdbtCookieBannerController.php
+++ b/modules/hdbt_cookie_banner/src/Controller/HdbtCookieBannerController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hdbt_cookie_banner\Controller;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm;
+
+/**
+ * HDBT cookie banner controller.
+ */
+class HdbtCookieBannerController extends ControllerBase {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   The config factory.
+   */
+  public function __construct(private readonly ConfigFactoryInterface $config) {
+  }
+
+  /**
+   * Returns site settings.
+   */
+  public function siteSettings(): CacheableJsonResponse {
+    $config = $this->config->get(HdbtCookieBannerForm::SETTINGS);
+
+    $response = new CacheableJsonResponse(Json::decode($config->get('site_settings')));
+    $response->addCacheableDependency($config);
+    $response->setMaxAge(600);
+    $response->setPublic();
+
+    return $response;
+  }
+
+}

--- a/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
+++ b/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
@@ -29,7 +29,7 @@ final class HdbtCookieBannerForm extends ConfigFormBase {
    */
   protected function getEditableConfigNames(): array {
     return [
-     self::SETTINGS,
+      self::SETTINGS,
     ];
   }
 

--- a/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
+++ b/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hdbt_cookie_banner\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * HDBT cookie banner form.
+ */
+final class HdbtCookieBannerForm extends ConfigFormBase {
+
+  /**
+   * Config settings.
+   */
+  public const SETTINGS = 'hdbt_cookie_banner.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'hdbt_cookie_banner';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return [
+     self::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $form['site_settings'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Site settings', options: ['context' => 'hdbt cookie banner']),
+      '#config_target' => self::SETTINGS . ":site_settings",
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
+    parent::validateForm($form, $form_state);
+
+    $values = $form_state->getValues();
+
+    if (!$this->isValidJson($values['site_settings'])) {
+      $form_state->setErrorByName('site_settings',
+        $this->t('Site settings must be valid JSON', options: ['context' => 'hdbt cookie banner'])
+      );
+    }
+  }
+
+  /**
+   * Validates JSON string.
+   *
+   * @param string $value
+   *   Input string.
+   *
+   * @return bool
+   *   True if input is valid JSON.
+   */
+  private function isValidJson(string $value): bool {
+    // @todo replace with json_validate in php >= 8.3.
+    // https://www.php.net/releases/8.3/en.php#json_validate.
+    json_decode($value);
+    return json_last_error() === JSON_ERROR_NONE;
+  }
+
+}


### PR DESCRIPTION
# [UHF-8652](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8652)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add controller for hdbt cookie banner

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8652`
* Run `make drush-updb drush-cr`'
* Run `drush en -y hdbt_cookie_banner`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check out `/admin/structure/hdbt-cookie-banner`
* [x] Check out `/api/cookie-banner`
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-8652]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ