### PR TITLE
UHF-9511 Content liftup entities

### DIFF
--- a/modules/helfi_paragraphs_content_liftup/helfi_paragraphs_content_liftup.install
+++ b/modules/helfi_paragraphs_content_liftup/helfi_paragraphs_content_liftup.install
@@ -7,10 +7,28 @@
 
 declare(strict_types=1);
 
+use Drupal\paragraphs\Entity\Paragraph;
+
 /**
  * Implements hook_uninstall().
  */
 function helfi_paragraphs_content_liftup_uninstall(): void {
+  // Remove stale content liftup paragraph entities.
+  $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->condition('type', 'content_liftup')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if (!empty($paragraph_ids)) {
+    // Load the paragraphs.
+    $paragraphs = Paragraph::loadMultiple($paragraph_ids);
+
+    // Delete the paragraphs.
+    foreach ($paragraphs as $paragraph) {
+      $paragraph->delete();
+    }
+  }
+
   $config_factory = Drupal::configFactory();
 
   // The configurations to remove.

--- a/modules/helfi_paragraphs_content_liftup/helfi_paragraphs_content_liftup.install
+++ b/modules/helfi_paragraphs_content_liftup/helfi_paragraphs_content_liftup.install
@@ -7,28 +7,10 @@
 
 declare(strict_types=1);
 
-use Drupal\paragraphs\Entity\Paragraph;
-
 /**
  * Implements hook_uninstall().
  */
 function helfi_paragraphs_content_liftup_uninstall(): void {
-  // Remove stale content liftup paragraph entities.
-  $paragraph_ids = \Drupal::entityQuery('paragraph')
-    ->condition('type', 'content_liftup')
-    ->accessCheck(FALSE)
-    ->execute();
-
-  if (!empty($paragraph_ids)) {
-    // Load the paragraphs.
-    $paragraphs = Paragraph::loadMultiple($paragraph_ids);
-
-    // Delete the paragraphs.
-    foreach ($paragraphs as $paragraph) {
-      $paragraph->delete();
-    }
-  }
-
   $config_factory = Drupal::configFactory();
 
   // The configurations to remove.

--- a/modules/helfi_platform_config_base/helfi_platform_config_base.install
+++ b/modules/helfi_platform_config_base/helfi_platform_config_base.install
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\paragraphs\Entity\Paragraph;
+
 /**
  * Implements hook_install().
  */
@@ -86,6 +88,24 @@ function helfi_platform_config_base_update_9002() : void {
  * UHF-9511 Uninstall content_liftup paragraph.
  */
 function helfi_platform_config_base_update_9003() : void {
+
+  // Remove stale content liftup paragraph entities.
+  $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->condition('type', 'content_liftup')
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if (!empty($paragraph_ids)) {
+    // Load the paragraphs.
+    $paragraphs = Paragraph::loadMultiple($paragraph_ids);
+
+    // Delete the paragraphs.
+    foreach ($paragraphs as $paragraph) {
+      $paragraph->delete();
+    }
+  }
+
+  // Uninstall helfi_paragraphs_content_liftup module.
   $module_installer = Drupal::service('module_installer');
   $module_installer->uninstall(['helfi_paragraphs_content_liftup']);
 


### PR DESCRIPTION
# [UHF-9511](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9511)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove stale content liftup paragraph entities before uninstalling the paragraph type

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9511_content_liftup_entities`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that uninstalling content liftup works, even if there are still content liftup paragraph entities in the db
* [ ] Check that code follows our standards


[UHF-9511]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ