### PR TITLE
UHF-11339: Added youtube no-cookie support

### DIFF
--- a/modules/helfi_media_remote_video/config/install/media.type.remote_video.yml
+++ b/modules/helfi_media_remote_video/config/install/media.type.remote_video.yml
@@ -19,4 +19,5 @@ source_configuration:
   providers:
     - YouTube
     - 'Icareus Suite'
+    - 'YouTube No-Cookie'
 field_map: {  }

--- a/modules/helfi_media_remote_video/config/install/oembed_providers.provider.youtube_no_cookie.yml
+++ b/modules/helfi_media_remote_video/config/install/oembed_providers.provider.youtube_no_cookie.yml
@@ -1,0 +1,24 @@
+uuid: fe53d3c6-950e-47c9-90f8-728571b5ba2d
+langcode: en
+status: true
+dependencies: {  }
+id: youtube_no_cookie
+label: 'YouTube No-Cookie'
+provider_url: 'https://www.youtube-nocookie.com/'
+endpoints:
+  -
+    schemes:
+      - 'https://*.youtube-nocookie.com/watch*'
+      - 'https://*.youtube-nocookie.com/v/*'
+      - 'https://*.youtube-nocookie.com/playlist?list=*'
+      - 'https://youtube-nocookie.com/playlist?list=*'
+      - 'https://*.youtube-nocookie.com/shorts*'
+      - 'https://youtube-nocookie.com/shorts*'
+      - 'https://*.youtube-nocookie.com/embed/*'
+      - 'https://*.youtube-nocookie.com/live*'
+      - 'https://youtube-nocookie.com/live*'
+    url: 'https://www.youtube-nocookie.com/oembed'
+    discovery: true
+    formats:
+      json: true
+      xml: false

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.install
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.install
@@ -52,9 +52,9 @@ function helfi_media_remote_video_install($is_syncing) : void {
 }
 
 /**
- * UHF-9088 Updated translations for media remote video.
+ * UHF-11339 Added youtube no-cookie support.
  */
-function helfi_media_remote_video_update_9001(): void {
+function helfi_media_remote_video_update_9002(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_media_remote_video');
 }

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -20,6 +20,7 @@ use Drupal\media\OEmbed\UrlResolverInterface;
 function helfi_media_remote_video_media_source_info_alter(array &$sources): void {
   // Add Helsinki-kanava (Icareus Suite) as an available provider.
   $sources['oembed:video']['providers'][] = 'Icareus Suite';
+  $sources['oembed:video']['providers'][] = 'YouTube No-Cookie';
 }
 
 /**
@@ -192,39 +193,47 @@ function _helfi_media_remote_video_remote_video_url_handler(string $video_url): 
   $provider = $url_resolver->getProviderByUrl($video_url);
   $helsinki_kanava_url_pattern = 'https://www.helsinkikanava.fi/*/web/helsinkikanava/player/vod?assetId=*';
 
-  // Handle only Helsinki-kanava videos (Icareus Suite).
-  if ($provider->getName() !== 'Icareus Suite') {
+  // Handle only Helsinki-kanava videos (Icareus Suite) and Youtube videos.
+  if ($provider->getName() !== 'Icareus Suite' && $provider->getName() !== 'YouTube') {
     return FALSE;
   }
 
-  // Try to convert the URL if it's of form 'player/event/view'.
-  if (str_contains($video_url, 'player/event/view')) {
-    preg_match('/helsinkikanava.fi\/((?i)[a-z]{2})/', $video_url, $language_matches);
-    // Default to 'fi' if no match.
-    $lang_code = $language_matches[1] ?? 'fi';
-    preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
-    $asset_id = $asset_id_matches[1] ?? NULL;
-
-    if (empty($asset_id)) {
-      return FALSE;
+  if ($provider->getName() === 'YouTube') {
+    if (str_contains($video_url, 'youtube.com') && !str_contains($video_url, 'no-cookie')) {
+      $converted_url = str_replace('youtube.com', 'youtube-nocookie.com', $video_url);
     }
-
-    // Assemble the converted URL.
-    $url_parts = explode('*', $helsinki_kanava_url_pattern);
-    $converted_url = $url_parts[0] . $lang_code . $url_parts[1] . $asset_id;
   }
 
-  // Try to convert the URL if it's of form 'web/helsinkikanava/player/webcast'.
-  if (str_contains($video_url, '/web/helsinkikanava/player/webcast')) {
-    preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
-    $asset_id = $asset_id_matches[1];
+  if ($provider->getName() === 'Icareus Suite') {
+    // Try to convert the URL if it's of form 'player/event/view'.
+    if (str_contains($video_url, 'player/event/view')) {
+      preg_match('/helsinkikanava.fi\/((?i)[a-z]{2})/', $video_url, $language_matches);
+      // Default to 'fi' if no match.
+      $lang_code = $language_matches[1] ?? 'fi';
+      preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
+      $asset_id = $asset_id_matches[1] ?? NULL;
 
-    if (empty($asset_id)) {
-      throw new Exception('URL is missing asset ID parameter.');
+      if (empty($asset_id)) {
+        return FALSE;
+      }
+
+      // Assemble the converted URL.
+      $url_parts = explode('*', $helsinki_kanava_url_pattern);
+      $converted_url = $url_parts[0] . $lang_code . $url_parts[1] . $asset_id;
     }
 
-    $url_parts = explode('*', $helsinki_kanava_url_pattern);
-    $converted_url = $url_parts[0] . 'fi' . $url_parts[1] . $asset_id;
+    // Try to convert the URL if it's of form 'web/helsinkikanava/player/webcast'.
+    if (str_contains($video_url, '/web/helsinkikanava/player/webcast')) {
+      preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
+      $asset_id = $asset_id_matches[1];
+
+      if (empty($asset_id)) {
+        throw new Exception('URL is missing asset ID parameter.');
+      }
+
+      $url_parts = explode('*', $helsinki_kanava_url_pattern);
+      $converted_url = $url_parts[0] . 'fi' . $url_parts[1] . $asset_id;
+    }
   }
 
   // Return the converted URL.

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -10,6 +10,7 @@ declare(strict_types=1);
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\helfi_media_remote_video\Entity\RemoteVideo;
+use Drupal\media\OEmbed\Provider;
 use Drupal\media\OEmbed\Resource;
 use Drupal\media\OEmbed\ResourceException;
 use Drupal\media\OEmbed\UrlResolverInterface;
@@ -262,5 +263,23 @@ function helfi_media_remote_video_theme_suggestions_media_oembed_iframe_alter(ar
 function helfi_media_remote_video_entity_bundle_info_alter(array &$bundles): void {
   if (isset($bundles['media']['remote_video'])) {
     $bundles['media']['remote_video']['class'] = RemoteVideo::class;
+  }
+}
+
+/**
+ * Alters an oEmbed resource URL before it is fetched.
+ *
+ * @param array $parsed_url
+ *   A parsed URL, as returned by \Drupal\Component\Utility\UrlHelper::parse().
+ * @param \Drupal\media\OEmbed\Provider $provider
+ *   The oEmbed provider for the resource.
+ *
+ * @see \Drupal\media\OEmbed\UrlResolverInterface::getResourceUrl()
+ */
+function helfi_media_remote_video_oembed_resource_url_alter(array &$parsed_url, Provider $provider) {
+  // Always serve YouTube videos from youtube-nocookie.com.
+  if ($provider->getName() === 'YouTube') {
+    $parsed_url['path'] = str_replace('youtube.com', 'youtube-nocookie.com', $parsed_url['path']);
+    $parsed_url['query']['url'] = str_replace('youtube.com', 'youtube-nocookie.com', $parsed_url['query']['url']);
   }
 }

--- a/modules/helfi_media_remote_video/helfi_media_remote_video.module
+++ b/modules/helfi_media_remote_video/helfi_media_remote_video.module
@@ -222,7 +222,8 @@ function _helfi_media_remote_video_remote_video_url_handler(string $video_url): 
       $converted_url = $url_parts[0] . $lang_code . $url_parts[1] . $asset_id;
     }
 
-    // Try to convert the URL if it's of form 'web/helsinkikanava/player/webcast'.
+    // Try to convert the URL if it's of form
+    // 'web/helsinkikanava/player/webcast'.
     if (str_contains($video_url, '/web/helsinkikanava/player/webcast')) {
       preg_match('/assetId=(\d+)/', $video_url, $asset_id_matches);
       $asset_id = $asset_id_matches[1];


### PR DESCRIPTION
# [UHF-11339](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11339)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Adds support for YouTube no-cookie urls

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-11339`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Test in some instance that has video embeds, for example etusivu

* [ ] Go edit some existing YouTube video media entity
* [ ] Save the entity and go check the url of the video, it should have now no-cookie in the url
* [ ] Add the video to some page to make sure it still works
* [ ] Add some YouTube video with a normal url to a page, check that the url is a no-cookie url even though the media url is without no-cookie
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation



[UHF-11339]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ