### PR TITLE
User inquiry block is still active 

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -203,7 +203,6 @@ function helfi_platform_config_update_9313() : void {
   }
 }
 
-
 /**
  * UHF-9761: Remove the user inquiry -popup that is no longer used.
  */

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -202,3 +202,17 @@ function helfi_platform_config_update_9313() : void {
     $module_installer->install(['helfi_paragraphs_curated_event_list']);
   }
 }
+
+
+/**
+ * UHF-9761: Remove the user inquiry -popup that is no longer used.
+ */
+function helfi_platform_config_update_9314() : void {
+  $config_factory = Drupal::configFactory();
+
+  // Make sure the configuration is present.
+  if (!$config_factory->get('block.block.hdbt_subtheme_user_inquiry')->isNew()) {
+    // Remove the user inquiry block.
+    $config_factory->getEditable('block.block.hdbt_subtheme_user_inquiry')->delete();
+  }
+}


### PR DESCRIPTION
The hook 9306 which was supposed to remove the block, did not run in every environment (Sote for example)

TEST IN SOTE or any other site where the user_inquiry block is still enabled

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_user_inquiry`
* Run `make drush-updb drush-cr`

## How to test

- Run drush cex
- The export should delete the configuration

