### PR TITLE
UHF-11394 Added missing translations

### DIFF
--- a/translations/override/fi.po
+++ b/translations/override/fi.po
@@ -5,6 +5,11 @@ msgid ""
 msgstr ""
 
 # Drupal
+msgid "1 error has been found: "
+msgid_plural "@count errors have been found: "
+msgstr[0] "1 virhe löytyi: "
+msgstr[1] "@count virhettä löytyi: "
+
 msgid ""
 "Menu links with lower weights are displayed before links with higher weights."
 msgstr "Mitä pienempi luku, sitä ylempänä järjestyksessä."


### PR DESCRIPTION
# [UHF-11394](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11394)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added inline form error translation


[UHF-11394]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ