### PR TITLE
UHF-10465 Send unapproved cookies to Sentry

### DIFF
--- a/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
+++ b/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
@@ -61,6 +61,7 @@
     }
   }
 
+  // Attach a behavior to capture unapproved cookies with Sentry.
   Drupal.behaviors.unapprovedCookies = {
     attach: function attach() {
       window.addEventListener(
@@ -69,6 +70,8 @@
           const { type, keys, consentedGroups } = e.detail
 
           if (window.Sentry) {
+            // Sentry requires a unique name for each error in order to record
+            // each found unapproved item per type.
             const name = `Unapproved ${type}`
             const message = `Found: ${keys.join(', ')}`
 
@@ -79,6 +82,8 @@
               }
             }
 
+            // Capture the error with Sentry and send a message with the
+            // unapproved items so that they can be searched in Sentry.
             window.Sentry.captureException(new UnapprovedItemError(message), {
               level: 'warning',
               tags: {
@@ -91,6 +96,7 @@
               },
             })
           } else {
+            // If Sentry is not defined, throw an error.
             throw new Error('Sentry is not defined')
           }
         }


### PR DESCRIPTION
# [UHF-10465](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10465)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added js to send unapproved cookies/items to Sentry

## How to install
* If you don't have yet, add to your compose.yaml `SENTRY_DSN_PUBLIC`  and `SENTRY_ENVIRONMENT`  variables in order to test the sentry logging from local environment 
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10465 `
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Add some unapproved items to your site for example from browser console by writing for example `localStrogage.setItem('someKey', 'someValue')` test different types for example sessionStorage etc. You can also add new items from dev tools -> applications and then select the one you want to add and double click empty row
* [x] Refresh the page, the error should be sent to Sentry
* [x] Go to [sentry](https://sentry.test.hel.ninja/organizations/city-of-helsinki/issues/?project=245&referrer=sidebar&statsPeriod=14d) and check that the item you added is logged there
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR


[UHF-10465]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ