### PR TITLE
UHF-11462: Performance improvements to Linked Events query parameter handling

### DIFF
--- a/modules/helfi_react_search/src/Enum/CategoryKeywords.php
+++ b/modules/helfi_react_search/src/Enum/CategoryKeywords.php
@@ -134,8 +134,6 @@ class CategoryKeywords {
 
   public const CHILDREN = 'yso:p4354';
 
-  public const WORKLIFE = 'yso:p6357';
-
   /**
    * Enum class, prevent instantiating.
    */

--- a/modules/helfi_react_search/src/Enum/CategoryKeywords.php
+++ b/modules/helfi_react_search/src/Enum/CategoryKeywords.php
@@ -134,6 +134,8 @@ class CategoryKeywords {
 
   public const CHILDREN = 'yso:p4354';
 
+  public const WORKLIFE = 'yso:p6357';
+
   /**
    * Enum class, prevent instantiating.
    */

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -403,6 +403,10 @@ class LinkedEvents {
             $params['internet_based'] = 'true';
             break;
 
+          case 'keyword':
+            $this->handleKeywords($params, $param);
+            break;
+
           default:
             $params[$key] = $param;
             break;

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -380,7 +380,7 @@ class LinkedEvents {
             break;
 
           case 'text':
-            $this->handleTextSearch($params, $param);
+            $params['all_ongoing_AND'] = $param;
             break;
 
           case 'isFree':
@@ -447,31 +447,6 @@ class LinkedEvents {
     }
 
     return implode(',', $keywords);
-  }
-
-  /**
-   * Handle text search.
-   *
-   * Some search phrases can be replaced with a keyword making the API request
-   * much more performant.
-   *
-   * @param array $params
-   *   The parameters. Passed by reference.
-   * @param string $text
-   *   The search text to handle.
-   */
-  protected function handleTextSearch(&$params, string $text) : void {
-    $keyword = match ($text) {
-      'tyollisyys', 'työllisyys' => CategoryKeywords::WORKLIFE,
-      default => NULL,
-    };
-
-    if ($keyword) {
-      $this->handleKeywords($params, $keyword);
-    }
-    else {
-      $params['all_ongoing_AND'] = $text;
-    }
   }
 
   /**

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -462,7 +462,8 @@ class LinkedEvents {
       default => NULL,
     };
 
-    // Always use the 'all_ongoing_AND'-parameter to filter out events that are not ongoing.
+    // Always use the 'all_ongoing_AND'-parameter to filter out events that are
+    // not ongoing.
     if ($keyword) {
       $params['all_ongoing_AND'] = ' ';
       $this->handleKeywords($params, $keyword);

--- a/modules/helfi_react_search/src/LinkedEvents.php
+++ b/modules/helfi_react_search/src/LinkedEvents.php
@@ -462,10 +462,7 @@ class LinkedEvents {
       default => NULL,
     };
 
-    // Always use the 'all_ongoing_AND'-parameter to filter out events that are
-    // not ongoing.
     if ($keyword) {
-      $params['all_ongoing_AND'] = ' ';
       $this->handleKeywords($params, $keyword);
     }
     else {

--- a/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
@@ -306,17 +306,11 @@ class LinkedEventsTest extends UnitTestCase {
     $url_format_places = $sut->formatPlacesUrl('tprek:1923');
     $this->assertEquals('https://api.hel.fi/linkedevents/v1/place?has_upcoming_events=true&sort=name&page_size=100', $url_format_places);
 
-    // Test the parseParams method; replace search text with a known keyword.
-    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys');
+    // Test the parseParams method; add keywords from category selections as
+    // well as manually.
+    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?categories=movie&keyword=yso:p6357');
     $this->assertEquals([
-      'keyword' => 'yso:p6357',
-    ], $params);
-
-    // Test the parseParams method; replace search text with a known keyword and
-    // add keywords from category selections.
-    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys&categories=movie');
-    $this->assertEquals([
-      'keyword' => 'yso:p6357,yso:p1235',
+      'keyword' => 'yso:p1235,yso:p6357',
     ], $params);
 
     // Test the parseParams method with multiple params.

--- a/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
@@ -336,7 +336,8 @@ class LinkedEventsTest extends UnitTestCase {
       'internet_based' => 'true',
     ], $params);
 
-    // Test the parseParams method; params without special handling should pass through untouched.
+    // Test the parseParams method; params without special handling should pass
+    // through untouched.
     $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?test_param_1=test_value_1&test_param_2=test_value_2');
     $this->assertEquals([
       'test_param_1' => 'test_value_1',

--- a/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
@@ -309,7 +309,6 @@ class LinkedEventsTest extends UnitTestCase {
     // Test the parseParams method; replace search text with a known keyword.
     $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys');
     $this->assertEquals([
-      'all_ongoing_AND' => ' ',
       'keyword' => 'yso:p6357',
     ], $params);
 
@@ -317,7 +316,6 @@ class LinkedEventsTest extends UnitTestCase {
     // add keywords from category selections.
     $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys&categories=movie');
     $this->assertEquals([
-      'all_ongoing_AND' => ' ',
       'keyword' => 'yso:p6357,yso:p1235',
     ], $params);
 

--- a/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/LinkedEventsTest.php
@@ -305,6 +305,43 @@ class LinkedEventsTest extends UnitTestCase {
     // Test the formatPlacesUrl method.
     $url_format_places = $sut->formatPlacesUrl('tprek:1923');
     $this->assertEquals('https://api.hel.fi/linkedevents/v1/place?has_upcoming_events=true&sort=name&page_size=100', $url_format_places);
+
+    // Test the parseParams method; replace search text with a known keyword.
+    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys');
+    $this->assertEquals([
+      'all_ongoing_AND' => ' ',
+      'keyword' => 'yso:p6357',
+    ], $params);
+
+    // Test the parseParams method; replace search text with a known keyword and
+    // add keywords from category selections.
+    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=tyollisyys&categories=movie');
+    $this->assertEquals([
+      'all_ongoing_AND' => ' ',
+      'keyword' => 'yso:p6357,yso:p1235',
+    ], $params);
+
+    // Test the parseParams method with multiple params.
+    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?text=test_text&categories=movie&start=2025-01-31&divisions=test_division&places=test_place&dateTypes=today&isFree=true&onlyEveningEvents=true&onlyRemoteEvents=true&onlyChildrenEvents=true');
+    $this->assertEquals([
+      'all_ongoing_AND' => 'test_text',
+      'keyword' => 'yso:p1235',
+      'start' => 'now',
+      'division' => 'test_division',
+      'location' => 'test_place',
+      'end' => 'today',
+      'is_free' => 'true',
+      'keyword_AND' => 'yso:p4354',
+      'starts_after' => '16',
+      'internet_based' => 'true',
+    ], $params);
+
+    // Test the parseParams method; params without special handling should pass through untouched.
+    $params = $sut->parseParams('https://tapahtumat.hel.fi/fi/haku?test_param_1=test_value_1&test_param_2=test_value_2');
+    $this->assertEquals([
+      'test_param_1' => 'test_value_1',
+      'test_param_2' => 'test_value_2',
+    ], $params);
   }
 
   /**


### PR DESCRIPTION
# [UHF-11462](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11462)

Requests from Linked Events React search components to Linked Events API are currently prone to timeouts, especially when a text search query parameter is included. It was suggested in the ticket that using a keyword instead would make the request more performant. ~This PR attempts to do just that~.

## Background investigation and performance testing

* A db query on "Työ ja yrittäminen" revealed all linked events paragraphs that have a `text`-parameter use the word `tyollisuus` or `työllisyys` (identical in terms of results). They will then all benefit from converting the text based search into a keyword based.
* Tested calling the api with the current request structure and the suggested alteration
  * Current: https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=10&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=fi&all_ongoing_AND=tyollisyys
    * Response time (uncached) ~ 8.5 seconds
  * Altered: https://api.hel.fi/linkedevents/v1/event/?event_type=General&format=json&include=keywords%2Clocation&page=1&page_size=10&sort=end_time&start=now&super_event_type=umbrella%2Cnone&language=fi&all_ongoing=true&keyword=yso:p6357
    * Response time (uncached) ~ 2.5 seconds
* This alteration currently only benefits the embeds in "Työ ja ympäristö", but can be extended. Also this alteration is not easily done as there's no keyword filtering available in https://tapahtumat.hel.fi/ .
* For example "Kasvatus ja koulutus" has lot's of embeds where the text based search could be replaced with a location filter (would result in the same performance improvement). It's possible to do location filtering in https://tapahtumat.hel.fi/ , so this should be easily achieved by content editors.

## What was done

* ~Adds a text parameter handler where certain text searches can be converted into keyword parameters instead of using the less performant `all_ongoing_AND`-parameter, which is still the default fot texts other than `tyollisuus` or `työllisyys`~. This was removed after discussing with Aleksi. Better to use this enhancement manually for now (by adding the keyword parameter manually) which makes it a conscious decision between a slightly different result set and performance.
* Adds parameter handling for a manual `keyword` query parameter to allow filtering with known keywords (even though such filtering isn't available in https://tapahtumat.hel.fi/). Also makes sure keywords can be set from different parameters without them overriding each other.
* Updates unit tests to cover some parameter handling use cases.

## How to install

See install steps in https://github.com/City-of-Helsinki/drupal-hdbt/pull/1196

## How to test

* [ ] Check that keyword parameters set by different parameter handlers work together
  * Go to https://helfi-elo.docker.so/fi/yritykset-ja-tyo/tyollisyyspalveluiden-tapahtumat and edit the page.
  * Update the **Api URL**-field with `https://tapahtumat.hel.fi/fi/haku?start=2025-01-31&categories=movie&keyword=yso:p6357` and Save
  * Open inspector network tab and search for `api.hel.fi/linkedevents/v1` (reload if needed to get it there)
  * Make sure the api call includes multiple values in the `keyword`-parameter (one manual and one set by the `categories`-handling)
* [ ] Check that code follows our standards

## Continuous documentation

* [x] This change doesn't require updates to the documentation

## Other PRs

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1196


[UHF-11462]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ