### PR TITLE
wrong return type causes whitescreen

### DIFF
--- a/modules/helfi_media_map/src/Entity/HelMap.php
+++ b/modules/helfi_media_map/src/Entity/HelMap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_media_map\Entity;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_media\Entity\MediaEntityBundle;
 use Drupal\media\MediaInterface;
 
@@ -27,10 +28,10 @@ class HelMap extends MediaEntityBundle implements MediaInterface {
   /**
    * Get the title of map.
    *
-   * @return string|null
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup|null
    *   The title of the map.
    */
-  public function getMediaTitle(): ?string {
+  public function getMediaTitle(): ?TranslatableMarkup {
     return $this->get('field_media_hel_map')
       ->first()
       ->get('title')


### PR DESCRIPTION

Whitescreen in this page on [PROD](https://www.hel.fi/fi/asuminen/pohjois-pasilaan-valmistuvien-hekan-vuokra-asuntojen-hakuaika-on-alkanut) or [LOCAL](https://helfi-asuminen.docker.so/fi/asuminen/pohjois-pasilaan-valmistuvien-hekan-vuokra-asuntojen-hakuaika-on-alkanut)

[Sentry error](https://sentry.hel.fi/organizations/city-of-helsinki/issues/50940/?referrer=slack&notification_uuid=c5458911-8163-42d4-bca0-4b66e39525c4&environment=production&alert_rule_id=154&alert_type=issue)

## What was done
Set correct return type on function


## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_returntype_whitescreen`
* Run `make drush-updb drush-cr`

## How to test
[This page](https://helfi-asuminen.docker.so/fi/asuminen/pohjois-pasilaan-valmistuvien-hekan-vuokra-asuntojen-hakuaika-on-alkanut) should load normally
