### PR TITLE
UHF-11232: Add schema entry for helfi linkit widget

### DIFF
--- a/config/schema/helfi_platform_config.schema.yml
+++ b/config/schema/helfi_platform_config.schema.yml
@@ -28,3 +28,15 @@ field.value.location:
     longitude:
       type: float
       label: longitude
+
+# Schema for the Helfi Linkit widget.
+field.widget.settings.helfi_linkit:
+  type: field.widget.settings.link_default
+  label: 'Helfi Linkit widget settings'
+  mapping:
+    linkit_profile:
+      type: string
+      label: 'Linkit profile'
+    linkit_auto_link_text:
+      type: boolean
+      label: 'Automatically populate link text from entity label'


### PR DESCRIPTION
# [UHF-11232](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11232)
Fix errors in Etusivu tests.

## What was done
* Add schema entry for helfi linkit widget 

## How to install
* Boot up Etusivu instance
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-11232`
* Run `make fresh`

## How to test
 * Run `make shell`
 * Run  `SIMPLETEST_BASE_URL=https://helfi-etusivu.docker.so vendor/bin/phpunit public/modules/custom/helfi_annif/` (this might take a while)
 * Troubleshooting:
   * Permission errors: run `chmod 777 -R` for directories  `public/sites/simpletest` and `public/sites/default/files/simpletest`
   * Deprecation warnings: unrelated, disregard for now

If all goes right, you should receive green lights and the tests should pass. Some deprecation warning show up, but they are not addressed here.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation



[UHF-11232]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ