### PR TITLE
UHF-10406: Catch exceptions from UrlResolverInterface::getProviderByUrl

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -546,7 +546,7 @@ function helfi_platform_config_form_alter(&$form, FormStateInterface $form_state
         '#title' => new TranslatableMarkup('Published'),
         '#default_value' => $redirect->isPublished(),
       ];
-    };
+    }
   }
 }
 

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -12,6 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\helfi_media_remote_video\Entity\RemoteVideo;
 use Drupal\media\OEmbed\Resource;
 use Drupal\media\OEmbed\ResourceException;
+use Drupal\media\OEmbed\UrlResolverInterface;
 
 /**
  * Implements hook_media_source_info_alter().
@@ -186,7 +187,8 @@ function _helfi_media_remote_video_remote_video_validate(array $form, FormStateI
  */
 function _helfi_media_remote_video_remote_video_url_handler(string $video_url): false|string {
   $converted_url = FALSE;
-  $url_resolver = \Drupal::service('media.oembed.url_resolver');
+  /** @var \Drupal\media\OEmbed\UrlResolverInterface $url_resolver */
+  $url_resolver = \Drupal::service(UrlResolverInterface::class);
   $provider = $url_resolver->getProviderByUrl($video_url);
   $helsinki_kanava_url_pattern = 'https://www.helsinkikanava.fi/*/web/helsinkikanava/player/vod?assetId=*';
 

--- a/modules/helfi_media_remote_video/src/Entity/RemoteVideo.php
+++ b/modules/helfi_media_remote_video/src/Entity/RemoteVideo.php
@@ -6,8 +6,6 @@ namespace Drupal\helfi_media_remote_video\Entity;
 
 use Drupal\helfi_media\Entity\MediaEntityBundle;
 use Drupal\media\MediaInterface;
-use Drupal\media\OEmbed\ProviderException;
-use Drupal\media\OEmbed\ResourceException;
 use Drupal\media\OEmbed\UrlResolverInterface;
 
 /**

--- a/modules/helfi_media_remote_video/src/Entity/RemoteVideo.php
+++ b/modules/helfi_media_remote_video/src/Entity/RemoteVideo.php
@@ -6,6 +6,9 @@ namespace Drupal\helfi_media_remote_video\Entity;
 
 use Drupal\helfi_media\Entity\MediaEntityBundle;
 use Drupal\media\MediaInterface;
+use Drupal\media\OEmbed\ProviderException;
+use Drupal\media\OEmbed\ResourceException;
+use Drupal\media\OEmbed\UrlResolverInterface;
 
 /**
  * Bundle class for remote_video media.
@@ -22,10 +25,18 @@ class RemoteVideo extends MediaEntityBundle implements MediaInterface {
     if (!$this->hasProvider()) {
       return NULL;
     }
-    $url_resolver = \Drupal::service('media.oembed.url_resolver');
+    /** @var \Drupal\media\OEmbed\UrlResolverInterface $url_resolver */
+    $url_resolver = \Drupal::service(UrlResolverInterface::class);
     $video_url = $this->get('field_media_oembed_video')->value;
-    $provider = $url_resolver->getProviderByUrl($video_url);
-    return rtrim($provider->getUrl(), '/');
+    try {
+      $provider = $url_resolver->getProviderByUrl($video_url);
+      return rtrim($provider->getUrl(), '/');
+    }
+    // UrlResolverInterface::getProviderByUrl makes
+    // network requests that can fail.
+    catch (\Exception) {
+      return NULL;
+    }
   }
 
   /**
@@ -34,7 +45,7 @@ class RemoteVideo extends MediaEntityBundle implements MediaInterface {
    * @return mixed
    *   The video title.
    */
-  public function getMediaTitle() {
+  public function getMediaTitle(): mixed {
     return $this->get('field_media_oembed_video')
       ->iframe_title;
   }

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -359,7 +359,7 @@ class LinkedEvents {
                   $params['end'] = 'today';
                   break;
 
-                case 'tomorrow';
+                case 'tomorrow':
                   $params['start'] = date('Y-m-d', strtotime('tomorrow'));
                   $params['end'] = date('Y-m-d', strtotime('tomorrow'));
                   break;
@@ -440,7 +440,7 @@ class LinkedEvents {
       };
 
       $keywords = array_merge($map, $keywords);
-    };
+    }
 
     return implode(',', $keywords);
   }


### PR DESCRIPTION
# [UHF-10406](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10406)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Fix crashes with some YouTube link.

Sentry issue: https://sentry.hel.fi/organizations/city-of-helsinki/issues/46100/?query=is%3Aunresolved+OEmbed&referrer=issue-stream&statsPeriod=14d

This issue was hard to reproduce locally. I believe the root cause was that google blocks OpenShift environment:
<img width="954" alt="image" src="https://github.com/user-attachments/assets/8734e411-1c8c-4435-a912-bb30d23c318a" />

Some YouTube links, like `https://youtube.com/watch?v=g2eYKMjE8ew` (missing www.), are perfecly fine, but not included in the list provider by [drupal/oembed_providers](https://www.drupal.org/project/oembed_providers): https://oembed.com/providers.json. This causes these links to [make network requests](https://github.com/drupal/drupal/blob/11.x/core/modules/media/src/OEmbed/UrlResolver.php#L139-L144) to google from the backend whenever they are used. According to the Sentry logs, Google seems to be banning our production environment.

These PRs include two fixes to this issue:
 - Handle the exception when thrown.
 - Add better sanitization video URLs in Rekry migrations, where these links have mostly come from, so no network requests to Google are needed in the first place.

## How to install
* Make sure your Rekry is up and running on latest dev branch.
    * `git pull origin UHF-10406`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10406`
    * `composer require drupal/hdbt:dev-UHF-10406`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Verify that exceptions no longer crash the page. Simulate google being angry at us by adding `throw new ResourceException('Test.', $url);` to the top of `UrlResolver::getProviderByUrl`. View some pages that have video embeds. They should not be shown at all (unless cached).
* [x] Verify that rekry migrations remove videos that not present in Helbit. Add video to some job listing, run: `drush migrate:import helfi_rekry_jobs --reset-threshold 1 --update`. The video should be removed.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/647
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1155


[UHF-10406]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ