### PR TITLE
UHF-8340: Changed remote video title to be required

### DIFF
--- a/modules/helfi_paragraphs_remote_video/config/install/field.field.paragraph.remote_video.field_remote_video_video_title.yml
+++ b/modules/helfi_paragraphs_remote_video/config/install/field.field.paragraph.remote_video.field_remote_video_video_title.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: remote_video
 label: 'Title of the video'
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/helfi_paragraphs_remote_video/helfi_paragraphs_remote_video.install
+++ b/modules/helfi_paragraphs_remote_video/helfi_paragraphs_remote_video.install
@@ -8,9 +8,9 @@
 declare(strict_types=1);
 
 /**
- * UHF-9088: Updated config translations for helfi_paragraphs_remote_video.
+ * UHF-8340: Updated video title required for helfi_paragraphs_remote_video.
  */
-function helfi_paragraphs_remote_video_update_9004(): void {
+function helfi_paragraphs_remote_video_update_9005(): void {
   // Re-import 'helfi_paragraphs_remote_video' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_paragraphs_remote_video');


### PR DESCRIPTION
# [UHF-8340](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8340)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed video title field to be required

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-8340`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Testing instructions are in hdbt pr

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1104


[UHF-8340]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ