### PR TITLE
UHF-9494: Changed how many items are shown in service units

### DIFF
--- a/modules/helfi_tpr_config/config/install/views.view.service_units.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.service_units.yml
@@ -91,7 +91,7 @@ display:
         type: full
         options:
           offset: 0
-          items_per_page: 8
+          items_per_page: 15
           total_pages: null
           id: 0
           tags:

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -412,3 +412,12 @@ function helfi_tpr_config_update_9076(): void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_tpr_config');
 }
+
+/**
+ * UHF-9494: Updated amount of items per page.
+ */
+function helfi_tpr_config_update_9077(): void {
+  // Re-import 'helfi_tpr_config' configuration.
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_tpr_config');
+}

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -405,15 +405,6 @@ function helfi_tpr_config_update_9074(): void {
 }
 
 /**
- * UHF-11363: Updated pager labels in views.
- */
-function helfi_tpr_config_update_9076(): void {
-  // Re-import 'helfi_tpr_config' configuration.
-  \Drupal::service('helfi_platform_config.config_update_helper')
-    ->update('helfi_tpr_config');
-}
-
-/**
  * UHF-9494: Updated amount of items per page.
  */
 function helfi_tpr_config_update_9077(): void {


### PR DESCRIPTION
# [UHF-9494](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9494)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed how many items are shown in service units

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helfi Platform config
    * `composer require drupal/helfi_platform_config:dev-UHF-9494`
* Run `make drush-updb drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Testing instructions are in hdbt pr
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1182


[UHF-9494]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ