### PR TITLE
UHF-11615: Fix the type response type hinting

### DIFF
--- a/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
+++ b/modules/helfi_paragraphs_news_list/src/EventSubscriber/CacheResponseSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\helfi_paragraphs_news_list\EventSubscriber;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Render\HtmlResponse;
 use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -64,7 +63,7 @@ final class CacheResponseSubscriber implements EventSubscriberInterface {
     $response = $event->getResponse();
 
     // Only handle cacheable responses.
-    if (!$response instanceof CacheableResponseInterface) {
+    if (!$response instanceof HtmlResponse) {
       return;
     }
 


### PR DESCRIPTION
# [UHF-11615](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11615)

## What was done

* Fixes the broken tests in Etusivu (See https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/876), which was caused by passing the wrong response type

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11615-fixes`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Verify that the Etusivu test are passing: `./vendor/bin/phpunit tests/dtt/src/ExistingSite/`

[UHF-11615]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ