### PR TITLE
UHF-9101: Added Unit contact card to Standard page and Landing page

### DIFF
--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -381,9 +381,9 @@ function helfi_tpr_config_update_9052() : void {
 }
 
 /**
- * UHF-10191 Change the unit default displays to use new image styles.
+ * UHF-9101 Add "Unit contact card" to standard page and landing page.
  */
-function helfi_tpr_config_update_9068(): void {
+function helfi_tpr_config_update_9069(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -125,11 +125,13 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
           'content_liftup' => 12,
           'service_list_search' => 16,
           'unit_search' => 17,
+          'unit_contact_card' => 18,
         ],
         'field_lower_content' => [
           'content_liftup' => 12,
           'service_list_search' => 16,
           'unit_search' => 17,
+          'unit_contact_card' => 18,
         ],
       ],
       'landing_page' => [
@@ -138,6 +140,7 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
           'service_list' => 15,
           'service_list_search' => 16,
           'unit_search' => 17,
+          'unit_contact_card' => 18,
         ],
       ],
     ],


### PR DESCRIPTION
# [UHF-9101](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9101)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added Unit contact card to Standard page and Landing page

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9101`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Login and go to add/edit standard page and landing page. Check that you can add Unit contact card paragraph in to standard page upper and lower content areas and in to landing page content area.

     ![image](https://github.com/user-attachments/assets/6f73a7b1-2f4a-493a-bce6-a9a76d31eece)

* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This feature has been documented/the documentation has been updated
   * Updated Paragraph/component information to "Hel.fi components google sheet"
* [ ] This change doesn't require updates to the documentation



[UHF-9101]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ