### PR TITLE
UHF-11363: Configuration translations

### DIFF
--- a/modules/hdbt_admin_tools/config/optional/language/fi/views.view.content.yml
+++ b/modules/hdbt_admin_tools/config/optional/language/fi/views.view.content.yml
@@ -23,10 +23,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            next: Seuraava
+            previous: Edellinen
+            first: Ensimmäinen
+            last: Viimeinen
       exposed_form:
         options:
           submit_button: Suodata

--- a/modules/hdbt_admin_tools/config/optional/language/sv/views.view.content.yml
+++ b/modules/hdbt_admin_tools/config/optional/language/sv/views.view.content.yml
@@ -22,10 +22,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Nästa ›'
-            previous: '‹ Föregående'
-            first: '« Första'
-            last: 'Sista »'
+            next: Nästa
+            previous: Föregående
+            first: Första
+            last: Sista
       exposed_form:
         options:
           submit_button: Filtrera

--- a/modules/hdbt_admin_tools/config/rewrite/views.view.content.yml
+++ b/modules/hdbt_admin_tools/config/rewrite/views.view.content.yml
@@ -316,10 +316,10 @@ display:
           pagination_heading_level: h4
           items_per_page: 50
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
       exposed_form:
         type: basic
         options:
@@ -375,8 +375,6 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
           is_grouped: false
           group_info:
             label: ''

--- a/modules/hdbt_admin_tools/config/rewrite/views.view.content.yml
+++ b/modules/hdbt_admin_tools/config/rewrite/views.view.content.yml
@@ -415,8 +415,6 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -509,9 +507,6 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              admin: '0'
-              content_producer: '0'
             reduce: true
           is_grouped: false
           group_info:

--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -105,9 +105,9 @@ function hdbt_admin_tools_update_9005(): void {
 }
 
 /**
- * UHF-11222: Fix issue with publish state translation on content listing view.
+ * UHF-11363: Updated pager labels in views.
  */
-function hdbt_admin_tools_update_9007(): void {
+function hdbt_admin_tools_update_9008(): void {
   // Re-import 'hdbt_admin_tools' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('hdbt_admin_tools');

--- a/modules/helfi_base_content/config/install/views.view.helfi_redirect.yml
+++ b/modules/helfi_base_content/config/install/views.view.helfi_redirect.yml
@@ -365,10 +365,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'next ›'
-            previous: '‹ previous'
-            first: '« first'
-            last: 'last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_base_content/config/optional/language/fi/views.view.helfi_redirect.yml
+++ b/modules/helfi_base_content/config/optional/language/fi/views.view.helfi_redirect.yml
@@ -50,10 +50,10 @@ display:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'
           tags:
-            previous: '‹ edellinen'
-            next: 'seuraava ›'
-            first: '« ensimmäinen'
-            last: 'viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
       fields:
         redirect_bulk_form:
           action_title: Valinnalla

--- a/modules/helfi_base_content/config/optional/language/fi/views.view.locked_content.yml
+++ b/modules/helfi_base_content/config/optional/language/fi/views.view.locked_content.yml
@@ -14,10 +14,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ Edellinen'
-            next: 'Seuraava ›'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_base_content/config/optional/language/fi/views.view.scheduler_scheduled_content.yml
+++ b/modules/helfi_base_content/config/optional/language/fi/views.view.scheduler_scheduled_content.yml
@@ -43,6 +43,13 @@ display:
         langcode:
           expose:
             label: Kieli
+      pager:
+        options:
+          tags:
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
       title: 'Ajastettu sisältö'
       empty:
         area_text_custom:

--- a/modules/helfi_base_content/config/optional/language/sv/views.view.helfi_redirect.yml
+++ b/modules/helfi_base_content/config/optional/language/sv/views.view.helfi_redirect.yml
@@ -50,10 +50,10 @@ display:
             items_per_page_label: 'Poster per sida'
             items_per_page_options_all_label: '- Alla -'
           tags:
-            previous: '‹ föregående'
-            next: 'nästa ›'
-            first: '« första'
-            last: 'sista »'
+            previous: Föregående
+            next: Nästa
+            first: Första
+            last: Sista
       fields:
         redirect_bulk_form:
           action_title: Med valda

--- a/modules/helfi_base_content/config/optional/language/sv/views.view.locked_content.yml
+++ b/modules/helfi_base_content/config/optional/language/sv/views.view.locked_content.yml
@@ -12,8 +12,8 @@ display:
       pager:
         options:
           tags:
-            first: '« Första'
-            last: 'Sista »'
+            first: Första
+            last: Sista
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_base_content/config/optional/language/sv/views.view.locked_content.yml
+++ b/modules/helfi_base_content/config/optional/language/sv/views.view.locked_content.yml
@@ -12,6 +12,8 @@ display:
       pager:
         options:
           tags:
+            previous: Föregående
+            next: Nästa
             first: Första
             last: Sista
           expose:

--- a/modules/helfi_base_content/config/optional/language/sv/views.view.scheduler_scheduled_content.yml
+++ b/modules/helfi_base_content/config/optional/language/sv/views.view.scheduler_scheduled_content.yml
@@ -51,10 +51,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ föregående'
-            next: 'nästa ›'
-            first: '« första'
-            last: 'sista »'
+            previous: Föregående
+            next: Nästa
+            first: Första
+            last: Sista
       title: 'Schemalagt innehåll'
       empty:
         area_text_custom:

--- a/modules/helfi_base_content/config/rewrite/views.view.locked_content.yml
+++ b/modules/helfi_base_content/config/rewrite/views.view.locked_content.yml
@@ -13,3 +13,10 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
+      pager:
+        options:
+          tags:
+            next: Next
+            previous: Previous
+            first: First
+            last: Last

--- a/modules/helfi_base_content/config/rewrite/views.view.scheduler_scheduled_content.yml
+++ b/modules/helfi_base_content/config/rewrite/views.view.scheduler_scheduled_content.yml
@@ -531,10 +531,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'next ›'
-            previous: '‹ previous'
-            first: '« first'
-            last: 'last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
       exposed_form:
         type: basic
         options:

--- a/modules/helfi_base_content/helfi_base_content.install
+++ b/modules/helfi_base_content/helfi_base_content.install
@@ -339,9 +339,9 @@ function helfi_base_content_update_9013(): void {
 }
 
 /**
- * UHF-11222: Fix issue with publish state translation on listing views.
+ * UHF-11363: Updated pager labels in views.
  */
-function helfi_base_content_update_9018(): void {
+function helfi_base_content_update_9019(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_base_content');
 }

--- a/modules/helfi_media/config/optional/language/fi/views.view.media.yml
+++ b/modules/helfi_media/config/optional/language/fi/views.view.media.yml
@@ -26,10 +26,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            next: Seuraava
+            previous: Edellinen
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_media/config/optional/language/fi/views.view.media_library.yml
+++ b/modules/helfi_media/config/optional/language/fi/views.view.media_library.yml
@@ -10,8 +10,8 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
+            next: Seuraava
+            previous: Edellinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_media/config/optional/language/sv/views.view.media.yml
+++ b/modules/helfi_media/config/optional/language/sv/views.view.media.yml
@@ -25,10 +25,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Nästa ›'
-            previous: '‹ Föregående'
-            first: '« Första'
-            last: 'Sista »'
+            next: Nästa
+            previous: Föregående
+            first: Första
+            last: Sista
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_media/config/optional/language/sv/views.view.media_library.yml
+++ b/modules/helfi_media/config/optional/language/sv/views.view.media_library.yml
@@ -8,11 +8,13 @@ display:
           action_title: Åtgärd
       pager:
         options:
+          tags:
+            next: Nästa
+            previous: Föregående
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'
             offset_label: Kompensera
-          tags: {  }
       exposed_form:
         options:
           submit_button: 'Tillämpa filter'

--- a/modules/helfi_media/config/rewrite/views.view.media_library.yml
+++ b/modules/helfi_media/config/rewrite/views.view.media_library.yml
@@ -142,8 +142,8 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
+            next: Next
+            previous: Previous
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -1081,10 +1081,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_media/helfi_media.install
+++ b/modules/helfi_media/helfi_media.install
@@ -118,9 +118,9 @@ function helfi_media_update_9013(): void {
 }
 
 /**
- * UHF-11222: Fix issue with publish state translation on listing views.
+ * UHF-11363: Updated pager labels in views.
  */
-function helfi_media_update_9018(): void {
+function helfi_media_update_9019(): void {
   // Re-import 'helfi_media' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_media');

--- a/modules/helfi_tpr_config/config/install/views.view.er_tpr_unit.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.er_tpr_unit.yml
@@ -93,8 +93,8 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
+            next: Next
+            previous: Previous
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/install/views.view.locked_services.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.locked_services.yml
@@ -383,10 +383,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/install/views.view.locked_units.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.locked_units.yml
@@ -383,10 +383,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.er_tpr_unit.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.er_tpr_unit.yml
@@ -5,8 +5,8 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
+            next: Seuraava
+            previous: Edellinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
@@ -24,10 +24,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            next: Seuraava
+            previous: Edellinen
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             offset_label: Offset
             items_per_page_label: 'Merkintöjä sivua kohti'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_units.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_units.yml
@@ -24,10 +24,10 @@ display:
       pager:
         options:
           tags:
-            next: 'Seuraava ›'
-            previous: '‹ Edellinen'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            next: Seuraava
+            previous: Edellinen
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_errand_service_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_errand_service_list.yml
@@ -13,10 +13,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ Edellinen'
-            next: 'Seuraava ›'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_service_channel_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_service_channel_list.yml
@@ -13,10 +13,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ Edellinen'
-            next: 'Seuraava ›'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_service_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_service_list.yml
@@ -13,10 +13,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ Edellinen'
-            next: 'Seuraava ›'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_unit_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.tpr_unit_list.yml
@@ -13,10 +13,10 @@ display:
       pager:
         options:
           tags:
-            previous: '‹ Edellinen'
-            next: 'Seuraava ›'
-            first: '« Ensimmäinen'
-            last: 'Viimeinen »'
+            previous: Edellinen
+            next: Seuraava
+            first: Ensimmäinen
+            last: Viimeinen
           expose:
             items_per_page_label: 'Merkintöjä sivua kohti'
             items_per_page_options_all_label: '- Kaikki -'

--- a/modules/helfi_tpr_config/config/optional/language/sv/views.view.er_tpr_unit.yml
+++ b/modules/helfi_tpr_config/config/optional/language/sv/views.view.er_tpr_unit.yml
@@ -9,8 +9,8 @@ display:
             items_per_page_options_all_label: '- Alla -'
             offset_label: Kompensera
           tags:
-            next: ››
-            previous: ‹‹
+            next: Nästa
+            previous: Föregående
       exposed_form:
         options:
           submit_button: Verkställ

--- a/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_errand_service_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_errand_service_list.yml
@@ -12,8 +12,8 @@ display:
       pager:
         options:
           tags:
-            first: '« Första'
-            last: 'Sista »'
+            first: Första
+            last: Sista
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_service_channel_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_service_channel_list.yml
@@ -12,10 +12,10 @@ display:
       pager:
         options:
           tags:
-            first: '« Första'
-            last: 'Sista »'
-            previous: ‹‹
-            next: ››
+            first: Första
+            last: Sista
+            previous: Föregående
+            next: Nästa
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_service_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_service_list.yml
@@ -12,10 +12,10 @@ display:
       pager:
         options:
           tags:
-            first: '« Första'
-            last: 'Sista »'
-            previous: ‹‹
-            next: ››
+            first: Första
+            last: Sista
+            previous: Föregående
+            next: Nästa
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_unit_list.yml
+++ b/modules/helfi_tpr_config/config/optional/language/sv/views.view.tpr_unit_list.yml
@@ -13,10 +13,10 @@ display:
       pager:
         options:
           tags:
-            first: '« Första'
-            last: 'Sista »'
-            previous: ‹‹
-            next: ››
+            first: Första
+            last: Sista
+            previous: Föregående
+            next: Nästa
           expose:
             items_per_page_label: 'Inlägg per sida'
             items_per_page_options_all_label: '- Alla -'

--- a/modules/helfi_tpr_config/config/rewrite/views.view.tpr_errand_service_list.yml
+++ b/modules/helfi_tpr_config/config/rewrite/views.view.tpr_errand_service_list.yml
@@ -471,10 +471,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/rewrite/views.view.tpr_service_channel_list.yml
+++ b/modules/helfi_tpr_config/config/rewrite/views.view.tpr_service_channel_list.yml
@@ -471,10 +471,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/rewrite/views.view.tpr_service_list.yml
+++ b/modules/helfi_tpr_config/config/rewrite/views.view.tpr_service_list.yml
@@ -471,10 +471,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/config/rewrite/views.view.tpr_unit_list.yml
+++ b/modules/helfi_tpr_config/config/rewrite/views.view.tpr_unit_list.yml
@@ -503,10 +503,10 @@ display:
           total_pages: null
           id: 0
           tags:
-            next: ››
-            previous: ‹‹
-            first: '« First'
-            last: 'Last »'
+            next: Next
+            previous: Previous
+            first: First
+            last: Last
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -405,9 +405,9 @@ function helfi_tpr_config_update_9074(): void {
 }
 
 /**
- * UHF-11222: Fix issue with publish state translation on listing views.
+ * UHF-11363: Updated pager labels in views.
  */
-function helfi_tpr_config_update_9075(): void {
+function helfi_tpr_config_update_9076(): void {
   // Re-import 'helfi_tpr_config' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');


### PR DESCRIPTION
# [UHF-11363](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11363)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated all pager texts to follow same naming patterns.

## How to install and test in Etusivu
* Get the latest dev branch
   * `git checkout dev && git pull origin dev`
* Run `composer i`
* Run `make up`
* Download the artifact from Etusivu github: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/actions/runs/12969542299/artifacts/2485922628
   * Unzip the latest.sql.zip and copy/move it to helfi_etusivu directory. Rename it `dump.sql`
* Run `make shell`
   * In shell, run `drush sql-drop -y && drush sql-query --file=/app/dump.sql && drush cr && drush cim -y && drush updb -y && drush cex -y` 
* There shouldn't be any significant changes to conf/cmi, if there is consult @khalima and we'll check them together
* Switch to branch UHF-11363 and get correct branch from platform config. Run this outside of docker container.
    * `git fetch --all && git checkout UHF-11363 && composer require drupal/helfi_platform_config:dev-UHF-11363`
* Run `drush updb -y && drush cex -y`
* Check that the changed configurations makes sense, and yet again consult @khalima


[UHF-11363]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ