### PR TITLE
UHF-10543: added patch fixing the problem which prevents saving content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,8 @@
                 "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2023-12-19/2313309-179.patch",
                 "[#UHF-9388] Process configuration translation files for custom modules (https://www.drupal.org/i/2845437)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fd68277191b8f8ec290e53b5fbbae699b2260384/patches/drupal-2845437-process-custom-module-translation-config-10.3.x.patch",
                 "[#UHF-9690] Allow updating lists when switching from allowed values to allowed values function (https://www.drupal.org/i/2873353)": "https://www.drupal.org/files/issues/2021-05-18/allow-allowed-values-function-update-D9-2873353_1.patch",
-                "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "https://www.drupal.org/files/issues/2024-08-08/3083786--mr-8066--10-3-backport.patch"
+                "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "https://www.drupal.org/files/issues/2024-08-08/3083786--mr-8066--10-3-backport.patch",
+                "[UHF-10543] issue https://www.drupal.org/project/drupal/issues/3285657": "https://www.drupal.org/files/issues/2022-06-14/core9.2-node-lock-translations-2744851.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"


### PR DESCRIPTION
# [UHF-10543](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10543)
Cannot save content due to error.

## What was done
Added a patch which fixes the error.

## How to install (ETUSIVU)
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10543`
* Run `make drush-updb drush-cr`

## How to recreate and test in etusivu
- Setup etusivu with production database
- Drush uli --uid=47
- Edit node 6756 english translation, set as published and save
When the patch is applied, you can save the content
When patch is not applied, an error occurs

## Original testing instructions (when drafts are in use)
- Create Finnish basic page, set “Save as: Published”
- Edit the Finnish page, set “Save as: Draft”
- Add English translation, set “Save as: Published”.
When broken:
- Attempt to publish the Finnish draft. You should see error: “The content has either been modified by another user, or you have already submitted modifications. As a result, your changes cannot be saved.”
When fixed: 
- Content is saved successfully


[UHF-10543]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ