### PR TITLE
UHF-10887 Hearings

### DIFF
--- a/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
+++ b/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
@@ -136,6 +136,10 @@ final class Hearings extends ExternalEntityStorageClientBase {
       $existingTranslations = $this->getTranslationLanguages($hearing);
       $selectedLangcode = $this->resolveLanguage($hearing, $langcode);
 
+      if (!in_array($langcode, $existingTranslations)) {
+        continue;
+      }
+
       $item = $hearing;
       $item += [
         'main_image_url' => $hearing['main_image']['url'],

--- a/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
+++ b/modules/helfi_paragraphs_hearings/src/Plugin/ExternalEntities/StorageClient/Hearings.php
@@ -134,8 +134,6 @@ final class Hearings extends ExternalEntityStorageClientBase {
 
     foreach ($results as $hearing) {
       $existingTranslations = $this->getTranslationLanguages($hearing);
-      $selectedLangcode = $this->resolveLanguage($hearing, $langcode);
-
       if (!in_array($langcode, $existingTranslations)) {
         continue;
       }
@@ -146,46 +144,18 @@ final class Hearings extends ExternalEntityStorageClientBase {
         'main_image' => Url::fromUri($hearing['main_image']['url']),
         'count' => $json['count'],
         'url' => sprintf('%s%s', self::HEARING_URL, $hearing['slug']),
-        'langcode' => $selectedLangcode,
+        'langcode' => $langcode,
         'existing_translations' => implode(',', $existingTranslations),
       ];
 
-      $item['title'] = $hearing['title'][$selectedLangcode] ?? $hearing['title']['fi'] ?? '';
-      $item['abstract'] = $hearing['abstract'][$selectedLangcode] ?? $hearing['abstract']['fi'] ?? '';
-      $item['main_image_caption'] = $hearing['main_image']['caption'][$selectedLangcode]
-        ?? $hearing['main_image']['caption']['fi']
-        ?? '';
+      $item['title'] = $hearing['title'][$langcode] ?? '';
+      $item['abstract'] = $hearing['abstract'][$langcode] ?? '';
+      $item['main_image_caption'] = $hearing['main_image']['caption'][$langcode] ?? '';
 
       $data[] = $item;
     }
 
     return $data;
-  }
-
-  /**
-   * Get language that exists on a hearing, preferably current language.
-   *
-   * @param array $hearing
-   *   The hearing.
-   * @param string $currentLangCode
-   *   Requested language code.
-   *
-   * @return string
-   *   Language code that can be used to show the hearing.
-   */
-  private function resolveLanguage(array $hearing, string $currentLangCode): string {
-    $existingTranslations = $this->getTranslationLanguages($hearing);
-    if (in_array($currentLangCode, $existingTranslations)) {
-      return $currentLangCode;
-    }
-
-    $possibleLanguages = ['fi', 'en', 'sv'];
-    foreach ($possibleLanguages as $langcode) {
-      if (in_array($langcode, $existingTranslations)) {
-        return $langcode;
-      }
-    }
-    throw new \InvalidArgumentException('Failed to resolve language.');
   }
 
   /**


### PR DESCRIPTION
# [UHF-10887](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10887)

Updated the hearing logic and removed code which is now obsolete.

Show only hearings with correct translation on the listing.
The old implementation tried it's best to show same amount of hearings for all translations. For example, if there were 3 finnish hearings but only 2 swedish, it would have shown 2 swedish and 1 finnish hearings.

A hearing paragraph can be found from strategia for example: [strategia test](https://www.test.hel.ninja/fi/paatoksenteko-ja-hallinto/osallistu-ja-vaikuta) or etusivu frontpage

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi packages
    * `composer require drupal/helfi_platform_config:dev-UHF-10887`
    * `composer require drupal/hdbt:dev-UHF-10887`
* Run `make drush-updb drush-cr`

## How to test
- Go to a page with hearings block on finnish language
  - At this moment there should be 2 finnish hearings visible
- Change language to swedish
  - There **should be 1 visible hearing** (instead of 1 finnish and 1 swedish)
- On english page, there should be **no visible hearings** (instead of 2 finnish)
 

## Related PRs
https://github.com/City-of-Helsinki/drupal-hdbt/pull/1137


[UHF-10887]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ