### PR TITLE
UHF-11579: Recommendation block, part 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drupal/focal_point": "^2.0",
         "drupal/jquery_ui": "^1.6",
         "drupal/jquery_ui_draggable": "^2.0",
+        "drupal/jsonapi_extras": "^3.26",
         "drupal/gin_toolbar": "^2.0",
         "drupal/hal": "^2.0",
         "drupal/helfi_api_base": "*",

--- a/modules/helfi_recommendations/config/optional/jsonapi.settings.yml
+++ b/modules/helfi_recommendations/config/optional/jsonapi.settings.yml
@@ -1,0 +1,4 @@
+read_only: true
+maintenance_header_retry_seconds:
+  min: 5
+  max: 10

--- a/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.media--image.yml
+++ b/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.media--image.yml
@@ -1,0 +1,149 @@
+uuid: 17053d14-14bb-45e0-9c86-b64f5b420474
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media--image
+disabled: false
+path: media/image
+resourceType: media--image
+resourceFields:
+  mid:
+    disabled: false
+    fieldName: mid
+    publicName: mid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  bundle:
+    disabled: false
+    fieldName: bundle
+    publicName: bundle
+    enhancer:
+      id: ''
+  revision_created:
+    disabled: false
+    fieldName: revision_created
+    publicName: revision_created
+    enhancer:
+      id: ''
+  revision_user:
+    disabled: false
+    fieldName: revision_user
+    publicName: revision_user
+    enhancer:
+      id: ''
+  revision_log_message:
+    disabled: false
+    fieldName: revision_log_message
+    publicName: revision_log_message
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  name:
+    disabled: false
+    fieldName: name
+    publicName: name
+    enhancer:
+      id: ''
+  thumbnail:
+    disabled: false
+    fieldName: thumbnail
+    publicName: thumbnail
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: false
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: false
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: false
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: false
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  field_media_image:
+    disabled: false
+    fieldName: field_media_image
+    publicName: field_media_image
+    enhancer:
+      id: ''
+  field_photographer:
+    disabled: false
+    fieldName: field_photographer
+    publicName: field_photographer
+    enhancer:
+      id: ''

--- a/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
+++ b/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.node--landing_page.yml
@@ -1,0 +1,227 @@
+uuid: 638ffd1c-1aa0-43ec-aaae-cf8912c5634e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node--landing_page
+disabled: false
+path: node/landing_page
+resourceType: node--landing_page
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: false
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: false
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: false
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: false
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: false
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: false
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: false
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  color_palette:
+    disabled: false
+    fieldName: color_palette
+    publicName: color_palette
+    enhancer:
+      id: ''
+  hide_sidebar_navigation:
+    disabled: false
+    fieldName: hide_sidebar_navigation
+    publicName: hide_sidebar_navigation
+    enhancer:
+      id: ''
+  toc_enabled:
+    disabled: false
+    fieldName: toc_enabled
+    publicName: toc_enabled
+    enhancer:
+      id: ''
+  toc_title:
+    disabled: false
+    fieldName: toc_title
+    publicName: toc_title
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  publish_on:
+    disabled: false
+    fieldName: publish_on
+    publicName: publish_on
+    enhancer:
+      id: ''
+  unpublish_on:
+    disabled: false
+    fieldName: unpublish_on
+    publicName: unpublish_on
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: false
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: false
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: false
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  published_at:
+    disabled: false
+    fieldName: published_at
+    publicName: published_at
+    enhancer:
+      id: ''
+  field_content:
+    disabled: false
+    fieldName: field_content
+    publicName: field_content
+    enhancer:
+      id: ''
+  field_has_hero:
+    disabled: false
+    fieldName: field_has_hero
+    publicName: field_has_hero
+    enhancer:
+      id: ''
+  field_hero:
+    disabled: false
+    fieldName: field_hero
+    publicName: field_hero
+    enhancer:
+      id: ''
+  field_liftup_image:
+    disabled: false
+    fieldName: field_liftup_image
+    publicName: field_liftup_image
+    enhancer:
+      id: ''
+  field_metatags:
+    disabled: false
+    fieldName: field_metatags
+    publicName: field_metatags
+    enhancer:
+      id: ''
+  field_whaever:
+    disabled: false
+    fieldName: field_whaever
+    publicName: field_whaever
+    enhancer:
+      id: ''

--- a/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.node--page.yml
+++ b/modules/helfi_recommendations/config/optional/jsonapi_extras.jsonapi_resource_config.node--page.yml
@@ -1,0 +1,239 @@
+uuid: 3b4629ed-ac1f-4b29-a58a-23940ba5b214
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node--page
+disabled: false
+path: node/page
+resourceType: node--page
+resourceFields:
+  nid:
+    disabled: false
+    fieldName: nid
+    publicName: nid
+    enhancer:
+      id: ''
+  uuid:
+    disabled: false
+    fieldName: uuid
+    publicName: uuid
+    enhancer:
+      id: ''
+  vid:
+    disabled: false
+    fieldName: vid
+    publicName: vid
+    enhancer:
+      id: ''
+  langcode:
+    disabled: false
+    fieldName: langcode
+    publicName: langcode
+    enhancer:
+      id: ''
+  type:
+    disabled: false
+    fieldName: type
+    publicName: type
+    enhancer:
+      id: ''
+  revision_timestamp:
+    disabled: false
+    fieldName: revision_timestamp
+    publicName: revision_timestamp
+    enhancer:
+      id: ''
+  revision_uid:
+    disabled: false
+    fieldName: revision_uid
+    publicName: revision_uid
+    enhancer:
+      id: ''
+  revision_log:
+    disabled: false
+    fieldName: revision_log
+    publicName: revision_log
+    enhancer:
+      id: ''
+  status:
+    disabled: false
+    fieldName: status
+    publicName: status
+    enhancer:
+      id: ''
+  uid:
+    disabled: false
+    fieldName: uid
+    publicName: uid
+    enhancer:
+      id: ''
+  title:
+    disabled: false
+    fieldName: title
+    publicName: title
+    enhancer:
+      id: ''
+  created:
+    disabled: false
+    fieldName: created
+    publicName: created
+    enhancer:
+      id: ''
+  changed:
+    disabled: false
+    fieldName: changed
+    publicName: changed
+    enhancer:
+      id: ''
+  promote:
+    disabled: false
+    fieldName: promote
+    publicName: promote
+    enhancer:
+      id: ''
+  sticky:
+    disabled: false
+    fieldName: sticky
+    publicName: sticky
+    enhancer:
+      id: ''
+  default_langcode:
+    disabled: false
+    fieldName: default_langcode
+    publicName: default_langcode
+    enhancer:
+      id: ''
+  revision_default:
+    disabled: false
+    fieldName: revision_default
+    publicName: revision_default
+    enhancer:
+      id: ''
+  revision_translation_affected:
+    disabled: false
+    fieldName: revision_translation_affected
+    publicName: revision_translation_affected
+    enhancer:
+      id: ''
+  color_palette:
+    disabled: false
+    fieldName: color_palette
+    publicName: color_palette
+    enhancer:
+      id: ''
+  hide_sidebar_navigation:
+    disabled: false
+    fieldName: hide_sidebar_navigation
+    publicName: hide_sidebar_navigation
+    enhancer:
+      id: ''
+  toc_enabled:
+    disabled: false
+    fieldName: toc_enabled
+    publicName: toc_enabled
+    enhancer:
+      id: ''
+  toc_title:
+    disabled: false
+    fieldName: toc_title
+    publicName: toc_title
+    enhancer:
+      id: ''
+  metatag:
+    disabled: false
+    fieldName: metatag
+    publicName: metatag
+    enhancer:
+      id: ''
+  path:
+    disabled: false
+    fieldName: path
+    publicName: path
+    enhancer:
+      id: ''
+  publish_on:
+    disabled: false
+    fieldName: publish_on
+    publicName: publish_on
+    enhancer:
+      id: ''
+  unpublish_on:
+    disabled: false
+    fieldName: unpublish_on
+    publicName: unpublish_on
+    enhancer:
+      id: ''
+  menu_link:
+    disabled: false
+    fieldName: menu_link
+    publicName: menu_link
+    enhancer:
+      id: ''
+  content_translation_source:
+    disabled: false
+    fieldName: content_translation_source
+    publicName: content_translation_source
+    enhancer:
+      id: ''
+  content_translation_outdated:
+    disabled: false
+    fieldName: content_translation_outdated
+    publicName: content_translation_outdated
+    enhancer:
+      id: ''
+  published_at:
+    disabled: false
+    fieldName: published_at
+    publicName: published_at
+    enhancer:
+      id: ''
+  field_content:
+    disabled: false
+    fieldName: field_content
+    publicName: field_content
+    enhancer:
+      id: ''
+  field_has_hero:
+    disabled: false
+    fieldName: field_has_hero
+    publicName: field_has_hero
+    enhancer:
+      id: ''
+  field_hero:
+    disabled: false
+    fieldName: field_hero
+    publicName: field_hero
+    enhancer:
+      id: ''
+  field_lead_in:
+    disabled: false
+    fieldName: field_lead_in
+    publicName: field_lead_in
+    enhancer:
+      id: ''
+  field_liftup_image:
+    disabled: false
+    fieldName: field_liftup_image
+    publicName: field_liftup_image
+    enhancer:
+      id: ''
+  field_lower_content:
+    disabled: false
+    fieldName: field_lower_content
+    publicName: field_lower_content
+    enhancer:
+      id: ''
+  field_metatags:
+    disabled: false
+    fieldName: field_metatags
+    publicName: field_metatags
+    enhancer:
+      id: ''
+  field_sidebar_content:
+    disabled: false
+    fieldName: field_sidebar_content
+    publicName: field_sidebar_content
+    enhancer:
+      id: ''

--- a/modules/helfi_recommendations/config/optional/jsonapi_extras.settings.yml
+++ b/modules/helfi_recommendations/config/optional/jsonapi_extras.settings.yml
@@ -1,0 +1,4 @@
+path_prefix: jsonapi
+include_count: true
+default_disabled: true
+validate_configuration_integrity: true

--- a/modules/helfi_recommendations/config/optional/search_api.index.suggestions.yml
+++ b/modules/helfi_recommendations/config/optional/search_api.index.suggestions.yml
@@ -56,6 +56,14 @@ field_settings:
     dependencies:
       module:
         - helfi_recommendations
+  uuid:
+    label: UUID
+    datasource_id: 'entity:suggested_topics'
+    property_path: uuid
+    type: string
+    dependencies:
+      module:
+        - helfi_recommendations
 datasource_settings:
   'entity:suggested_topics': {  }
 processor_settings:

--- a/modules/helfi_recommendations/helfi_recommendations.info.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.info.yml
@@ -10,5 +10,6 @@ dependencies:
   - readonly_field_widget:readonly_field_widget
   - drupal:field
   - jsonapi_extras:jsonapi_extras
+  - search_api:search_api
 'interface translation project': helfi_recommendations
 'interface translation server pattern': modules/custom/helfi_recommendations/translations/%language.po

--- a/modules/helfi_recommendations/helfi_recommendations.info.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.info.yml
@@ -9,5 +9,6 @@ dependencies:
   - helfi_api_base:helfi_api_base
   - readonly_field_widget:readonly_field_widget
   - drupal:field
+  - jsonapi_extras:jsonapi_extras
 'interface translation project': helfi_recommendations
 'interface translation server pattern': modules/custom/helfi_recommendations/translations/%language.po

--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -14,6 +14,21 @@ use Drupal\helfi_recommendations\TextConverter\Document;
 use Drupal\helfi_recommendations\TopicsManagerInterface;
 
 /**
+ * Implements hook_theme().
+ */
+function helfi_recommendations_theme() : array {
+  return [
+    'recommendations_block' => [
+      'variables' => [
+        'rows' => NULL,
+        'no_results_message' => NULL,
+      ],
+      'template' => 'recommendations-block',
+    ],
+  ];
+}
+
+/**
  * Implements hook_entity_insert().
  */
 function helfi_recommendations_entity_insert(EntityInterface $entity) : void {

--- a/modules/helfi_recommendations/helfi_recommendations.services.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.services.yml
@@ -25,3 +25,8 @@ services:
       - { name: helfi_recommendations.text_converter, priority: -1 }
 
   Drupal\helfi_recommendations\EventSubscriber\SearchApiSubscriber: ~
+
+  helfi_recommendations.instance_api_client:
+    parent: helfi_api_base.api_client_base
+    arguments:
+      - '@logger.channel.helfi_recommendations'

--- a/modules/helfi_recommendations/helfi_recommendations.services.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.services.yml
@@ -26,7 +26,14 @@ services:
 
   Drupal\helfi_recommendations\EventSubscriber\SearchApiSubscriber: ~
 
-  helfi_recommendations.instance_api_client:
+  helfi_recommendations.json_api_client:
     parent: helfi_api_base.api_client_base
     arguments:
       - '@logger.channel.helfi_recommendations'
+
+  helfi_recommendations.elastic_client_factory:
+    class: Drupal\helfi_recommendations\ElasticClientBuilder
+
+  helfi_recommendations.elastic_client:
+    class: Elastic\Elasticsearch\Client
+    factory: ['@helfi_recommendations.elastic_client_factory', 'create']

--- a/modules/helfi_recommendations/helfi_recommendations.services.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.services.yml
@@ -26,11 +26,6 @@ services:
 
   Drupal\helfi_recommendations\EventSubscriber\SearchApiSubscriber: ~
 
-  helfi_recommendations.json_api_client:
-    parent: helfi_api_base.api_client_base
-    arguments:
-      - '@logger.channel.helfi_recommendations'
-
   helfi_recommendations.elastic_client_factory:
     class: Drupal\helfi_recommendations\ElasticClientBuilder
 

--- a/modules/helfi_recommendations/src/ElasticClientBuilder.php
+++ b/modules/helfi_recommendations/src/ElasticClientBuilder.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_recommendations;
+
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\helfi_api_base\Environment\Project;
+use Drupal\helfi_api_base\Environment\ServiceEnum;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+
+/**
+ * The client builder factory.
+ */
+final class ElasticClientBuilder {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $environmentResolver
+   *   The environment resolver.
+   */
+  public function __construct(
+    private readonly EnvironmentResolverInterface $environmentResolver,
+  ) {
+  }
+
+  /**
+   * Creates a new client instance.
+   *
+   * @return \Elastic\Elasticsearch\Client
+   *   The client.
+   */
+  public function create() : Client {
+    try {
+      $environment = $this->environmentResolver
+        ->getEnvironment(Project::ETUSIVU, $this->environmentResolver->getActiveEnvironmentName());
+    }
+    catch (\InvalidArgumentException) {
+      // Use prod in case matching environment does not exist.
+      $environment = $this->environmentResolver
+        ->getEnvironment(Project::ETUSIVU, EnvironmentEnum::Prod->value);
+    }
+    $service = $environment
+      ->getService(ServiceEnum::ElasticProxy)
+      ->address;
+
+    return ClientBuilder::create()
+      ->setSSLVerification($service->protocol === 'https')
+      ->setHosts([
+        $service->getAddress(),
+      ])
+      ->setHttpClientOptions([
+        'client' => [
+          'timeout' => 1,
+          'connect_timeout' => 1,
+        ],
+      ])
+      ->build();
+  }
+
+}

--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -36,12 +36,8 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
   const CACHE_MAX_AGE = 3600;
 
   /**
-   * Recommendations data.
-   *
-   * @var array
+   * {@inheritdoc}
    */
-  private $recommendationTopics = [];
-
   public function __construct(
     array $configuration,
     $plugin_id,
@@ -172,19 +168,18 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
    *   Array of recommendations
    */
   private function getRecommendations(ContentEntityInterface $entity): array {
-    if (empty($this->recommendationTopics)) {
-      try {
-        $recommendations = $this->recommendationManager
-          ->getRecommendations($entity, 3, $entity->language()->getId());
-        $this->recommendationTopics = $recommendations;
-      }
+    $recommendations = [];
+
+    try {
+      $recommendations = $this->recommendationManager
+        ->getRecommendations($entity, 3, $entity->language()->getId());
+    }
       catch (\Exception $exception) {
         Error::logException($this->logger, $exception);
         return [];
-      }
     }
 
-    return $this->recommendationTopics;
+    return $recommendations;
   }
 
 }

--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -11,7 +11,6 @@ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -19,7 +18,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Utility\Error;
 use Drupal\helfi_platform_config\EntityVersionMatcher;
 use Drupal\helfi_recommendations\RecommendationManager;
-use Drupal\helfi_recommendations\TopicsManager;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -174,9 +172,9 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       $recommendations = $this->recommendationManager
         ->getRecommendations($entity, 3, $entity->language()->getId());
     }
-      catch (\Exception $exception) {
-        Error::logException($this->logger, $exception);
-        return [];
+    catch (\Exception $exception) {
+      Error::logException($this->logger, $exception);
+      return [];
     }
 
     return $recommendations;

--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_recommendations\Plugin\Block;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
@@ -117,6 +118,20 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
     }
 
     return $max_age;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    ['entity' => $entity] = $this->entityVersionMatcher->getType();
+
+    if ($entity instanceof ContentEntityInterface && $this->recommendationManager->showRecommendations($entity)) {
+      return AccessResult::allowed();
+    }
+
+    return AccessResult::forbidden();
   }
 
   /**

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
@@ -142,4 +142,21 @@ final class SuggestedTopicsReferenceItem extends EntityReferenceItem {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave($update) {
+    parent::postSave($update);
+
+    // If the entity is new, set the parent entity data on the target entity.
+    if (!$update) {
+      $entity = $this->entity;
+      assert($entity instanceof SuggestedTopicsInterface);
+
+      $parent = $this->getEntity();
+      $entity->setParentEntity($parent);
+      $entity->save();
+    }
+  }
+
 }

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
@@ -146,8 +146,6 @@ final class SuggestedTopicsReferenceItem extends EntityReferenceItem {
    * {@inheritdoc}
    */
   public function postSave($update) {
-    parent::postSave($update);
-
     // If the entity is new, set the parent entity data on the target entity.
     if (!$update) {
       $entity = $this->entity;
@@ -157,6 +155,9 @@ final class SuggestedTopicsReferenceItem extends EntityReferenceItem {
       $entity->setParentEntity($parent);
       $entity->save();
     }
+
+    // No need to rewrite the field item to storage.
+    return FALSE;
   }
 
 }

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldType/SuggestedTopicsReferenceItem.php
@@ -12,6 +12,7 @@ use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\TypedData\MapDataDefinition;
 use Drupal\helfi_recommendations\Entity\SuggestedTopicsInterface;
 use Drupal\helfi_recommendations\TypedData\ComputedReferencePublishedStatus;
 
@@ -69,6 +70,18 @@ final class SuggestedTopicsReferenceItem extends EntityReferenceItem {
       'size' => 'tiny',
       'default' => 0,
     ];
+    $schema['columns']['instances'] = [
+      'description' => 'Serialized array of instances to show recommendations from.',
+      'type' => 'blob',
+      'size' => 'big',
+      'serialize' => TRUE,
+    ];
+    $schema['columns']['content_types'] = [
+      'description' => 'Serialized array of content types to show recommendations from.',
+      'type' => 'blob',
+      'size' => 'big',
+      'serialize' => TRUE,
+    ];
 
     return $schema;
   }
@@ -87,8 +100,14 @@ final class SuggestedTopicsReferenceItem extends EntityReferenceItem {
 
     $properties['show_block'] = DataDefinition::create('boolean')
       ->setLabel(new TranslatableMarkup('Show automatically recommended content on this page', [], ['context' => 'annif']))
-      ->setClass(ComputedReferencePublishedStatus::class)
-      ->setComputed(TRUE)
+      ->setRequired(FALSE);
+
+    $properties['instances'] = MapDataDefinition::create()
+      ->setLabel(new TranslatableMarkup('Instances to show recommendations from', [], ['context' => 'annif']))
+      ->setRequired(FALSE);
+
+    $properties['content_types'] = MapDataDefinition::create()
+      ->setLabel(new TranslatableMarkup('Allowed content types for recommendations', [], ['context' => 'annif']))
       ->setRequired(FALSE);
 
     return $properties;

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
@@ -6,12 +6,17 @@ namespace Drupal\helfi_recommendations\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Field\Attribute\FieldWidget;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\helfi_api_base\Environment\Project;
 use Drupal\helfi_recommendations\Entity\SuggestedTopics;
 use Drupal\helfi_recommendations\Entity\SuggestedTopicsInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Defines the 'suggested_topics_reference' field widget.
@@ -23,6 +28,34 @@ use Drupal\helfi_recommendations\Entity\SuggestedTopicsInterface;
   field_types: ['suggested_topics_reference'],
 )]
 final class SuggestedTopicsReferenceWidget extends WidgetBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    array $third_party_settings,
+    private readonly EnvironmentResolverInterface $environmentResolver,
+  ) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['third_party_settings'],
+      $container->get('helfi_api_base.environment_resolver')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -44,15 +77,40 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
 
     // Add custom configuration fields.
     $field = $items[$delta];
-    $definition = $field
-      ->getFieldDefinition()
-      ->getFieldStorageDefinition()
-      ->getPropertyDefinition('published');
 
     $element['published'] = [
       '#type' => 'checkbox',
       '#default_value' => $field->get('published')->getValue() ?? TRUE,
-      '#title' => $definition->getLabel(),
+      '#title' => $this->getFieldPropertyDefinition($field, 'published')->getLabel(),
+    ];
+
+    $element['show_block'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $field->get('show_block')->getValue() ?? TRUE,
+      '#title' => $this->getFieldPropertyDefinition($field, 'show_block')->getLabel(),
+    ];
+
+    $projects = $this->environmentResolver->getProjects();
+    $element['instances'] = [
+      '#type' => 'checkboxes',
+      '#default_value' => $field->get('instances')->getValue() ?? [],
+      '#title' => $this->getFieldPropertyDefinition($field, 'instances')->getLabel(),
+      '#options' => array_map(fn (Project $project) => $project->label(), $projects),
+      '#description' => $this->t('Select the instances that should be used for recommendations. If no instances are selected, recommendations will be shown from all instances.'),
+    ];
+
+    $element['content_types'] = [
+      '#type' => 'checkboxes',
+      '#default_value' => $field->get('content_types')->getValue() ?? [],
+      '#title' => $this->getFieldPropertyDefinition($field, 'content_types')->getLabel(),
+      // @todo Include TPR entity types & bundles.
+      '#options' => [
+        'node|news_article' => $this->t('News article'),
+        'node|news_item' => $this->t('News item'),
+        'node|landing_page' => $this->t('Landing page'),
+        'node|page' => $this->t('Standard page'),
+      ],
+      '#description' => $this->t('Select the content types that should be used for recommendations. If no content types are selected, recommendations will be shown from all content types.'),
     ];
 
     // Render suggested topics entity.
@@ -64,12 +122,34 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       }
 
       $element['keywords'] = [
-        '#theme' => 'item_list',
-        '#items' => $keywords,
+        '#type' => 'textarea',
+        '#default_value' => implode("\n", $keywords),
+        '#title' => $this->t('Generated keywords'),
+        '#disabled' => TRUE,
+        '#description' => $this->t('Keywords are generated automatically.'),
+        '#placeholder' => $this->t('No keywords generated yet.'),
       ];
     }
 
     return $element;
+  }
+
+  /**
+   * Get the property definition for a field.
+   *
+   * @param \Drupal\Core\Field\FieldItemInterface $field
+   *   The field item.
+   * @param string $property_name
+   *   The property name.
+   *
+   * @return \Drupal\Core\TypedData\DataDefinitionInterface
+   *   The property definition.
+   */
+  private function getFieldPropertyDefinition(FieldItemInterface $field, string $property_name) {
+    return $field
+      ->getFieldDefinition()
+      ->getFieldStorageDefinition()
+      ->getPropertyDefinition($property_name);
   }
 
 }

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -290,21 +290,6 @@ class RecommendationManager {
   }
 
   /**
-   * Sort query result by created time.
-   *
-   * @param array $results
-   *   Query results to sort.
-   */
-  private function sortByCreatedAt(array &$results) : void {
-    usort($results, function ($a, $b) {
-      if ($a->created == $b->created) {
-        return 0;
-      }
-      return ($a->created > $b->created) ? -1 : 1;
-    });
-  }
-
-  /**
    * Fetch node data.
    *
    * @param array $results
@@ -405,6 +390,9 @@ class RecommendationManager {
    */
   private function buildRemoteNodeData(string $instance, string $type, string $bundle, string $id, string $target_langcode) : array {
     $environment = $this->environmentResolver->getEnvironment($instance, $this->environmentResolver->getActiveEnvironmentName());
+
+    // Use internal url for json api requests to avoid varnish caching issues.
+    // This is also the only way for this to work in local environments.
     $base_url = sprintf('%s/jsonapi/%s/%s', $environment->getInternalAddress($target_langcode), $type, $bundle);
     $url = Url::fromUri($base_url, [
       'query' => [

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -304,6 +304,11 @@ final class RecommendationManager implements RecommendationManagerInterface {
               ],
             ],
             [
+              'exists' => [
+                'field' => 'uuid',
+              ],
+            ],
+            [
               'nested' => [
                 'path' => 'keywords',
                 'score_mode' => 'sum',
@@ -447,9 +452,10 @@ final class RecommendationManager implements RecommendationManagerInterface {
       $type = !empty($hit['_source']['parent_type']) ? reset($hit['_source']['parent_type']) : NULL;
       $bundle = !empty($hit['_source']['parent_bundle']) ? reset($hit['_source']['parent_bundle']) : NULL;
       $id = !empty($hit['_source']['parent_id']) ? reset($hit['_source']['parent_id']) : NULL;
+      $uuid = !empty($hit['_source']['uuid']) ? reset($hit['_source']['uuid']) : NULL;
 
       // We need all this in order to continue.
-      if (!$instance || !$type || !$bundle || !$id) {
+      if (!$instance || !$type || !$bundle || !$id || !$uuid) {
         continue;
       }
 
@@ -458,7 +464,7 @@ final class RecommendationManager implements RecommendationManagerInterface {
         : $this->buildRemoteEntityData($instance, $type, $bundle, $id, $target_langcode);
 
       if ($data) {
-        $node_data[] = $data;
+        $node_data[] = ['uuid' => $uuid] + $data;
       }
 
       if (count($node_data) >= $limit) {

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -46,8 +46,8 @@ final class RecommendationManager implements RecommendationManagerInterface {
    *   The environment resolver.
    * @param \Drupal\helfi_recommendations\TopicsManagerInterface $topicsManager
    *   The topics manager.
-   * @param \Drupal\helfi_api_base\ApiClient\ApiClient $jsonApiClient
-   *   The JSON API client.
+   * @param \GuzzleHttp\Client $guzzleClient
+   *   The Guzzle client.
    * @param \Elastic\Elasticsearch\Client $elasticClient
    *   The Elasticsearch client.
    */

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -190,6 +190,26 @@ class RecommendationManager {
           ],
           'must' => [
             [
+              'exists' => [
+                'field' => 'parent_id',
+              ],
+            ],
+            [
+              'exists' => [
+                'field' => 'parent_instance',
+              ],
+            ],
+            [
+              'exists' => [
+                'field' => 'parent_type',
+              ],
+            ],
+            [
+              'exists' => [
+                'field' => 'parent_bundle',
+              ],
+            ],
+            [
               'nested' => [
                 'path' => 'keywords',
                 'score_mode' => 'sum',
@@ -305,10 +325,10 @@ class RecommendationManager {
     $node_data = [];
 
     foreach ($results['hits']['hits'] as $hit) {
-      $instance = $hit['_source']['parent_instance'] ? reset($hit['_source']['parent_instance']) : NULL;
-      $type = $hit['_source']['parent_type'] ? reset($hit['_source']['parent_type']) : NULL;
-      $bundle = $hit['_source']['parent_bundle'] ? reset($hit['_source']['parent_bundle']) : NULL;
-      $id = $hit['_source']['parent_id'] ? reset($hit['_source']['parent_id']) : NULL;
+      $instance = !empty($hit['_source']['parent_instance']) ? reset($hit['_source']['parent_instance']) : NULL;
+      $type = !empty($hit['_source']['parent_type']) ? reset($hit['_source']['parent_type']) : NULL;
+      $bundle = !empty($hit['_source']['parent_bundle']) ? reset($hit['_source']['parent_bundle']) : NULL;
+      $id = !empty($hit['_source']['parent_id']) ? reset($hit['_source']['parent_id']) : NULL;
 
       // We need all this in order to continue.
       if (!$instance || !$type || !$bundle || !$id) {

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -370,6 +370,14 @@ class RecommendationManager {
     $data = [];
     $entity = $this->entityTypeManager->getStorage($type)->load($id);
 
+    if ($entity instanceof TranslatableInterface) {
+      if (!$entity->hasTranslation($target_langcode)) {
+        return $data;
+      }
+
+      $entity = $entity->getTranslation($target_langcode);
+    }
+
     if ($entity instanceof EntityInterface) {
       $data['title'] = $entity->label();
       $data['url'] = $entity->toUrl();
@@ -401,6 +409,7 @@ class RecommendationManager {
     $url = Url::fromUri($base_url, [
       'query' => [
         'filter[drupal_internal__nid]' => $id,
+        'filter[langcode]' => $target_langcode,
       ],
     ]);
 

--- a/modules/helfi_recommendations/src/RecommendationManagerInterface.php
+++ b/modules/helfi_recommendations/src/RecommendationManagerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_recommendations;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * The recommendation manager interface.
+ */
+interface RecommendationManagerInterface {
+
+  /**
+   * Check if recommendations should be shown.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   *
+   * @return bool
+   *   Whether recommendations should be shown.
+   */
+  public function showRecommendations(ContentEntityInterface $entity): bool;
+
+  /**
+   * Get recommendations for a node.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The node.
+   * @param int $limit
+   *   How many recommendations should be returned.
+   * @param string|null $target_langcode
+   *   Which translation to use to select the recommendations,
+   *   null uses the entity's translation.
+   *
+   * @return array
+   *   Array of recommendations.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getRecommendations(ContentEntityInterface $entity, int $limit = 3, ?string $target_langcode = NULL): array;
+
+}

--- a/modules/helfi_recommendations/src/TopicsManager.php
+++ b/modules/helfi_recommendations/src/TopicsManager.php
@@ -85,12 +85,12 @@ final class TopicsManager implements TopicsManagerInterface {
     if ($entity->language()->getId() === 'fi') {
       $this->queueFactory
         ->get('helfi_recommendations_queue')
-          ->createItem([
+        ->createItem([
           'entity_id' => $entity->id(),
-            'entity_type' => $entity->getEntityTypeId(),
-            'language' => $entity->language()->getId(),
-            'overwrite' => $overwriteExisting,
-          ]);
+          'entity_type' => $entity->getEntityTypeId(),
+          'language' => $entity->language()->getId(),
+          'overwrite' => $overwriteExisting,
+        ]);
     }
   }
 

--- a/modules/helfi_recommendations/src/TopicsManagerInterface.php
+++ b/modules/helfi_recommendations/src/TopicsManagerInterface.php
@@ -56,4 +56,15 @@ interface TopicsManagerInterface {
    */
   public function getKeywords(ContentEntityInterface $entity): array;
 
+  /**
+   * Get the topics reference fields of an entity.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity.
+   *
+   * @return \Drupal\Core\Field\EntityReferenceFieldItemListInterface[]
+   *   Array of topics reference fields.
+   */
+  public function getTopicsReferenceFields(ContentEntityInterface $entity): array;
+
 }

--- a/modules/helfi_recommendations/templates/recommendations-block.html.twig
+++ b/modules/helfi_recommendations/templates/recommendations-block.html.twig
@@ -4,6 +4,6 @@
   </div>
 {% else %}
   {% for row in rows %}
-    {{ row }}
+    {{ link(row.title, row.url) }}
   {% endfor %}
 {% endif %}

--- a/modules/helfi_recommendations/tests/src/Kernel/RecommendationManagerKernelTest.php
+++ b/modules/helfi_recommendations/tests/src/Kernel/RecommendationManagerKernelTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_recommendations\Kernel;
+
+use DG\BypassFinals;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\helfi_api_base\ApiClient\ApiClient;
+use Drupal\helfi_api_base\ApiClient\ApiResponse;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\helfi_api_base\Environment\Project;
+use Drupal\helfi_recommendations\RecommendationManager;
+use Drupal\helfi_recommendations\TopicsManagerInterface;
+use Drupal\helfi_recommendations\Entity\SuggestedTopics;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Tests\helfi_api_base\Traits\EnvironmentResolverTrait;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Kernel tests for RecommendationManager.
+ *
+ * @group helfi_recommendations
+ * @coversDefaultClass \Drupal\helfi_recommendations\RecommendationManager
+ */
+class RecommendationManagerKernelTest extends AnnifKernelTestBase {
+
+  use EnvironmentResolverTrait;
+  use NodeCreationTrait;
+  use ProphecyTrait;
+
+  /**
+   * Test environment.
+   *
+   * @var \Drupal\helfi_api_base\Environment\EnvironmentEnum
+   */
+  private EnvironmentEnum $environment = EnvironmentEnum::Local;
+
+  /**
+   * Additional modules to enable.
+   *
+   * @var string[]
+   */
+  protected static $modules = [
+    'helfi_api_base',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    // https://github.com/elastic/elasticsearch-php/issues/1227.
+    BypassFinals::enable();
+
+    parent::setUp();
+    $this->setActiveProject(Project::ETUSIVU, $this->environment);
+
+    $user = $this->createUser();
+    $this->container->get('current_user')->setAccount($user);
+  }
+
+  /**
+   * Tests showRecommendations without suggested topics reference fields.
+   *
+   * @covers ::showRecommendations
+   */
+  public function testShowRecommendationsWithoutFields(): void {
+    NodeType::create([
+      'name' => $this->randomMachineName(),
+      'type' => 'another_test_node_bundle',
+    ])->save();
+
+    $node = Node::create([
+      'type' => 'another_test_node_bundle',
+      'title' => 'Test node',
+    ]);
+    $node->save();
+
+    $recommendationManager = $this->getSut();
+    $this->assertFalse($recommendationManager->showRecommendations($node));
+  }
+
+  /**
+   * Tests showRecommendations with show_block = FALSE.
+   *
+   * @covers ::showRecommendations
+   */
+  public function testShowRecommendationsWithShowBlockFalse(): void {
+    $node = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => [
+        [
+          'entity' => SuggestedTopics::create(),
+          'show_block' => FALSE,
+        ],
+      ],
+    ]);
+    $node->save();
+
+    $recommendationManager = $this->getSut();
+    $this->assertFalse($recommendationManager->showRecommendations($node));
+  }
+
+  /**
+   * Tests showRecommendations with show_block = TRUE.
+   *
+   * @covers ::showRecommendations
+   */
+  public function testShowRecommendationsWithShowBlockTrue(): void {
+    $node = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => [
+        [
+          'entity' => SuggestedTopics::create(),
+          'show_block' => TRUE,
+        ],
+      ],
+    ]);
+    $node->save();
+
+    $recommendationManager = $this->getSut();
+    $this->assertTrue($recommendationManager->showRecommendations($node));
+  }
+
+  /**
+   * Tests getRecommendations with local entities and translations.
+   *
+   * @covers ::getRecommendations
+   */
+  public function testGetRecommendationsWithTranslations(): void {
+    $term1 = Term::create([
+      'name' => 'foo',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term1->save();
+
+    $term2 = Term::create([
+      'name' => 'bar',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term2->save();
+
+    $nodeSource = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => SuggestedTopics::create([
+        'keywords' => [
+          ['entity' => $term1, 'score' => 0.8],
+          ['entity' => $term2, 'score' => 0.2],
+        ],
+      ]),
+    ]);
+    $translationSource = $nodeSource->toArray();
+    $nodeSource->addTranslation('sv', $translationSource);
+    $nodeSource->save();
+
+    $nodeTitle = $this->randomString();
+    $nodeTitleSV = $this->randomString();
+    $nodeResult = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $nodeTitle,
+    ]);
+    $translation = $nodeResult->toArray();
+    $translation['title'] = $nodeTitleSV;
+    $nodeResult->addTranslation('sv', $translation);
+    $nodeResult->save();
+
+    $recommendationManager = $this->getSut([
+      'hits' => [
+        'hits' => [
+          [
+            '_source' => [
+              'parent_instance' => [Project::ETUSIVU],
+              'parent_type' => ['node'],
+              'parent_bundle' => ['test_node_bundle'],
+              'parent_id' => [$nodeResult->id()],
+            ],
+          ],
+        ],
+      ],
+    ]);
+
+    // Test recommendations in Finnish.
+    $recommendations = $recommendationManager->getRecommendations($nodeSource);
+    $this->assertNotEmpty($recommendations);
+    $this->assertEquals($nodeTitle, $recommendations[0]['title']);
+    $this->assertArrayHasKey('url', $recommendations[0]);
+
+    // Test recommendations in English.
+    $recommendations = $recommendationManager->getRecommendations($nodeSource, 3, 'sv');
+    $this->assertNotEmpty($recommendations);
+    $this->assertEquals($nodeTitleSV, $recommendations[0]['title']);
+    $this->assertArrayHasKey('url', $recommendations[0]);
+  }
+
+  /**
+   * Tests getRecommendations with empty search results.
+   *
+   * @covers ::getRecommendations
+   */
+  public function testGetRecommendationsWithEmptyResults(): void {
+    $term1 = Term::create([
+      'name' => 'foo',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term1->save();
+
+    $term2 = Term::create([
+      'name' => 'bar',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term2->save();
+
+    $nodeSource = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => SuggestedTopics::create([
+        'keywords' => [
+          ['entity' => $term1, 'score' => 0.8],
+          ['entity' => $term2, 'score' => 0.2],
+        ],
+      ]),
+    ]);
+    $nodeSource->save();
+
+    $recommendationManager = $this->getSut([
+      'hits' => [
+        'hits' => [],
+      ],
+    ]);
+
+    // Test recommendations with empty results.
+    $recommendations = $recommendationManager->getRecommendations($nodeSource);
+    $this->assertEmpty($recommendations);
+  }
+
+  /**
+   * Tests getRecommendations with external results.
+   *
+   * @covers ::getRecommendations
+   */
+  public function testGetRecommendationsWithExternalResults(): void {
+    $term1 = Term::create([
+      'name' => 'foo',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term1->save();
+
+    $term2 = Term::create([
+      'name' => 'bar',
+      'vid' => 'test_vocabulary',
+    ]);
+    $term2->save();
+
+    $nodeSource = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => SuggestedTopics::create([
+        'keywords' => [
+          ['entity' => $term1, 'score' => 0.8],
+          ['entity' => $term2, 'score' => 0.2],
+        ],
+      ]),
+    ]);
+    $nodeSource->save();
+
+    $resultTitle = $this->randomString();
+    $recommendationManager = $this->getSut(
+      [
+        'hits' => [
+          'hits' => [
+            [
+              '_source' => [
+                'parent_instance' => [Project::ASUMINEN],
+                'parent_type' => ['node'],
+                'parent_bundle' => ['test_node_bundle'],
+                'parent_id' => ['123'],
+              ],
+            ],
+          ],
+        ],
+      ],
+      [
+        'data' => [
+          (object) [
+            'attributes' => (object) [
+              'title' => $resultTitle,
+              'path' => (object) [
+                'alias' => '/test-node',
+              ],
+            ],
+          ],
+        ],
+      ],
+    );
+
+    $recommendations = $recommendationManager->getRecommendations($nodeSource);
+    $this->assertNotEmpty($recommendations);
+    $this->assertEquals($resultTitle, $recommendations[0]['title']);
+    $this->assertArrayHasKey('url', $recommendations[0]);
+  }
+
+  /**
+   * Gets service under test.
+   *
+   * @param array $elasticData
+   *   The elasticsearch mock data.
+   * @param array $jsonApiData
+   *   The json api data.
+   *
+   * @return \Drupal\helfi_recommendations\RecommendationManager
+   *   The service under test.
+   */
+  private function getSut(
+    array $elasticData = [],
+    array $jsonApiData = [],
+  ): RecommendationManager {
+    $loggerChannel = $this->prophesize(LoggerChannelInterface::class);
+    $entityTypeManager = $this->container->get(EntityTypeManagerInterface::class);
+    $environmentResolver = $this->container->get(EnvironmentResolverInterface::class);
+    $topicsManager = $this->container->get(TopicsManagerInterface::class);
+
+    $jsonApiResponse = (object) $jsonApiData;
+    $jsonApiClient = $this->prophesize(ApiClient::class);
+    $jsonApiClient->makeRequest(Argument::any(), Argument::any())->willReturn(new ApiResponse($jsonApiResponse));
+
+    $elasticResponse = $this->prophesize(Elasticsearch::class);
+    $elasticResponse->asArray()->willReturn($elasticData);
+
+    $elasticsearchClient = $this->prophesize(Client::class);
+    $elasticsearchClient->search(Argument::any())->willReturn($elasticResponse->reveal());
+
+    return new RecommendationManager(
+      $loggerChannel->reveal(),
+      $entityTypeManager,
+      $environmentResolver,
+      $topicsManager,
+      $jsonApiClient->reveal(),
+      $elasticsearchClient->reveal(),
+    );
+  }
+
+}

--- a/modules/helfi_recommendations/tests/src/Kernel/TopicsManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Kernel/TopicsManagerTest.php
@@ -115,7 +115,7 @@ class TopicsManagerTest extends AnnifKernelTestBase {
 
     $sut->processEntities($batch);
 
-    $supported = ['fi', 'sv', 'en'];
+    $supported = ['fi'];
     foreach ($batch as $key => $node) {
       $reference = $node->get('test_keywords')->entity;
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_recommendations\Unit;
 
-use DG\BypassFinals;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\TranslatableInterface;
@@ -73,9 +72,9 @@ class RecommendationManagerTest extends UnitTestCase {
   protected $jsonApiClient;
 
   /**
-   * The mocked Elasticsearch client.
+   * The Elasticsearch client.
    *
-   * @var \Prophecy\Prophecy\ObjectProphecy
+   * @var \Elastic\Elasticsearch\Client
    */
   protected $elasticClient;
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
@@ -17,7 +17,7 @@ use Drupal\helfi_recommendations\RecommendationManager;
 use Drupal\helfi_recommendations\TopicsManagerInterface;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
-use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -83,9 +83,6 @@ class RecommendationManagerTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    // https://github.com/elastic/elasticsearch-php/issues/1227.
-    BypassFinals::enable();
-
     parent::setUp();
 
     $this->logger = $this->prophesize(LoggerInterface::class);
@@ -93,7 +90,7 @@ class RecommendationManagerTest extends UnitTestCase {
     $this->environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
     $this->topicsManager = $this->prophesize(TopicsManagerInterface::class);
     $this->jsonApiClient = $this->prophesize(ApiClient::class);
-    $this->elasticClient = $this->prophesize(Client::class);
+    $this->elasticClient = ClientBuilder::create()->build();
 
     $this->recommendationManager = new RecommendationManager(
       $this->logger->reveal(),
@@ -101,7 +98,7 @@ class RecommendationManagerTest extends UnitTestCase {
       $this->environmentResolver->reveal(),
       $this->topicsManager->reveal(),
       $this->jsonApiClient->reveal(),
-      $this->elasticClient->reveal()
+      $this->elasticClient
     );
   }
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\helfi_api_base\ApiClient\ApiClient;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_recommendations\RecommendationManager;
 use Drupal\helfi_recommendations\TopicsManagerInterface;
@@ -19,6 +18,7 @@ use Psr\Log\LoggerInterface;
 use Elastic\Elasticsearch\ClientBuilder;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use GuzzleHttp\Client as GuzzleClient;
 
 /**
  * Unit tests for RecommendationManager.
@@ -88,7 +88,7 @@ class RecommendationManagerTest extends UnitTestCase {
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
     $this->environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
     $this->topicsManager = $this->prophesize(TopicsManagerInterface::class);
-    $this->jsonApiClient = $this->prophesize(ApiClient::class);
+    $this->jsonApiClient = $this->prophesize(GuzzleClient::class);
     $this->elasticClient = ClientBuilder::create()->build();
 
     $this->recommendationManager = new RecommendationManager(
@@ -147,6 +147,7 @@ class RecommendationManagerTest extends UnitTestCase {
     $language->getId()->willReturn('en');
     $entity->hasTranslation('en')->willReturn(TRUE);
     $entity->language()->willReturn($language->reveal());
+    $entity->id()->willReturn(1);
 
     $this->topicsManager->getKeywords($entity->reveal())->willReturn([]);
 
@@ -171,7 +172,7 @@ class RecommendationManagerTest extends UnitTestCase {
     $entity->language()->willReturn($language->reveal());
     $entity->hasTranslation('en')->willReturn(TRUE);
     $entity->getTranslation('en')->willReturn($entity->reveal());
-
+    $entity->id()->willReturn(1);
     $this->topicsManager->getKeywords($entity->reveal())->willThrow(new \Exception('Test error'));
     $this->logger->log('error', Argument::any(), Argument::any())->shouldBeCalled();
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_recommendations\Unit;
+
+use DG\BypassFinals;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\helfi_api_base\ApiClient\ApiClient;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
+use Drupal\helfi_recommendations\RecommendationManager;
+use Drupal\helfi_recommendations\TopicsManagerInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+use Elastic\Elasticsearch\Client;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+/**
+ * Unit tests for RecommendationManager.
+ *
+ * @group helfi_recommendations
+ * @coversDefaultClass \Drupal\helfi_recommendations\RecommendationManager
+ */
+class RecommendationManagerTest extends UnitTestCase {
+  use ProphecyTrait;
+
+  /**
+   * The recommendation manager.
+   *
+   * @var \Drupal\helfi_recommendations\RecommendationManager
+   */
+  protected RecommendationManager $recommendationManager;
+
+  /**
+   * The mocked logger.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $logger;
+
+  /**
+   * The mocked entity type manager.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The mocked environment resolver.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $environmentResolver;
+
+  /**
+   * The mocked topics manager.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $topicsManager;
+
+  /**
+   * The mocked JSON API client.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $jsonApiClient;
+
+  /**
+   * The mocked Elasticsearch client.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $elasticClient;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    // https://github.com/elastic/elasticsearch-php/issues/1227.
+    BypassFinals::enable();
+
+    parent::setUp();
+
+    $this->logger = $this->prophesize(LoggerInterface::class);
+    $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
+    $this->environmentResolver = $this->prophesize(EnvironmentResolverInterface::class);
+    $this->topicsManager = $this->prophesize(TopicsManagerInterface::class);
+    $this->jsonApiClient = $this->prophesize(ApiClient::class);
+    $this->elasticClient = $this->prophesize(Client::class);
+
+    $this->recommendationManager = new RecommendationManager(
+      $this->logger->reveal(),
+      $this->entityTypeManager->reveal(),
+      $this->environmentResolver->reveal(),
+      $this->topicsManager->reveal(),
+      $this->jsonApiClient->reveal(),
+      $this->elasticClient->reveal()
+    );
+  }
+
+  /**
+   * Tests the showRecommendations method with no suggested topics fields.
+   *
+   * @covers ::showRecommendations
+   */
+  public function testShowRecommendationsNoFields(): void {
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $entity->getFieldDefinitions()->willReturn([]);
+
+    $this->assertFalse($this->recommendationManager->showRecommendations($entity->reveal()));
+  }
+
+  /**
+   * Tests the showRecommendations method with suggested topics fields.
+   *
+   * @covers ::showRecommendations
+   */
+  public function testShowRecommendationsWithFields(): void {
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $field_definition = $this->prophesize(FieldDefinitionInterface::class);
+    $field_definition->getType()->willReturn('suggested_topics_reference');
+
+    $field = $this->prophesize(EntityReferenceFieldItemListInterface::class);
+    $field->getValue()->willReturn([
+      ['show_block' => TRUE],
+    ]);
+
+    $entity->getFieldDefinitions()->willReturn([
+      'field_suggested_topics' => $field_definition->reveal(),
+    ]);
+    $entity->get('field_suggested_topics')->willReturn($field->reveal());
+
+    $this->assertTrue($this->recommendationManager->showRecommendations($entity->reveal()));
+  }
+
+  /**
+   * Tests the getRecommendations method with no keywords.
+   *
+   * @covers ::getRecommendations
+   */
+  public function testGetRecommendationsNoKeywords(): void {
+    $entity = $this->prophesize(ContentEntityInterface::class);
+    $language = $this->prophesize(LanguageInterface::class);
+    $language->getId()->willReturn('en');
+    $entity->hasTranslation('en')->willReturn(TRUE);
+    $entity->language()->willReturn($language->reveal());
+
+    $this->topicsManager->getKeywords($entity->reveal())->willReturn([]);
+
+    $this->assertEquals(
+      [],
+      $this->recommendationManager->getRecommendations($entity->reveal())
+    );
+  }
+
+  /**
+   * Tests error handling in getRecommendations.
+   *
+   * @covers ::getRecommendations
+   */
+  public function testGetRecommendationsErrorHandling(): void {
+    // Create a mock that implements both interfaces.
+    $entity = $this->prophesize(ContentEntityInterface::class)
+      ->willImplement(TranslatableInterface::class);
+
+    $language = $this->prophesize(LanguageInterface::class);
+    $language->getId()->willReturn('en');
+    $entity->language()->willReturn($language->reveal());
+    $entity->hasTranslation('en')->willReturn(TRUE);
+    $entity->getTranslation('en')->willReturn($entity->reveal());
+
+    $this->topicsManager->getKeywords($entity->reveal())->willThrow(new \Exception('Test error'));
+    $this->logger->log('error', Argument::any(), Argument::any())->shouldBeCalled();
+
+    $this->assertEquals(
+      [],
+      $this->recommendationManager->getRecommendations($entity->reveal())
+    );
+  }
+
+}

--- a/src/Plugin/Field/FieldFormatter/TextSpan.php
+++ b/src/Plugin/Field/FieldFormatter/TextSpan.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_platform_config\Plugin\Field\FieldFormatter;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\Plugin\Field\FieldType\StringLongItem;
 
 /**
  * Plugin implementation of the 'Text with span' formatter.
@@ -32,7 +33,7 @@ class TextSpan extends FormatterBase {
     $markup = [];
 
     foreach ($items as $delta => $item) {
-
+      assert($item instanceof StringLongItem);
       $value = $item->value;
       if (empty($value)) {
         $value = $item->getValue();


### PR DESCRIPTION
# [UHF-11579](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11579)

This PR continues the base implementation for a recommendations block, that can fetch content recommendations from other instances as well.

## What was done

- Finalise the block implementation (excluding final theming)
- Add configuration options to select:
  - recommendation block visibility in current entity page
  - instances to show recommendations from
  - content types to show recommendations from 
- Fine tune the elasticsearch query
- Configure a JSON-API endpoint, and use it to fetch recommendation data for other instances.
- Add tests

## Known TODO's

- Still need to figure out how to avoid hitting annif API TPS-limit when processing the queue.
- Still need to figure out how to update index when keywords are generated.
- Still need to figure out translation handling.

## Open questions

- As the data needed for suggestion content is quite minimal (only title and url, and maybe image for some content types), maybe we should index all of it? We wouldn't then need the JSON API call at all (didn't realise this until I had already implemented it)
- How do we handle the json api configuration that is already in etusivu instance?

## How to install

### Frontpage instance

- Make sure your https://github.com/City-of-Helsinki/drupal-helfi-etusivu instance is up and running on latest dev branch.
  - `git pull origin dev`
  - `make fresh`
- Clear the suggestions-index to allow other instances to populate it properly
  - `drush sapi-c suggestions`

### Other instances

Set up two additional instances to allow cross-instance testing. They can be for example:
- https://github.com/City-of-Helsinki/drupal-helfi-kymp
- https://github.com/City-of-Helsinki/drupal-helfi-tyo-yrittaminen

If you use asuminen or rekry, make sure to use the `UHF-11579_recommendation-p2`-branch for proper json api routing in local (see other PR's).

#### Run these steps for both:
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Add new composer dependencies
  * `composer require drupal/jsonapi_extras:^3.26`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11579_recommendation-p2`
* Run `make drush-updb drush-cr`
* Enable `helfi_recommendations`-module and import relevant configurations:
  * `drush en helfi_recommendations`
  * `drush helfi:platform-config:update helfi_recommendations`
* Create a new field for one of the content types
  * **Reference** / **Recommended topics** with default settings
* Enable **Text converter** view mode that same content type
  * Update **Text converter** view mode settings to only display the **Content region** -field
* Enable recommendations block
  * Place block **AI powered recommendations** into **Content**-region with default settings
  * Save

## How to test

* Add a couple new pages to both instances using the content type where you added the new field
  * Always run `drush queue:run helfi_recommendations_queue` after saving a node, to avoid having multiple nodes in the queue (keyword generation might fail after the first one, possible due to some TPS-limit in the annif-API). Then edit and save the node again to update the index. Then run `drush queue:run helfi_recommendations_queue` again to make sure the queue is empty for the next node.
  * https://www.loremipsum.fi/seitseman_veljesta/ is an easy source
  * You can use the "Columns"-paragraph with text columns. Use identical content for some of the nodes. Then for some nodes keep one of the columns identical to the rest, but use different content in the other one. Also titles will cause variation in the generated keywords.
  * Make all nodes public
* Recommendations block should start showing links to recommended content from both instances.
* Try changing the recommendation settings (show recommendations, instances and bundles) and check the outcome.

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/694
* https://github.com/City-of-Helsinki/drupal-helfi-asuminen/pull/545


[UHF-11579]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ