### PR TITLE
UHF-X Accordion paragraphs weights

### DIFF
--- a/modules/helfi_node_news_item/config/optional/language/fi/field.field.node.news_item.field_news_item_links_link.yml
+++ b/modules/helfi_node_news_item/config/optional/language/fi/field.field.node.news_item.field_news_item_links_link.yml
@@ -1,2 +1,2 @@
 label: Linkki
-description: 'Sisäinen tai ulkoinen linkki haluttuun kohteeseen. Linkin teksti -kentän arvo näytetään sivuston käyttäjälle.'
+description: 'Lisää sisäisen tai ulkoisen linkin URL-osoite sekä sivulla näkyvä linkkiteksti.'

--- a/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.install
+++ b/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.install
@@ -8,9 +8,9 @@
 declare(strict_types=1);
 
 /**
- * UHF-8835 Update accordion paragraph translations.
+ * Update accordion paragraph weights.
  */
-function helfi_paragraphs_accordion_update_9002(): void {
+function helfi_paragraphs_accordion_update_9003(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_paragraphs_accordion');
 }

--- a/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
+++ b/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
@@ -16,10 +16,10 @@ use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
  */
 function helfi_paragraphs_accordion_helfi_paragraph_types() : array {
   return [
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'text'),
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'image'),
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'phasing'),
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns'),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'text', 0),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'image', 1),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'phasing', 2),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns',3),
     new ParagraphTypeCollection('paragraph', 'accordion', 'field_accordion_items', 'accordion_item'),
     new ParagraphTypeCollection('paragraphs_library_item', 'paragraphs_library_item', 'paragraphs', 'accordion'),
   ];

--- a/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
+++ b/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
@@ -19,7 +19,7 @@ function helfi_paragraphs_accordion_helfi_paragraph_types() : array {
     new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'text', 0),
     new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'image', 1),
     new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'phasing', 2),
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns',3),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns', 3),
     new ParagraphTypeCollection('paragraph', 'accordion', 'field_accordion_items', 'accordion_item'),
     new ParagraphTypeCollection('paragraphs_library_item', 'paragraphs_library_item', 'paragraphs', 'accordion'),
   ];

--- a/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
+++ b/modules/helfi_paragraphs_accordion/helfi_paragraphs_accordion.module
@@ -16,10 +16,10 @@ use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
  */
 function helfi_paragraphs_accordion_helfi_paragraph_types() : array {
   return [
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns'),
-    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'image'),
     new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'text'),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'image'),
     new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'phasing'),
+    new ParagraphTypeCollection('paragraph', 'accordion_item', 'field_accordion_item_content', 'columns'),
     new ParagraphTypeCollection('paragraph', 'accordion', 'field_accordion_items', 'accordion_item'),
     new ParagraphTypeCollection('paragraphs_library_item', 'paragraphs_library_item', 'paragraphs', 'accordion'),
   ];


### PR DESCRIPTION

## What was done
<!-- Describe what was done -->

* Sorted the accordion paragraphs in the following order: text, image, phasing, columns

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_accordion_paragraph_weight`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards
