### PR TITLE
UHF-11208: wait for the cookies

### DIFF
--- a/assets/js/chat_leijuke.js
+++ b/assets/js/chat_leijuke.js
@@ -34,9 +34,29 @@
   class EuCookieManager {
     cookieCheck(cookieNames) {
       let cookiesOk = true;
-      cookieNames.map((cookieName) => {
-        if (!Drupal.cookieConsent.getConsentStatus([cookieName])) cookiesOk = false;
-      });
+
+      // If cookies are not available yet, wait for a while.
+      if (Drupal.cookieConsent.getConsentStatus(cookieNames) === undefined) {
+        let i = 0;
+
+        const interval = setInterval(()=> {
+          let found = false;
+          cookieNames.map((cookieName) => {
+            found = Drupal.cookieConsent.getConsentStatus([cookieName]) || false;
+          });
+
+          if (i >= 3 || found) {
+            cookiesOk = found;
+            clearInterval(interval);
+          }
+          i++;
+        }, 1000)
+      } else {
+        cookieNames.map((cookieName) => {
+          if (!Drupal.cookieConsent.getConsentStatus([cookieName])) cookiesOk = false;
+        });
+      }
+
       return cookiesOk;
     }
     cookieSet() {


### PR DESCRIPTION
wait for the cookies awhile instad of just preventing the chat from loading

# [UHF-11208](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11208)
The chat would not open after user authentication redirect

## What was done
Wait for the cookies to be available


## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-11208`
* Run `make drush-updb drush-cr`

## How to test
- Go to sote-hammashoito -page
- Open chat and use the authentication
- Go through the auth-pipe and redirect back to Sote-hammashoito -page
- The chat should open normally




[UHF-11208]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ