### PR TITLE
UHF-8650: Switch react and share to use hds cookie banner

### DIFF
--- a/assets/js/reactAndShareSettings.js
+++ b/assets/js/reactAndShareSettings.js
@@ -2,9 +2,7 @@
   'use strict';
 
   var loadReactAndShare = function () {
-    // @todo UHF-8650: EU Cookie Compliance module will be removed.
-    // @todo UHF-8650: Convert the following code to support HDS cookie banner.
-    if (Drupal.eu_cookie_compliance.hasAgreed('statistics')) {
+    if (window && window.hds.cookieConsent && window.hds.cookieConsent.getConsentStatus(['statistics'])) {
       window.rnsData = {
         apiKey: drupalSettings.reactAndShareApiKey,
         disableFa: true,
@@ -32,11 +30,9 @@
     loadReactAndShare = function () {};
   };
 
-  // Run after choosing cookie settings.
-  $(document).on('eu_cookie_compliance.changeStatus', loadReactAndShare);
-
-  // Run after page is ready.
-  $(document).ready(function () {
+  if (window.hds.cookieConsent) {
     loadReactAndShare();
-  });
+  } else {
+    $(document).on('hds_cookieConsent_ready', loadReactAndShare);
+  }
 })(jQuery, Drupal);


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->
* We want to use new cookie banner

## What was done
<!-- Describe what was done -->

* React and share was switched to new cookie banner


## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8650_cookie_banner_activation`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that react and share works with new cookie banner
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1080


[UHF-8650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ