### PR TITLE
UHF-8670 Hero image author

### DIFF
--- a/modules/hdbt_admin_tools/src/Plugin/Field/FieldType/SelectIcon.php
+++ b/modules/hdbt_admin_tools/src/Plugin/Field/FieldType/SelectIcon.php
@@ -15,7 +15,7 @@ use Drupal\Core\TypedData\DataDefinition;
  * @FieldType(
  *   id = "select2_icon",
  *   label = @Translation("Select Icon"),
- *   category = @Translation("Helfi"),
+ *   category = "Helfi",
  *   default_widget = "select_icon_widget",
  *   default_formatter = "select_icon_formatter"
  * )

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -196,15 +196,16 @@ function _helfi_media_remote_video_remote_video_url_handler(string $video_url): 
   // Try to convert the URL if it's of form 'player/event/view'.
   if (str_contains($video_url, 'player/event/view')) {
     preg_match('/helsinkikanava.fi\/((?i)[a-z]{2})/', $video_url, $language_matches);
-    $lang_code = $language_matches[1];
+    // Default to 'fi' if no match.
+    $lang_code = $language_matches[1] ?? 'fi';
     preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
-    $asset_id = $asset_id_matches[1];
+    $asset_id = $asset_id_matches[1] ?? NULL;
 
     if (empty($asset_id)) {
       return FALSE;
     }
 
-    $lang_code = empty($lang_code) ? 'fi' : $lang_code;
+    // Assemble the converted URL.
     $url_parts = explode('*', $helsinki_kanava_url_pattern);
     $converted_url = $url_parts[0] . $lang_code . $url_parts[1] . $asset_id;
   }

--- a/modules/helfi_paragraphs_hero/helfi_paragraphs_hero.module
+++ b/modules/helfi_paragraphs_hero/helfi_paragraphs_hero.module
@@ -41,3 +41,12 @@ function helfi_paragraphs_hero_design_allowed_values(FieldStorageDefinitionInter
   $moduleHandler->alter('helfi_hero_design', $designs, $definition, $entity);
   return $designs;
 }
+
+/**
+ * Implements hook_preprocess().
+ */
+function helfi_paragraphs_hero_preprocess_paragraph__hero(array &$variables): void {
+  $paragraph = $variables['paragraph'];
+  assert($paragraph instanceof Hero);
+  $variables['image_author'] = $paragraph->getImageAuthor();
+}

--- a/modules/helfi_paragraphs_hero/tests/modules/helfi_paragraphs_hero_test/helfi_paragraphs_hero_test.info.yml
+++ b/modules/helfi_paragraphs_hero/tests/modules/helfi_paragraphs_hero_test/helfi_paragraphs_hero_test.info.yml
@@ -1,0 +1,3 @@
+name: 'Helfi Paragraphs Hero Test'
+core_version_requirement: '^10 || ^11'
+type: module

--- a/modules/helfi_paragraphs_hero/tests/modules/helfi_paragraphs_hero_test/helfi_paragraphs_hero_test.module
+++ b/modules/helfi_paragraphs_hero/tests/modules/helfi_paragraphs_hero_test/helfi_paragraphs_hero_test.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains test alter for helfi_paragraphs_hero.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_helfi_hero_design_alter().
+ */
+function helfi_paragraphs_hero_test_helfi_hero_design_alter(array &$designs) {
+  $designs['test-design'] = t('Test design');
+}

--- a/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroDesignAllowedValuesAlterTest.php
+++ b/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroDesignAllowedValuesAlterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\Tests\helfi_paragraphs_hero\Kernel;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests allowed values alter for hero design.
+ *
+ * @group helfi_paragraphs_hero
+ */
+class HeroDesignAllowedValuesAlterTest extends KernelTestBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_paragraphs_hero',
+    'helfi_paragraphs_hero_test',
+    'field',
+    'entity',
+    'user',
+  ];
+
+  /**
+   * Test the hero design allowed values alter.
+   */
+  public function testHeroDesignAlter() {
+    // Load the required definition and entity mocks.
+    $definition = $this->createMock(FieldStorageDefinitionInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    // Call the allowed designs function.
+    $allowed_designs = helfi_paragraphs_hero_design_allowed_values($definition, $entity);
+
+    // Call the function that triggers the drupal_alter.
+    helfi_paragraphs_hero_test_helfi_hero_design_alter($allowed_designs);
+
+    // Define the expected outcome after the alter hook.
+    $expected_designs = $allowed_designs + ['test-design' => $this->t('Test design')];
+
+    // Assert that the design data has been altered as expected.
+    $this->assertEquals($expected_designs, $allowed_designs);
+  }
+
+}

--- a/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroDesignAllowedValuesTest.php
+++ b/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroDesignAllowedValuesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\Tests\helfi_paragraphs_hero\Kernel;
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests allowed values for hero design.
+ *
+ * @group helfi_paragraphs_hero
+ */
+class HeroDesignAllowedValuesTest extends KernelTestBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_paragraphs_hero',
+    'field',
+    'entity',
+    'user',
+  ];
+
+  /**
+   * Test the hero design allowed values function.
+   */
+  public function testAllowedValues() {
+    // Load the required definition and entity mocks.
+    $definition = $this->createMock(FieldStorageDefinitionInterface::class);
+    $entity = $this->createMock(FieldableEntityInterface::class);
+
+    // Call the allowed designs function.
+    $allowed_designs = helfi_paragraphs_hero_design_allowed_values($definition, $entity);
+
+    // Define the expected allowed designs.
+    $expected_designs = [
+      'without-image-left' => $this->t('Without image, align left'),
+      'with-image-right' => $this->t('Image on the right'),
+      'with-image-left' => $this->t('Image on the left'),
+      'with-image-bottom' => $this->t('Image on the bottom'),
+      'diagonal' => $this->t('Diagonal'),
+    ];
+
+    // Assert that the allowed values match the expected values.
+    $this->assertEquals($expected_designs, $allowed_designs);
+  }
+
+}

--- a/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroParagraphTest.php
+++ b/modules/helfi_paragraphs_hero/tests/src/Kernel/HeroParagraphTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_paragraphs_hero\Kernel\Entity;
+
+use Drupal\file\Entity\File;
+use Drupal\helfi_paragraphs_hero\Entity\Hero;
+use Drupal\media\Entity\Media;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\Tests\helfi_paragraphs_hero\Kernel\KernelTestBase;
+
+/**
+ * Tests Hero installation.
+ *
+ * @coversDefaultClass \Drupal\helfi_paragraphs_hero\Entity\Hero
+ * @group helfi_paragraphs_hero
+ */
+class HeroParagraphTest extends KernelTestBase {
+
+  /**
+   * Tests that paragraph uses proper bundle class.
+   */
+  public function testBundleClass() : void {
+    $defaults = [
+      'type' => 'hero',
+      'field_hero_title' => 'Hero title',
+      'field_hero_desc' => 'Hero description',
+      'field_hero_image' => NULL,
+      'field_hero_design' => 'with-image-left',
+    ];
+
+    $paragraph = Paragraph::create($defaults);
+    $paragraph->save();
+
+    $this->assertInstanceOf(Hero::class, $paragraph);
+    $this->assertEquals($defaults['field_hero_title'], $paragraph->getTitle());
+    $this->assertEquals($defaults['field_hero_desc'], $paragraph->getDescription());
+    $this->assertEquals($defaults['field_hero_image'], $paragraph->getImage());
+    $this->assertEquals($defaults['field_hero_design'], $paragraph->getDesign());
+  }
+
+  /**
+   * Test the getImageAuthor method when no image exists.
+   */
+  public function testGetImageAuthorNoImageExists(): void {
+    /** @var \Drupal\helfi_paragraphs_hero\Entity\Hero $hero_paragraph */
+    $hero_paragraph = Paragraph::create([
+      'type' => 'hero',
+      'field_hero_image' => NULL,
+    ]);
+    $this->assertFalse($hero_paragraph->getImageAuthor());
+  }
+
+  /**
+   * Test the getImageAuthor method when image author is empty.
+   */
+  public function testGetImageAuthorWhenAuthorEmpty(): void {
+    $image = $this->createMediaEntityWithVirtualFile('', 'public://virtual-file.jpg');
+
+    /** @var \Drupal\helfi_paragraphs_hero\Entity\Hero $hero_paragraph */
+    $hero_paragraph = Paragraph::create([
+      'type' => 'hero',
+      'field_hero_image' => [
+        'target_id' => $image->id(),
+      ],
+    ]);
+    $this->assertFalse(
+      $hero_paragraph->getImageAuthor(),
+      'Image exists, but image author is empty, getImageAuthor() returns FALSE.'
+    );
+  }
+
+  /**
+   * Test the getImageAuthor method when image author exists.
+   */
+  public function testGetImageAuthor(): void {
+    $image = $this->createMediaEntityWithVirtualFile('Ken Smith', 'public://virtual-file.jpg');
+
+    /** @var \Drupal\helfi_paragraphs_hero\Entity\Hero $hero_paragraph */
+    $hero_paragraph = Paragraph::create([
+      'type' => 'hero',
+      'field_hero_image' => [
+        'target_id' => $image->id(),
+      ],
+    ]);
+
+    $image_author = $hero_paragraph->getImageAuthor();
+    $this->assertInstanceOf(
+      '\Drupal\Core\StringTranslation\TranslatableMarkup',
+      $image_author,
+      'Image author is returned as TranslatableMarkup.'
+    );
+    $this->assertEquals(
+      'Image: Ken Smith',
+      $image_author->render(),
+      'Image author text is correctly returned.'
+    );
+  }
+
+  /**
+   * Helper function to create a media entity with a virtual file.
+   *
+   * @param string $photographer
+   *   The photographer name.
+   * @param string $file_uri
+   *   The URI of the virtual file.
+   *
+   * @return \Drupal\media\Entity\Media
+   *   The created media entity.
+   */
+  protected function createMediaEntityWithVirtualFile(string $photographer, string $file_uri): Media {
+    // Create a file entity using a virtual file path.
+    $file = File::create([
+      'uri' => $file_uri,
+      'status' => 1,
+    ]);
+    $file->save();
+
+    // Create the media entity and associate the file.
+    $image = Media::create([
+      'bundle' => 'image',
+      'status' => TRUE,
+      'field_media_image' => [
+        'target_id' => $file->id(),
+        'alt' => 'alt text',
+      ],
+      'field_photographer' => [
+        ['value' => $photographer],
+      ],
+      'langcode' => 'en',
+    ]);
+    $image->save();
+    return $image;
+  }
+
+}

--- a/modules/helfi_paragraphs_hero/tests/src/Kernel/KernelTestBase.php
+++ b/modules/helfi_paragraphs_hero/tests/src/Kernel/KernelTestBase.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_paragraphs_hero\Kernel;
+
+use Drupal\KernelTests\KernelTestBase as CoreKernelTestBase;
+
+/**
+ * Kernel test base for news feed list tests.
+ */
+class KernelTestBase extends CoreKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'allowed_formats',
+    'content_translation',
+    'crop',
+    'entity',
+    'field',
+    'file',
+    'filter',
+    'focal_point',
+    'hdbt_admin_tools',
+    'helfi_media',
+    'helfi_paragraphs_hero',
+    'image',
+    'language',
+    'link',
+    'linkit',
+    'media',
+    'media_library',
+    'options',
+    'paragraphs',
+    'responsive_image',
+    'system',
+    'text',
+    'user',
+    'views',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig(['system', 'paragraphs']);
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('paragraph');
+    $this->installEntitySchema('paragraphs_type');
+    $this->installEntitySchema('media');
+    $this->installEntitySchema('media_type');
+    $this->installEntitySchema('language_content_settings');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('crop');
+    $this->installEntitySchema('crop_type');
+    $this->installSchema('file', ['file_usage']);
+
+    $this->installConfig([
+      'media',
+      'image',
+      'media_library',
+      'crop',
+      'focal_point',
+      'helfi_media',
+      'helfi_paragraphs_hero',
+      'hdbt_admin_tools',
+      'filter',
+    ]);
+  }
+
+}

--- a/modules/helfi_paragraphs_hero/translations/fi.po
+++ b/modules/helfi_paragraphs_hero/translations/fi.po
@@ -15,3 +15,7 @@ msgstr "Kuva alhaalla"
 
 msgid "Diagonal"
 msgstr "Diagonaalinen"
+
+msgctxt "Helfi Paragraphs Hero"
+msgid "Image: @image_author"
+msgstr "Kuva: @image_author"

--- a/modules/helfi_paragraphs_hero/translations/sv.po
+++ b/modules/helfi_paragraphs_hero/translations/sv.po
@@ -15,3 +15,7 @@ msgstr "Bild justerad ner"
 
 msgid "Diagonal"
 msgstr "Diagonal"
+
+msgctxt "Helfi Paragraphs Hero"
+msgid "Image: @image_author"
+msgstr "Bild: @image_author"


### PR DESCRIPTION
# [UHF-8670](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8670)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added getter methods to Hero bundle class for getting image, image author, description and title.
* Added a preprocess for the Hero paragraph and added the image_author variable for the templates.
* Added translations for image author field.
* Fixed deprecated translatable string for category field.
* Added tests for Hero bundle class and Hero design alter function.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config and the HDBT theme
    * `composer require drupal/helfi_platform_config:dev-UHF-8670 drupal/hdbt:dev-UHF-8670`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to some page with Hero and check that the image author text has appeared. See screenshot below. 

   ![image](https://github.com/user-attachments/assets/a6993f2d-4f1d-4f06-b85a-51a0549f9826)
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1051


[UHF-8670]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ