### PR TITLE
UHF-10554: Fix announcements and surveys for alt languages

### DIFF
--- a/modules/helfi_etusivu_entities/README.md
+++ b/modules/helfi_etusivu_entities/README.md
@@ -3,6 +3,10 @@
 Remote entities module allows fetching announcements from `Etusivu`-instance.
 It utilizes `json-api` and `external_entities`-module to transfer the data between instances.
 
+## Language support
+
+If current language is not in [default languages](https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/default-languages.md), remote entities use fallback language. Alt languages show local announcements in current language (if translated) and in English.
+
 ## How to set up locally
 
 Local setup requires Etusivu-instance to be up and running with some relevant data created to it.


### PR DESCRIPTION
# [UHF-10554](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10554)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix announcements and surveys for alt languages.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10554`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10554]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ