### PR TITLE
UHF-11222: Language support for the curated event list, fix translation in the content listing view

### DIFF
--- a/modules/hdbt_admin_tools/config/optional/language/fi/views.view.content.yml
+++ b/modules/hdbt_admin_tools/config/optional/language/fi/views.view.content.yml
@@ -4,6 +4,7 @@ display:
       fields:
         langcode:
           label: Kieli
+          separator: ', '
         title:
           label: Otsikko
         type:
@@ -51,9 +52,9 @@ display:
           group_info:
             label: Julkaisutila
             group_items:
-              1:
+              -
                 title: Julkaistu
-              2:
+              -
                 title: Julkaisematon
         langcode:
           expose:

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -103,3 +103,12 @@ function hdbt_admin_tools_update_9005(): void {
     $language_switcher_block->save();
   }
 }
+
+/**
+ * UHF-11222: Fix issue with publish state translation on content listing view.
+ */
+function hdbt_admin_tools_update_9006(): void {
+  // Re-import 'hdbt_admin_tools' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('hdbt_admin_tools');
+}

--- a/modules/helfi_paragraphs_curated_event_list/src/Plugin/ExternalEntities/StorageClient/Events.php
+++ b/modules/helfi_paragraphs_curated_event_list/src/Plugin/ExternalEntities/StorageClient/Events.php
@@ -169,7 +169,8 @@ class Events extends ExternalEntityStorageClientBase {
       $event_url = '/events/';
       if ($langcode === 'fi') {
         $event_url = '/tapahtumat/';
-      } elseif ($langcode === 'sv') {
+      }
+      elseif ($langcode === 'sv') {
         $event_url = '/kurser/';
       }
 

--- a/modules/helfi_paragraphs_curated_event_list/src/Plugin/ExternalEntities/StorageClient/Events.php
+++ b/modules/helfi_paragraphs_curated_event_list/src/Plugin/ExternalEntities/StorageClient/Events.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Events extends ExternalEntityStorageClientBase {
   protected const API_URL = 'https://api.hel.fi/linkedevents/v1';
-  protected const EVENTS_BASE_URL = 'https://tapahtumat.hel.fi/events/';
+  protected const EVENTS_BASE_URL = 'https://tapahtumat.hel.fi/';
 
   /**
    * The current language service.
@@ -166,10 +166,17 @@ class Events extends ExternalEntityStorageClientBase {
         continue;
       }
 
+      $event_url = '/events/';
+      if ($langcode === 'fi') {
+        $event_url = '/tapahtumat/';
+      } elseif ($langcode === 'sv') {
+        $event_url = '/kurser/';
+      }
+
       $event['clean_title'] = $event['name'][$langcode];
       $start = new \DateTime($event['start_time']);
       $event['title'] = $event['clean_title'] . ' (' . $start->format('d.m.Y H:i') . ')';
-      $event['external_link'] = self::EVENTS_BASE_URL . $event['id'];
+      $event['external_link'] = self::EVENTS_BASE_URL . $langcode . $event_url . $event['id'];
       $prepared[$event['id']] = $event;
     }
 


### PR DESCRIPTION
# [UHF-11222](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11222)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add language support for the curated event list.
* Fix translation in the content listing view.

## How to install
* Make sure your Front page instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-11222`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11222`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure your user has site language and admin language set to Finnish in here https://helfi-etusivu.docker.so/en/user
* [ ] Next go to https://helfi-etusivu.docker.so/en/admin/content and make sure that the "Julkaisutila" filter has options "Julkaistu" and "Julkaisematon". It used to have "Published" and "Julkaistu" which didn't make any sense.
* [ ] Now go to https://helfi-etusivu.docker.so/sv/nyheter and scroll down. There should be a Curated event list block. The block title should now be correctly translated and it should say "Rekommenderade evenemang"
* [ ] Lastly check that the events now link to the correct language version on the events page. For Finnish events is `/fi/tapahtumat/`, for English events its `/en/events/` and for Swedish its `/sv/kurser/`.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to configuration files and included in this PR.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/890
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1166
* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1630


[UHF-11222]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ