### PR TITLE
UFF-11615: Fix empty news list cache duration

### DIFF
--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -92,11 +92,12 @@ function helfi_paragraphs_news_list_paragraph_view(
     $ids = $query->execute();
     $entities = $storage->loadMultiple($ids);
 
-    // Don't cache empty results for long periods of time.
+    // Don't cache empty results for longer periods of time.
     if (empty($entities)) {
       // Setting a max-age here is not enough since it would not bubble up to
       // the page cache. Therefore we set a cache tag for empty results and let
-      // CacheResponseSubscriber set the max-age of the response cache.
+      // CacheResponseSubscriber set the max-age of the response cache when
+      // the cache tag is present.
       // @see https://www.drupal.org/node/2352009
       // @see \Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber::handleNewsListCache()
       $build['#cache']['tags'][] = 'helfi_news_list_empty_results';

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -91,6 +91,11 @@ function helfi_paragraphs_news_list_paragraph_view(
     $ids = $query->execute();
     $entities = $storage->loadMultiple($ids);
 
+    // Set the cache max-age to 10mins to avoid caching the empty result.
+    if (empty($entities)) {
+      $build['#cache']['max-age'] = 600;
+    }
+
     foreach ($entities as $item) {
       $item->addCacheableDependency($entity);
 

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -19,6 +19,7 @@ use Drupal\helfi_api_base\Environment\Project;
 use Drupal\helfi_paragraphs_news_list\Entity\ExternalEntity\News;
 use Drupal\helfi_paragraphs_news_list\Entity\ExternalEntity\Term;
 use Drupal\helfi_paragraphs_news_list\Entity\NewsFeedParagraph;
+use Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber;
 use Drupal\paragraphs\ParagraphInterface;
 
 /**
@@ -99,7 +100,7 @@ function helfi_paragraphs_news_list_paragraph_view(
       // @see https://www.drupal.org/node/2352009
       // @see \Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber::handleNewsListCache()
       $build['#cache']['tags'][] = 'helfi_news_list_empty_results';
-      $build['#cache']['max-age'] = 600;
+      $build['#cache']['max-age'] = CacheResponseSubscriber::EMPTY_LIST_MAX_AGE;
     }
 
     foreach ($entities as $item) {

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -93,13 +93,13 @@ function helfi_paragraphs_news_list_paragraph_view(
 
     // Don't cache empty results for long periods of time.
     if (empty($entities)) {
-      // Setting a max-age here doesn't work since it would not bubble up to
-      // the page cache.
-      // Therefore we instead set a cache tag for empty results
-      // and let the CacheResponseSubscriber set the max-age.
+      // Setting a max-age here is not enough since it would not bubble up to
+      // the page cache. Therefore we set a cache tag for empty results and let
+      // CacheResponseSubscriber set the max-age of the response cache.
       // @see https://www.drupal.org/node/2352009
       // @see \Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber::handleNewsListCache()
       $build['#cache']['tags'][] = 'helfi_news_list_empty_results';
+      $build['#cache']['max-age'] = 600;
     }
 
     foreach ($entities as $item) {

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.module
@@ -91,9 +91,15 @@ function helfi_paragraphs_news_list_paragraph_view(
     $ids = $query->execute();
     $entities = $storage->loadMultiple($ids);
 
-    // Set the cache max-age to 10mins to avoid caching the empty result.
+    // Don't cache empty results for long periods of time.
     if (empty($entities)) {
-      $build['#cache']['max-age'] = 600;
+      // Setting a max-age here doesn't work since it would not bubble up to
+      // the page cache.
+      // Therefore we instead set a cache tag for empty results
+      // and let the CacheResponseSubscriber set the max-age.
+      // @see https://www.drupal.org/node/2352009
+      // @see \Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber::handleNewsListCache()
+      $build['#cache']['tags'][] = 'helfi_news_list_empty_results';
     }
 
     foreach ($entities as $item) {

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.services.yml
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.services.yml
@@ -9,3 +9,5 @@ services:
   helfi_paragraphs_news_list.elastic_client:
     class: Elastic\Elasticsearch\Client
     factory: ['@helfi_paragraphs_news_list.elastic_client_factory', 'create']
+
+  Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber: ~

--- a/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
+++ b/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
@@ -18,6 +18,11 @@ use Symfony\Component\HttpKernel\KernelEvents;
 final class CacheResponseSubscriber implements EventSubscriberInterface {
 
   /**
+   * The max age to cache empty news list results.
+   */
+  public const EMPTY_LIST_MAX_AGE = 600;
+
+  /**
    * Constructs a new CacheResponseSubscriber object.
    *
    * @param \Drupal\Core\Datetime\TimeInterface $time
@@ -41,9 +46,8 @@ final class CacheResponseSubscriber implements EventSubscriberInterface {
 
     // Set max-age to 10 minutes for pages with empty news list results.
     if (in_array('helfi_news_list_empty_results', $cache_tags)) {
-      $max_age = 600;
-      $response->setMaxAge($max_age);
-      $date = new \DateTime('@' . ($this->time->getRequestTime() + $max_age));
+      $response->setMaxAge(self::EMPTY_LIST_MAX_AGE);
+      $date = new \DateTime('@' . ($this->time->getRequestTime() + self::EMPTY_LIST_MAX_AGE));
       $response->setExpires($date);
     }
   }

--- a/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
+++ b/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
@@ -6,12 +6,11 @@ namespace Drupal\helfi_paragraphs_news_list\EventSubscriber;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Render\HtmlResponse;
 use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-
-use Drupal\Core\Render\HtmlResponse;
 
 /**
  * Cache response subscriber.
@@ -40,7 +39,7 @@ final class CacheResponseSubscriber implements EventSubscriberInterface {
   protected function handleNewsListCache(HtmlResponse $response): void {
     $cache_tags = $response->getCacheableMetadata()->getCacheTags();
 
-    // Set max-age to 10 minutes for empty news list results.
+    // Set max-age to 10 minutes for pages with empty news list results.
     if (in_array('helfi_news_list_empty_results', $cache_tags)) {
       $max_age = 600;
       $response->setMaxAge($max_age);

--- a/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
+++ b/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
@@ -25,9 +25,9 @@ final class CacheResponseSubscriber implements EventSubscriberInterface {
   /**
    * Constructs a new CacheResponseSubscriber object.
    *
-   * @param \Drupal\Core\Datetime\TimeInterface $time
+   * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
-   * @param \Drupal\Core\Session\UserInterface $currentUser
+   * @param \Drupal\Core\Session\AccountInterface $currentUser
    *   The current user.
    */
   public function __construct(
@@ -37,6 +37,8 @@ final class CacheResponseSubscriber implements EventSubscriberInterface {
 
   /**
    * Handle news list cache.
+   *
+   * Sets the max-age and expires header for pages with empty news list results.
    *
    * @param \Drupal\Core\Render\HtmlResponse $response
    *   The response.

--- a/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
+++ b/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_paragraphs_news_list\EventSubscriber;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheableResponseInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+use Drupal\Core\Render\HtmlResponse;
+
+/**
+ * Cache response subscriber.
+ */
+final class CacheResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new CacheResponseSubscriber object.
+   *
+   * @param \Drupal\Core\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \Drupal\Core\Session\UserInterface $currentUser
+   *   The current user.
+   */
+  public function __construct(
+    private readonly TimeInterface $time,
+    private readonly AccountInterface $currentUser,
+  ) {}
+
+  /**
+   * Handle news list cache.
+   *
+   * @param \Drupal\Core\Render\HtmlResponse $response
+   *   The response.
+   */
+  protected function handleNewsListCache(HtmlResponse $response): void {
+    $cache_tags = $response->getCacheableMetadata()->getCacheTags();
+
+    // Set max-age to 10 minutes for empty news list results.
+    if (in_array('helfi_news_list_empty_results', $cache_tags)) {
+      $max_age = 600;
+      $response->setMaxAge($max_age);
+      $date = new \DateTime('@' . ($this->time->getRequestTime() + $max_age));
+      $response->setExpires($date);
+    }
+  }
+
+  /**
+   * Kernel response event handler.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event.
+   */
+  public function onKernelResponse(ResponseEvent $event): void {
+    $response = $event->getResponse();
+
+    // Only handle cacheable responses.
+    if (!$response instanceof CacheableResponseInterface) {
+      return;
+    }
+
+    // Only handle anonymous user requests.
+    if ($this->currentUser->isAuthenticated()) {
+      return;
+    }
+
+    $this->handleNewsListCache($response);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::RESPONSE => ['onKernelResponse'],
+    ];
+  }
+
+}

--- a/modules/helfi_paragraphs_news_list/tests/src/Kernel/CacheResponseSubscriberTest.php
+++ b/modules/helfi_paragraphs_news_list/tests/src/Kernel/CacheResponseSubscriberTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_paragraphs_news_list\Kernel;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Render\HtmlResponse;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\helfi_paragraphs_news_list\EventSubscriber\CacheResponseSubscriber;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * Tests the CacheResponseSubscriber.
+ */
+class CacheResponseSubscriberTest extends KernelTestBase {
+
+  /**
+   * Tests the handling of empty news list cache.
+   */
+  public function testEmptyNewsListCacheHandling(): void {
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getRequestTime()->willReturn(1234567890);
+
+    $account = $this->prophesize(AccountInterface::class);
+    $account->isAuthenticated()->willReturn(FALSE);
+
+    $cacheableMetadata = $this->prophesize(CacheableMetadata::class);
+    $cacheableMetadata->getCacheTags()
+      ->willReturn(['helfi_news_list_empty_results', 'node:123']);
+
+    $response = $this->prophesize(HtmlResponse::class);
+    $response->getCacheableMetadata()
+      ->willReturn($cacheableMetadata->reveal());
+
+    $response->setMaxAge(CacheResponseSubscriber::EMPTY_LIST_MAX_AGE)
+      ->willReturn($response)
+      ->shouldBeCalled();
+
+    $response->setExpires(new \DateTime('@' . (1234567890 + CacheResponseSubscriber::EMPTY_LIST_MAX_AGE)))
+      ->willReturn($response)
+      ->shouldBeCalled();
+
+    $event = $this->prophesize(ResponseEvent::class);
+    $event->getResponse()->willReturn($response->reveal());
+
+    $sut = new CacheResponseSubscriber(
+      $time->reveal(),
+      $account->reveal(),
+    );
+
+    $sut->onKernelResponse($event->reveal());
+  }
+
+  /**
+   * Tests the handling of non-empty news list cache.
+   */
+  public function testNonEmptyNewsListCacheHandling(): void {
+    $time = $this->prophesize(TimeInterface::class);
+    $time->getRequestTime()->willReturn(1234567890);
+
+    $account = $this->prophesize(AccountInterface::class);
+    $account->isAuthenticated()->willReturn(FALSE);
+
+    $cacheableMetadata = $this->prophesize(CacheableMetadata::class);
+    $cacheableMetadata->getCacheTags()
+      ->willReturn(['node:123']);
+
+    $response = $this->prophesize(HtmlResponse::class);
+    $response->getCacheableMetadata()
+      ->willReturn($cacheableMetadata->reveal());
+
+    $response->setMaxAge(CacheResponseSubscriber::EMPTY_LIST_MAX_AGE)
+      ->shouldNotBeCalled();
+
+    $response->setExpires(new \DateTime('@' . (1234567890 + CacheResponseSubscriber::EMPTY_LIST_MAX_AGE)))
+      ->shouldNotBeCalled();
+
+    $event = $this->prophesize(ResponseEvent::class);
+    $event->getResponse()->willReturn($response->reveal());
+
+    $sut = new CacheResponseSubscriber(
+      $time->reveal(),
+      $account->reveal(),
+    );
+
+    $sut->onKernelResponse($event->reveal());
+  }
+
+}


### PR DESCRIPTION
# [UHF-11615](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11615)

News lists paragraphs could have empty result in cases when the external source is not available. The list remains empty until the page cache expire or when purged, which could sometimes take a long time.

This fix sets the maximum cache duration to 10mins when a news list is empty.

## What was done

* Set the max-age of the paragraph render cache to 600sec (10mins)
* In addition, set the page render cache's max-age to the same value

## How to install
* Make sure your `helfi-etusivu` instance is up and running
  * Rebuild and re-index the news entities to Elasticsearch
* Make sure your `helfi-tyo-yrittaminen` instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11615`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`

## How to test
* [x] Visit https://helfi-elo.docker.so/fi/yritykset-ja-tyo
   * [x] Verify that news items are appearing
   * [x] Verify that cache-control header's max-age=31536000
* [x] Simulate an external source outage by turning off the elastic container in `helfi-etusivu`
* [x] Clear the drupal cache: `drush cr`
* [x] Visit https://helfi-elo.docker.so/fi/yritykset-ja-tyo
   * [x] News list should be empty
   * [x] Verify that cache-control header's max-age=600
   * [x] Verify also that the expire header is set to 10mins


[UHF-11615]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ