### PR TITLE
UHF-X Do not load unnecessary css files during Askem load

### DIFF
--- a/assets/js/reactAndShareSettings.js
+++ b/assets/js/reactAndShareSettings.js
@@ -4,7 +4,9 @@
   var loadReactAndShare = function () {
     if (Drupal.eu_cookie_compliance.hasAgreed('statistics')) {
       window.rnsData = {
-        apiKey: drupalSettings.reactAndShareApiKey
+        apiKey: drupalSettings.reactAndShareApiKey,
+        disableFa: true,
+        disableFonts: true,
       };
 
       if (drupalSettings.siteName !== undefined) {


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Added settings from https://docs.reactandshare.com/#default-fonts to prevent the loading of Font Awesome and Open sans css files

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-0000_insert_correct_branch`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Setup Askem on your local (ask @khalima if you need help)
* [x] Check that the Askem design still works and the following CSS files are not loaded when `rns.js` file gets loaded.
   ![image](https://github.com/user-attachments/assets/224414b2-1331-47db-94db-e26ab2bd123d)
* [x] Check that code follows our standards
