### PR TITLE
UHF-10275 linked events autocomplete sort

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -112,3 +112,11 @@ function _helfi_react_search_lookup_term_tid(string $keyword_id) {
 
   return NULL;
 }
+
+/**
+ * Implements hook_select2_autocomplete_matches_alter().
+ */
+function helfi_react_search_select2_autocomplete_matches_alter(array &$matches) {
+  // Sort from shortest to longest.
+  usort($matches, fn($a, $b) => strlen($a['text']) > strlen($b['text']));
+}

--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -118,9 +118,10 @@ function _helfi_react_search_lookup_term_tid(string $keyword_id) {
  */
 function helfi_react_search_select2_autocomplete_matches_alter(array &$matches, array $options) {
   // Sort from shortest to longest.
+  $x = 1;
   if (
-    isset($options['target_bundle']) &&
-    $options['target_bundle'] === 'linked_events_keywords'
+    isset($options['target_bundles']) &&
+    in_array('linked_events_keywords', $options['target_bundles'])
   ) {
     usort($matches, fn($a, $b) => strlen($a['text']) > strlen($b['text']));
   }

--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -118,7 +118,6 @@ function _helfi_react_search_lookup_term_tid(string $keyword_id) {
  */
 function helfi_react_search_select2_autocomplete_matches_alter(array &$matches, array $options) {
   // Sort from shortest to longest.
-  $x = 1;
   if (
     isset($options['target_bundles']) &&
     in_array('linked_events_keywords', $options['target_bundles'])

--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -116,7 +116,12 @@ function _helfi_react_search_lookup_term_tid(string $keyword_id) {
 /**
  * Implements hook_select2_autocomplete_matches_alter().
  */
-function helfi_react_search_select2_autocomplete_matches_alter(array &$matches) {
+function helfi_react_search_select2_autocomplete_matches_alter(array &$matches, array $options) {
   // Sort from shortest to longest.
-  usort($matches, fn($a, $b) => strlen($a['text']) > strlen($b['text']));
+  if (
+    isset($options['target_bundle']) &&
+    $options['target_bundle'] === 'linked_events_keywords'
+  ) {
+    usort($matches, fn($a, $b) => strlen($a['text']) > strlen($b['text']));
+  }
 }


### PR DESCRIPTION
# [UHF-10275](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10275)
Sort autocomplete results from shortest to longest

## What was done
Added select2 alter

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10275`
* Run `make drush-updb drush-cr`

## How to test
- Login as admin
- Go and edit any page which have linkedevents search
- Try adding new items to topics select2 
  - The autocomplete results should be from shortest to longest 


[UHF-10275]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ