### PR TITLE
UHF-10461: Add support for language direction by rewriting whole editor.

### DIFF
--- a/modules/hdbt_cookie_banner/assets/css/cookie-banner-admin-ui.css
+++ b/modules/hdbt_cookie_banner/assets/css/cookie-banner-admin-ui.css
@@ -83,3 +83,7 @@ textarea.error {
 .je-object__container:has(:not([style*="display: none;"])>p[style="color: red;"]) > .je-object__title{
   color: red;
 }
+
+input:not(:disabled) ~ .save-notice {
+  display: none;
+}

--- a/modules/hdbt_cookie_banner/assets/css/cookie-banner-admin-ui.css
+++ b/modules/hdbt_cookie_banner/assets/css/cookie-banner-admin-ui.css
@@ -71,3 +71,15 @@ textarea {
   width: 100%;
   height: 90dvh;
 }
+
+textarea.error {
+  border-color: #d9534f!important;
+}
+
+.alert-heading {
+  margin: 0;
+}
+
+.je-object__container:has(:not([style*="display: none;"])>p[style="color: red;"]) > .je-object__title{
+  color: red;
+}

--- a/modules/hdbt_cookie_banner/assets/js/cookie-banner-admin-ui.js
+++ b/modules/hdbt_cookie_banner/assets/js/cookie-banner-admin-ui.js
@@ -8,6 +8,7 @@
         bannerElement: document.getElementById('editor_holder'),
         errorHolderElement: document.getElementById('error_holder'),
         errorHolderElement2: document.getElementById('error_holder2'),
+        errorHolderElement3: document.getElementById('error_holder3'),
         editorOptions: {
           theme: 'bootstrap3',
           iconlib: 'bootstrap',
@@ -24,6 +25,7 @@
           { "code": "sv", "name": "Swedish", "direction": "ltr" },
           { "code": "en", "name": "English", "direction": "ltr" }
         ],
+        saveButton: document.querySelector('#edit-submit'),
       };
 
       // state used in the script
@@ -57,8 +59,15 @@
       function updateErrors() {
         const errors = [...state.textareaErrors, ...state.editorErrors];
         if (errors.length === 0) {
-          config.errorHolderElement.innerHTML = '';
-          config.errorHolderElement2.innerHTML = '';
+          if(config.errorHolderElement){
+            config.errorHolderElement.innerHTML = '';
+          }
+          if(config.errorHolderElement2){
+            config.errorHolderElement2.innerHTML = '';
+          }
+          if(config.errorHolderElement3){
+            config.errorHolderElement3.innerHTML = '';
+          }
           config.textarea.classList.remove('error');
           return;
         }
@@ -74,8 +83,15 @@
           </ul>
         </div>`;
 
-        config.errorHolderElement.innerHTML = errorSummary;
-        config.errorHolderElement2.innerHTML = errorSummary;
+        if(config.errorHolderElement){
+          config.errorHolderElement.innerHTML = errorSummary;
+        }
+        if(config.errorHolderElement2){
+          config.errorHolderElement2.innerHTML = errorSummary;
+        }
+        if(config.errorHolderElement3){
+          config.errorHolderElement3.innerHTML = errorSummary;
+        }
         if (state.textareaErrors.length > 0) {
           config.textarea.classList.add('error');
         } else {
@@ -219,6 +235,20 @@
       }
 
       /**
+       * Function to disable or enable the submit button
+       * @param {boolean} disable Should the submit button be disabled or enabled
+       */
+      function toggleSubmitButton(disable) {
+        if (disable) {
+          config.saveButton.disabled = true;  // Disable the button
+          config.saveButton.style.display = 'none'; // Hide the button
+        } else {
+          config.saveButton.disabled = false; // Enable the button
+          config.saveButton.style.display = ''; // Hide the button
+        }
+      }
+
+      /**
        * Initializes the editor on page load
        */
       function initialize() {
@@ -245,6 +275,24 @@
         initializeBannerEditor(state.jsonValue);
 
         config.textarea.addEventListener('input', debounce(textareaChangeHandler, 100));
+
+        config.bannerElement.addEventListener('focusin', function(event) {
+          // Disable the save button when an input element receives focus
+          if (event.target.matches('input, select, textarea')) {
+            toggleSubmitButton(true);
+          }
+        });
+
+        config.bannerElement.addEventListener('focusout', function(event) {
+          // Enable the save button when an input element loses focus
+          if (event.target.matches('input, select, textarea')) {
+            toggleSubmitButton(false);
+          }
+        });
+
+        const saveNotice = config.saveButton.insertAdjacentElement('afterend', document.createElement('p'));
+        saveNotice.classList.add('save-notice');
+        saveNotice.innerText = 'Click here to unfocus the input and to see Save-button.';
       }
 
       // Initialize the editor once the page has loaded

--- a/modules/hdbt_cookie_banner/assets/js/cookie-banner-admin-ui.js
+++ b/modules/hdbt_cookie_banner/assets/js/cookie-banner-admin-ui.js
@@ -60,7 +60,6 @@
           config.errorHolderElement.innerHTML = '';
           config.errorHolderElement2.innerHTML = '';
           config.textarea.classList.remove('error');
-          console.log('No errors found');
           return;
         }
         const errorSummary = `
@@ -75,25 +74,6 @@
           </ul>
         </div>`;
 
-        // const errorSummary = `
-        // <section aria-label="Errors found" class="hds-notification hds-notification--error">
-        //   <div class="hds-notification__content">
-        //     <div class="hds-notification__label" role="heading" aria-level="2" tabindex="-1">
-        //       <span class="hds-icon hds-icon--error-fill" aria-hidden="true"></span>
-        //       <span>Errors found</span>
-        //     </div>
-        //     <div class="hds-notification__body hds-error-summary__body">
-        //       <ul>
-        //         ${ errors.map((error, index) => `<li>Error ${index + 1}: ${
-        //           (error.message) ?
-        //             `<a href="#editor_holder" onclick="window.scrollIntoError(event, '${error.path}', true);">${error.message}</a>` :
-        //             `<a href="#editor_holder" onclick="window.scrollIntoError(event, '#edit-site-settings', false);">${error}</a>`
-        //           }</li>`).join('') }
-        //       </ul>
-        //     </div>
-        //   </div>
-        // </section>
-        // `;
         config.errorHolderElement.innerHTML = errorSummary;
         config.errorHolderElement2.innerHTML = errorSummary;
         if (state.textareaErrors.length > 0) {
@@ -101,7 +81,6 @@
         } else {
           config.textarea.classList.remove('error');
         }
-        console.log('Errors found:', errors);
       }
 
       /**
@@ -193,21 +172,17 @@
        * Handles changes in the banner editor
        */
       function bannerChangeHandler() {
-        // console.log('bannerEditor onChange');
         const errors = state.bannerEditor.validate();
         state.editorErrors = errors;
         updateErrors();
         if (errors.length) {
-          console.error('Not updating textarea due to invalid configuration:', errors);
+          console.error('Not updating textarea due to invalid configuration');
           return;
         }
 
         const updatedVal = state.bannerEditor.getValue();
 
-        // console.log('bannerEditor onChange checking for changes in languages:', state.languages, updatedVal.languages);
-
         if (JSON.stringify(state.languages) !== JSON.stringify(updatedVal.languages)) {
-          // console.log('bannerEditor onChange languages changed:', state.languages, updatedVal.languages);
           state.languages = updatedVal.languages;
           state.schema = updateSchema(state.languages, state.schema);
 
@@ -225,9 +200,7 @@
           const updatedVal = JSON.parse(config.textarea.value);
           state.textareaErrors = [];
 
-          // console.log('textarea input checking for changes in languages:', languages, updatedVal.languages);
           if (JSON.stringify(state.languages) !== JSON.stringify(updatedVal.languages)) {
-            // console.log('bannerEditor onChange languages changed:', state.languages, updatedVal.languages);
             state.languages = updatedVal.languages;
             state.schema = updateSchema(state.languages, state.schema);
 

--- a/modules/hdbt_cookie_banner/assets/json/siteSettings.schema.json
+++ b/modules/hdbt_cookie_banner/assets/json/siteSettings.schema.json
@@ -6,15 +6,18 @@
       "properties": {
         "fi": {
           "type": "string",
-          "title": "fi (Finnish)"
+          "title": "fi (Finnish)",
+          "minLength": 1
         },
         "sv": {
           "type": "string",
-          "title": "sv (Swedish)"
+          "title": "sv (Swedish)",
+          "minLength": 1
         },
         "en": {
           "type": "string",
-          "title": "en (English)"
+          "title": "en (English)",
+          "minLength": 1
         }
       },
       "required": [
@@ -180,13 +183,61 @@
       ]
     }
   },
-  "title": "Site settings",
-  "description": "Configure HDS cookie banner settings.json to adjust allowed cookies, translations and other features.",
+  "title": "Cookie banner site settings",
+  "description": "This tool helps you configure HDS cookie banner for your site. You can still copy and edit the raw JSON if you wish to using the textarea.",
   "options": {
     "disable_collapse": true
   },
   "type": "object",
   "properties": {
+    "languages": {
+      "title": "Supported languages",
+      "description": "List all languages you wish banner to support.",
+      "type": "array",
+      "format": "table",
+      "options": {
+        "disable_collapse": true
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "minLength": 2,
+            "title": "Code (eg. \"fi\")"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name (ex. \"Finnish\")"
+          },
+          "direction": {
+            "type": "string",
+            "title": "(Reading) direction",
+            "enum": [
+              "ltr",
+              "rtl"
+            ],
+            "options": {
+              "enum_titles": [
+                "ltr (Left to right)",
+                "rtl (Right to left)"
+              ]
+            },
+            "default": "ltr",
+            "pattern": "(ltr|rtl)"
+          }
+        },
+        "required": [
+          "code",
+          "name",
+          "direction"
+        ],
+        "title": "Language"
+      },
+      "uniqueItems": true,
+      "minItems": 1
+    },
     "siteName": {
       "description": "Name of the website the cookie banner is running in.",
       "title": "Website name",
@@ -820,6 +871,7 @@
     }
   },
   "required": [
+    "languages",
     "siteName",
     "cookieName",
     "requiredGroups",

--- a/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
+++ b/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
@@ -117,7 +117,7 @@ final class HdbtCookieBannerForm extends ConfigFormBase {
 
     $form['json_editor_container']['json_editor'] = [
       '#type' => 'item',
-      '#markup' => '<div class="json_editor"><h1>HDS Cookie Consent Settings</h1><div id="language_holder"></div><div id="editor_holder"></div></div>',
+      '#markup' => '<div class="json_editor"><h1>HDS Cookie Consent Settings</h1><div id="error_holder"></div><div id="editor_holder"></div><div id="error_holder2"></div>',
       '#attached' => [
         'library' => [
           'hdbt_cookie_banner/cookie_banner_admin_ui',

--- a/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
+++ b/modules/hdbt_cookie_banner/src/Form/HdbtCookieBannerForm.php
@@ -165,6 +165,11 @@ final class HdbtCookieBannerForm extends ConfigFormBase {
       '#rows' => 5,
     ];
 
+    $form['editor_holder'] = [
+      '#type' => 'item',
+      '#markup' => '<div id="error_holder3"></div>',
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 


### PR DESCRIPTION
# [UHF-10461](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10461)
<!-- What problem does this solve? -->

* Cookie banner did not support language directions or language attributes for screen readers 
* The editor did not save language options properly to json, so adding languages was inpossible.

## What was done
<!-- Describe what was done -->

* Whole editor was rewritten
* json syntax was updated
* banner code was updated

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10461_fixed_cookie_banner_editor`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10461]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ