### PR TITLE
UHF-11166: Cookie banner WSOD

### DIFF
--- a/modules/hdbt_cookie_banner/src/Services/CookieSettings.php
+++ b/modules/hdbt_cookie_banner/src/Services/CookieSettings.php
@@ -192,7 +192,7 @@ class CookieSettings {
    *   Returns the active Etusivu environment or NULL.
    */
   protected function getActiveEtusivuEnvironment(?bool $default_to_production = FALSE): Environment|NULL {
-    $environment = 'NULL';
+    $environment = NULL;
 
     // Get active Etusivu environment.
     try {

--- a/modules/hdbt_cookie_banner/tests/src/Kernel/Services/CookieSettingsTest.php
+++ b/modules/hdbt_cookie_banner/tests/src/Kernel/Services/CookieSettingsTest.php
@@ -237,4 +237,37 @@ class CookieSettingsTest extends KernelTestBase {
     $this->assertNull($url);
   }
 
+  /**
+   * Tests getActiveEtusivuEnvironment with non-existent environment.
+   */
+  public function testGetActiveEtusivuEnvironment(): void {
+    // Expected settings for external (hel.fi) setup.
+    $expected = [
+      ['use_custom_settings', FALSE],
+    ];
+
+    // Set up the configurations with specified settings.
+    $this->setUpTheConfigurations($expected);
+
+    // Simulate that the environment resolver returns NULL because
+    // the environment has a typo or current environment is f.e. dev.
+    $this->environmentResolver
+      ->method('getEnvironment')
+      ->willThrowException(new \InvalidArgumentException());
+
+    // Test that the URL by route is returned.
+    $url = $this->cookieSettings->getCookieSettingsPageUrl();
+    $this->assertInstanceOf(Url::class, $url);
+
+    // Simulate that the route does not exist by throwing an exception.
+    $this->routeProvider->expects($this->once())
+      ->method('getRouteByName')
+      ->with('hdbt_cookie_banner.cookie_settings_page')
+      ->willThrowException(new RouteNotFoundException());
+
+    // Test that NULL is returned.
+    $url = $this->cookieSettings->getCookieSettingsPageUrl();
+    $this->assertNull($url);
+  }
+
 }


### PR DESCRIPTION
# [UHF-11166](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11166)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed typo from HDBT cookie banner service's `getActiveEtusivuEnvironment()` method and tested the method.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the tests pass
* [ ] Check that code follows our standards



[UHF-11166]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ