### PR TITLE
UHF-10023: Remove gif file format from the list of allowed formats on the media image field

### DIFF
--- a/modules/helfi_media/config/install/field.field.media.image.field_media_image.yml
+++ b/modules/helfi_media/config/install/field.field.media.image.field_media_image.yml
@@ -28,7 +28,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: ''
-  file_extensions: 'png gif jpg jpeg'
+  file_extensions: 'png jpg jpeg'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''

--- a/modules/helfi_media/helfi_media.install
+++ b/modules/helfi_media/helfi_media.install
@@ -118,9 +118,9 @@ function helfi_media_update_9013(): void {
 }
 
 /**
- * UHF-11363: Updated pager labels in views.
+ * UHF-10023: Removed gif as allowed file format in media images.
  */
-function helfi_media_update_9019(): void {
+function helfi_media_update_9020(): void {
   // Re-import 'helfi_media' configuration.
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_media');


### PR DESCRIPTION
# [UHF-10023](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10023)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove gif file format from the list of allowed formats on the media image field.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-10023`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure you can't add gif files to media library anymore: `/media/add/image`
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation


[UHF-10023]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ