### PR TITLE
UHF-9509: Made unit_contact_card addable to paragraphs library

### DIFF
--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -387,3 +387,11 @@ function helfi_tpr_config_update_9069(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-9509 Add "Unit contact card" to paragraphs library.
+ */
+function helfi_tpr_config_update_9070(): void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}

--- a/modules/helfi_tpr_config/helfi_tpr_config.module
+++ b/modules/helfi_tpr_config/helfi_tpr_config.module
@@ -149,6 +149,7 @@ function helfi_tpr_config_helfi_paragraph_types() : array {
         'paragraphs' => [
           'unit_search' => 0,
           'service_list' => 0,
+          'unit_contact_card' => 0,
         ],
       ],
     ],


### PR DESCRIPTION
# [UHF-9509](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9509)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Made unit_contact_card addable to paragraphs library.

## How to install
* Check installation instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/302)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check testing instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/302)
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/817
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/302

[UHF-9509]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ