### PR TITLE
UHF-X: External event entity causes WSOD fix

### DIFF
--- a/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
+++ b/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
@@ -76,7 +76,7 @@ function helfi_paragraphs_curated_event_list_preprocess_external_entity__linkede
       $event->get('start_time')->first()->get('date')->getValue()->getTimestamp() :
       NULL;
   }
-  catch(\Exception) {
+  catch (\Exception) {
   }
 
   $end = NULL;
@@ -85,7 +85,7 @@ function helfi_paragraphs_curated_event_list_preprocess_external_entity__linkede
       $event->get('end_time')->first()->get('date')->getValue()->getTimestamp() :
       NULL;
   }
-  catch(\Exception) {
+  catch (\Exception) {
   }
 
   $variables['start_timestamp'] = $start;

--- a/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
+++ b/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
@@ -68,9 +68,14 @@ function helfi_paragraphs_curated_event_list_paragraph_view(
 function helfi_paragraphs_curated_event_list_preprocess_external_entity__linkedevents_event(
   array &$variables,
 ): void {
+  /** @var \Drupal\helfi_paragraphs_curated_event_list\Entity\LinkedEventsEvent $event */
   $event = $variables['external_entity'];
-  $variables['start_timestamp'] = $event->start_time->date->getTimeStamp();
-  $variables['end_timestamp'] = $event->end_time->date->getTimeStamp();
+
+  $start = $event->get('start_time')->getValue() ? $event->start_time->date->getTimeStamp() : NULL;
+  $end = $event->get('end_time')->getValue() ? $event->end_time->date->getTimeStamp() : NULL;
+
+  $variables['start_timestamp'] = $start;
+  $variables['end_timestamp'] = $end;
 }
 
 /**

--- a/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
+++ b/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.module
@@ -70,9 +70,23 @@ function helfi_paragraphs_curated_event_list_preprocess_external_entity__linkede
 ): void {
   /** @var \Drupal\helfi_paragraphs_curated_event_list\Entity\LinkedEventsEvent $event */
   $event = $variables['external_entity'];
+  $start = NULL;
+  try {
+    $start = $event->get('start_time')->getValue() ?
+      $event->get('start_time')->first()->get('date')->getValue()->getTimestamp() :
+      NULL;
+  }
+  catch(\Exception) {
+  }
 
-  $start = $event->get('start_time')->getValue() ? $event->start_time->date->getTimeStamp() : NULL;
-  $end = $event->get('end_time')->getValue() ? $event->end_time->date->getTimeStamp() : NULL;
+  $end = NULL;
+  try {
+    $end = $event->get('end_time')->getValue() ?
+      $event->get('end_time')->first()->get('date')->getValue()->getTimestamp() :
+      NULL;
+  }
+  catch(\Exception) {
+  }
 
   $variables['start_timestamp'] = $start;
   $variables['end_timestamp'] = $end;


### PR DESCRIPTION
Prevent whitescreen when event does not have either start or end time.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-X_curated_events_whitescreen`
* Update HDBT
    * `composer require drupal/hdbt:dev-UHF-X_curated_events_whitescreen`
* Run `make drush-updb drush-cr`

## How to test
- Add a curated event paragraphs to a page
- Add the following events:
```
- Sound of Stoa
- Ilmaispäivä
- Kiasman ilmaispäivä
- DocPoint 2025
```

- Save the page
- Go see the page
You should not see whitescreen

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/895
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1169
