### PR TITLE
UHF-11593: Added new image field for contact card

### DIFF
--- a/modules/helfi_image_styles/config/install/responsive_image.styles.square_thumbnail.yml
+++ b/modules/helfi_image_styles/config/install/responsive_image.styles.square_thumbnail.yml
@@ -7,8 +7,8 @@ dependencies:
     - image.style.1_500w_500h_LQ
   module:
     - helfi_image_styles
-id: contact_card
-label: 'Contact Card'
+id: square_thumbnail
+label: 'Square thumbnail'
 image_style_mappings:
   -
     image_mapping_type: image_style

--- a/modules/helfi_image_styles/config/install/responsive_image.styles.square_thumbnail.yml
+++ b/modules/helfi_image_styles/config/install/responsive_image.styles.square_thumbnail.yml
@@ -1,4 +1,4 @@
-uuid: e756e7d0-c3ad-418c-a5de-408a7cdf5d63
+uuid: cc481cd1-3694-4473-9722-d143aa720531
 langcode: en
 status: true
 dependencies:

--- a/modules/helfi_media/config/install/core.entity_view_display.media.image.square_thumbnail.yml
+++ b/modules/helfi_media/config/install/core.entity_view_display.media.image.square_thumbnail.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_photographer
     - media.type.image
-    - responsive_image.styles.contact_card
+    - responsive_image.styles.square_thumbnail
   module:
     - responsive_image
 id: media.image.square_thumbnail
@@ -19,7 +19,7 @@ content:
     type: responsive_image
     label: hidden
     settings:
-      responsive_image_style: contact_card
+      responsive_image_style: square_thumbnail
       image_link: ''
       image_loading:
         attribute: eager

--- a/modules/helfi_media/config/install/core.entity_view_display.media.image.square_thumbnail.yml
+++ b/modules/helfi_media/config/install/core.entity_view_display.media.image.square_thumbnail.yml
@@ -1,0 +1,36 @@
+uuid: 0d32e090-076b-4aea-9319-7e5b572b993f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.square_thumbnail
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_photographer
+    - media.type.image
+    - responsive_image.styles.contact_card
+  module:
+    - responsive_image
+id: media.image.square_thumbnail
+targetEntityType: media
+bundle: image
+mode: square_thumbnail
+content:
+  field_media_image:
+    type: responsive_image
+    label: hidden
+    settings:
+      responsive_image_style: contact_card
+      image_link: ''
+      image_loading:
+        attribute: eager
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_photographer: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/modules/helfi_media/config/install/core.entity_view_mode.media.square_thumbnail.yml
+++ b/modules/helfi_media/config/install/core.entity_view_mode.media.square_thumbnail.yml
@@ -1,0 +1,11 @@
+uuid: 2230c2a0-8d52-4106-b17f-b0d571ef449e
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.square_thumbnail
+label: 'Square thumbnail'
+description: ''
+targetEntityType: media
+cache: true

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
@@ -26,18 +26,10 @@ mode: default
 content:
   field_contact_description:
     type: string_textarea
-    weight: 6
+    weight: 5
     region: content
     settings:
       rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-  field_contact_image_photographer:
-    type: string_textfield
-    weight: 1
-    region: content
-    settings:
-      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_contact_image_reference:
@@ -49,7 +41,7 @@ content:
     third_party_settings: {  }
   field_contact_name:
     type: string_textfield
-    weight: 2
+    weight: 1
     region: content
     settings:
       size: 60
@@ -57,7 +49,7 @@ content:
     third_party_settings: {  }
   field_contact_social_media:
     type: paragraphs
-    weight: 7
+    weight: 6
     region: content
     settings:
       title: Lohko
@@ -75,7 +67,7 @@ content:
     third_party_settings: {  }
   field_contact_social_media_link:
     type: link_default
-    weight: 8
+    weight: 7
     region: content
     settings:
       placeholder_url: ''
@@ -83,7 +75,7 @@ content:
     third_party_settings: {  }
   field_contact_title:
     type: string_textfield
-    weight: 3
+    weight: 2
     region: content
     settings:
       size: 60
@@ -91,7 +83,7 @@ content:
     third_party_settings: {  }
   field_email:
     type: email_default
-    weight: 4
+    weight: 3
     region: content
     settings:
       placeholder: ''
@@ -99,7 +91,7 @@ content:
     third_party_settings: {  }
   field_phone_number:
     type: telephone_default
-    weight: 5
+    weight: 4
     region: content
     settings:
       placeholder: ''
@@ -107,4 +99,5 @@ content:
 hidden:
   created: true
   field_contact_image: true
+  field_contact_image_photographer: true
   status: true

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
@@ -13,10 +13,8 @@ dependencies:
     - field.field.paragraph.contact_card.field_contact_title
     - field.field.paragraph.contact_card.field_email
     - field.field.paragraph.contact_card.field_phone_number
-    - image.style.thumbnail
     - paragraphs.paragraphs_type.contact_card
   module:
-    - focal_point
     - link
     - media_library
     - paragraphs
@@ -33,16 +31,6 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
-  field_contact_image:
-    type: image_focal_point
-    weight: 9
-    region: content
-    settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
-      preview_link: true
-      offsets: '50,50'
     third_party_settings: {  }
   field_contact_image_photographer:
     type: string_textfield
@@ -72,8 +60,8 @@ content:
     weight: 7
     region: content
     settings:
-      title: Paragraph
-      title_plural: Paragraphs
+      title: Lohko
+      title_plural: Lohkot
       edit_mode: open
       closed_mode: summary
       autocollapse: none
@@ -118,4 +106,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_contact_image: true
   status: true

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
@@ -52,8 +52,8 @@ content:
     weight: 6
     region: content
     settings:
-      title: Lohko
-      title_plural: Lohkot
+      title: Paragraph
+      title_plural: Paragraphs
       edit_mode: open
       closed_mode: summary
       autocollapse: none

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_form_display.paragraph.contact_card.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.contact_card.field_contact_description
     - field.field.paragraph.contact_card.field_contact_image
     - field.field.paragraph.contact_card.field_contact_image_photographer
+    - field.field.paragraph.contact_card.field_contact_image_reference
     - field.field.paragraph.contact_card.field_contact_name
     - field.field.paragraph.contact_card.field_contact_social_media
     - field.field.paragraph.contact_card.field_contact_social_media_link
@@ -17,6 +18,7 @@ dependencies:
   module:
     - focal_point
     - link
+    - media_library
     - paragraphs
     - telephone
 id: paragraph.contact_card.default
@@ -34,7 +36,7 @@ content:
     third_party_settings: {  }
   field_contact_image:
     type: image_focal_point
-    weight: 0
+    weight: 9
     region: content
     settings:
       progress_indicator: throbber
@@ -49,6 +51,13 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  field_contact_image_reference:
+    type: media_library_widget
+    weight: 0
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
   field_contact_name:
     type: string_textfield

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.contact_card.field_contact_description
     - field.field.paragraph.contact_card.field_contact_image
     - field.field.paragraph.contact_card.field_contact_image_photographer
+    - field.field.paragraph.contact_card.field_contact_image_reference
     - field.field.paragraph.contact_card.field_contact_name
     - field.field.paragraph.contact_card.field_contact_social_media
     - field.field.paragraph.contact_card.field_contact_social_media_link
@@ -50,6 +51,15 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 7
+    region: content
+  field_contact_image_reference:
+    type: entity_reference_entity_view
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_contact_name:
     type: string

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -1,4 +1,4 @@
-uuid: 389c1a0f-1940-449c-b50e-d00234e8217d
+uuid: 736348ff-8ed2-4313-9a99-fa4c7fa2ebf9
 langcode: en
 status: true
 dependencies:

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -37,7 +37,7 @@ content:
     type: responsive_image
     label: hidden
     settings:
-      responsive_image_style: contact_card
+      responsive_image_style: square_thumbnail
       image_link: ''
       image_loading:
         attribute: eager

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -1,4 +1,4 @@
-uuid: 736348ff-8ed2-4313-9a99-fa4c7fa2ebf9
+uuid: 389c1a0f-1940-449c-b50e-d00234e8217d
 langcode: en
 status: true
 dependencies:
@@ -56,7 +56,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: default
+      view_mode: square_thumbnail
       link: false
     third_party_settings: {  }
     weight: 8

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/core.entity_view_display.paragraph.contact_card.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - field.field.paragraph.contact_card.field_email
     - field.field.paragraph.contact_card.field_phone_number
     - paragraphs.paragraphs_type.contact_card
-    - responsive_image.styles.contact_card
+    - responsive_image.styles.square_thumbnail
   module:
     - entity_reference_revisions
     - helfi_paragraphs_contact_card_listing

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/field.field.paragraph.contact_card.field_contact_image.yml
@@ -11,7 +11,7 @@ id: paragraph.contact_card.field_contact_image
 field_name: field_contact_image
 entity_type: paragraph
 bundle: contact_card
-label: Image
+label: 'DEPRECATED Image'
 description: 'Use a square image for the best result. Portrait and landscape images will be cropped to a square, the focal point can be selected with the image upload.'
 required: false
 translatable: false

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/field.field.paragraph.contact_card.field_contact_image_reference.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/field.field.paragraph.contact_card.field_contact_image_reference.yml
@@ -1,0 +1,29 @@
+uuid: e3388822-df3f-48b3-91ff-22a054752779
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_contact_image_reference
+    - media.type.image
+    - paragraphs.paragraphs_type.contact_card
+id: paragraph.contact_card.field_contact_image_reference
+field_name: field_contact_image_reference
+entity_type: paragraph
+bundle: contact_card
+label: 'Contact image'
+description: 'Use a square image for the best result. Portrait and landscape images will be cropped to a square, the focal point can be selected with the image upload.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/field.storage.paragraph.field_contact_image_reference.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/field.storage.paragraph.field_contact_image_reference.yml
@@ -1,0 +1,20 @@
+uuid: bf481f31-99eb-479a-8ef0-5a15b06d4ae0
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_contact_image_reference
+field_name: field_contact_image_reference
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_paragraphs_contact_card_listing/config/install/field.storage.paragraph.field_email.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/install/field.storage.paragraph.field_email.yml
@@ -11,7 +11,7 @@ type: email
 settings: {  }
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/fi/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/fi/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,2 +1,2 @@
 label: Kuva
-description: 'Vaaka- ja pystykuvat rajataan neliöiksi. Rajatun kuvan keskipisteen voi valita kuvan latauksen yhteydessä. '
+description: 'VANHENTUNUT Vaaka- ja pystykuvat rajataan neliöiksi. Rajatun kuvan keskipisteen voi valita kuvan latauksen yhteydessä. '

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/fi/field.field.paragraph.contact_card.field_contact_image_reference.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/fi/field.field.paragraph.contact_card.field_contact_image_reference.yml
@@ -1,0 +1,2 @@
+label: Kuva
+description: 'Vaaka- ja pystykuvat rajataan neliöiksi. Rajatun kuvan keskipisteen voi valita kuvan latauksen yhteydessä. '

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,1 +1,1 @@
-label: Bild
+label: 'DEPRECATED Bild'

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,1 +1,1 @@
-label: 'DEPRECATED Bild'
+label: 'Bild'

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image.yml
@@ -1,1 +1,1 @@
-label: 'Bild'
+label: Bild

--- a/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image_reference.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/config/optional/language/sv/field.field.paragraph.contact_card.field_contact_image_reference.yml
@@ -1,0 +1,1 @@
+label: Bild

--- a/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.info.yml
+++ b/modules/helfi_paragraphs_contact_card_listing/helfi_paragraphs_contact_card_listing.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - drupal:telephone
   - helfi_base_content:helfi_base_content
   - helfi_image_styles:helfi_image_styles
+  - helfi_media:helfi_media


### PR DESCRIPTION
# [UHF-11593](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11593)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added a new image field which is media reference for contact card listing 
* Made it possible to add multiple emails in one card
* Renamed responsive image style contact card to square thumbnail

## How to install
Test for example in **KYMP** since there is a good paragraph already in the content

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11593`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11593 `
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update helfi_media` and  `drush helfi:platform-config:update helfi_paragraphs_contact_card_listing` 
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/kaupunkisuunnittelu-ja-rakentaminen/uutta-helsinkia-rakentamassa/kruunuvuorenranta
* [ ] Edit the contact card listing so that the first one has the old image, second one has old and new image, third has only new image and fourth doesn't have either
* [ ] Make sure that if the new image is set, it should be visible, if new image is not set, the old one should show and if neither is set, the color line class should appear (don't know if this is used anymore though)
* [ ] Edit one of the cards so that it has multiple emails, make sure they render correctly
* [ ] Test that the word break works correctly with email, social media and phone number fields
* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1241


[UHF-11593]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ