### PR TITLE
UHF-10259: Curated event list modules on core sites only

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -186,6 +186,15 @@ function helfi_platform_config_update_9312() : void {
  * UHF-10259: Enable helfi_paragraphs_curated_event_list module.
  */
 function helfi_platform_config_update_9313() : void {
+  $environmentResolver = \Drupal::getContainer()->get('helfi_api_base.environment_resolver');
+
+  try {
+    $environmentResolver->getActiveEnvironment();
+  }
+  catch (\InvalidArgumentException) {
+    return;
+  }
+
   $module_installer = \Drupal::service('module_installer');
 
   // Enable helfi_paragraphs_curated_event_list.


### PR DESCRIPTION
# [UHF-10259](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10259)
Follow up fix for non-core sites

## What was done
Added logic to only turn on curated event list module for core sites.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10259-curated-event-list`
* Run `make drush-updb drush-cr`

