### PR TITLE
UHF-8650 Config ignore fix

### DIFF
--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.install
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.install
@@ -32,3 +32,20 @@ function hdbt_cookie_banner_install($is_syncing) : void {
   // Grant required permissions.
   hdbt_cookie_banner_grant_permissions();
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function hdbt_cookie_banner_uninstall(): void {
+  $config_factory = Drupal::configFactory();
+
+  // The configurations to remove.
+  $configurations = [
+    'hdbt_cookie_banner.settings',
+  ];
+
+  // Remove each installed configuration.
+  foreach ($configurations as $config) {
+    $config_factory->getEditable($config)->delete();
+  }
+}

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -7,8 +7,8 @@
 
 declare(strict_types=1);
 
-use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm;
 
 /**

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -7,14 +7,37 @@
 
 declare(strict_types=1);
 
+use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\hdbt_cookie_banner\Form\HdbtCookieBannerForm;
 
 /**
- * Implements hook_config_ignore_settings_alter().
+ * Implements hook_config_ignore_ignored_alter().
  */
-function hdbt_cookie_banner_config_ignore_settings_alter(array &$settings): void {
-  $settings[] = HdbtCookieBannerForm::SETTINGS;
+function hdbt_cookie_banner_config_ignore_ignored_alter(ConfigIgnoreConfig $ignored): void {
+  $settings_to_ignore = [
+    'site_settings',
+    'use_custom_settings',
+    'use_internal_hds_cookie_js',
+    'hds_cookie_js_override',
+  ];
+
+  $settings_to_ignore = array_map(
+    fn($setting) => HdbtCookieBannerForm::SETTINGS . ':' . $setting,
+    $settings_to_ignore,
+  );
+
+  // Add the configuration objects to the ignore list, but retain the
+  // hdbt_cookie_banner.settings.
+  foreach (['create', 'update', 'delete'] as $operation) {
+    foreach (['import', 'export'] as $direction) {
+      $list = array_merge(
+        $ignored->getList($direction, $operation),
+        $settings_to_ignore,
+      );
+      $ignored->setList($direction, $operation, $list);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
# [UHF-8650](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added uninstall hook to remove the module settings file when module is uninstalled.
* Switched the deprecated `config_ignore_settings_alter` to `config_ignore_ignored_alter`. Ignored only the config objects in the `hdbt_cookie_banner.settings.yml`. Otherwise uninstallation or revert would not work.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8650_config_ignore_fix`
* Run `make shell`


## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run `drush en -y hdbt_cookie_banner` and `drush cex -y`
* [ ] Check that the `cookie_banner.settings.yml` is exported to `conf/cmi`
* [ ] Check that code follows our standards


[UHF-8650]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ