### PR TITLE
UHF-8792 Form fields for visual regression tests.

### DIFF
--- a/modules/helfi_test_content/assets/js/focus.js
+++ b/modules/helfi_test_content/assets/js/focus.js
@@ -1,0 +1,65 @@
+// Retrieve query parameters.
+const params = new URLSearchParams(window.location.search);
+
+// Act on URL param "focus".
+if (params.has('focus') && params.get('focus') === '') {
+
+  // Apply styles to the element.
+  const applyElementStyles = (element) => {
+    element.focus();
+
+    // Save the focus styles to a variable to be used later.
+    const computedStyles = window.getComputedStyle(element);
+
+    Array.from(computedStyles).forEach(prop => {
+      // Only apply the style to an element if the style has a value.
+      const value = computedStyles.getPropertyValue(prop);
+      if (value) {
+        element.style[prop] = value;
+      }
+    });
+  };
+
+  // Simulate hover on inputs.
+  const simulateFocusOnInputs = () => {
+    const inputs = [
+      'input.hds-text-input__input',
+      'textarea.hds-text-input__input',
+      'input.hds-checkbox__input',
+      'input.hds-button--primary',
+      'input.hds-button--secondary',
+      'select.hdbt--select',
+    ];
+
+    inputs.forEach(tag => {
+      // Get all elements that match the tag.
+      const elements = document.querySelectorAll(`.components--test-content ${tag}`);
+
+      // Iterate over each element and simulate focus.
+      elements.forEach((element) => {
+        applyElementStyles(element);
+      })
+    });
+
+    // Focusing the radio input element does not apply the styles to the
+    // label::before pseudo-element. We need to apply the styles via class
+    // instead.
+    const radioInputs = document.querySelectorAll('.components--test-content input.hds-radio-button__input');
+
+    // Iterate over each element and apply the
+    // hds-radio-button--simulate-focus class.
+    radioInputs.forEach((radioInput) => {
+      const radioLabel = radioInput.nextElementSibling;
+      if (radioLabel && radioLabel.classList.contains('hds-radio-button__label')) {
+        radioLabel.classList.add('hds-radio-button--simulate-focus');
+      }
+    });
+  }
+
+  // Simulate hover on inputs after the page has been rendered.
+  window.addEventListener('load', () => {
+    requestAnimationFrame(() => {
+      simulateFocusOnInputs();
+    });
+  });
+}

--- a/modules/helfi_test_content/helfi_test_content.libraries.yml
+++ b/modules/helfi_test_content/helfi_test_content.libraries.yml
@@ -1,0 +1,4 @@
+test_focus:
+  version: 1.0
+  js:
+    assets/js/focus.js: { }

--- a/modules/helfi_test_content/helfi_test_content.routing.yml
+++ b/modules/helfi_test_content/helfi_test_content.routing.yml
@@ -1,0 +1,7 @@
+helfi_test_content.helfi_test_content_form:
+  path: '/helfi-test-content/helfi-test-content-form'
+  defaults:
+    _title: 'Helfi Test Content Form'
+    _controller: '\Drupal\helfi_test_content\Controller\HelfiTestContentFormController::formPage'
+  requirements:
+    _permission: 'access content'

--- a/modules/helfi_test_content/src/Controller/HelfiTestContentFormController.php
+++ b/modules/helfi_test_content/src/Controller/HelfiTestContentFormController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_test_content\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\helfi_test_content\Form\HelfiTestContentForm;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Returns responses for Helfi test content routes.
+ */
+final class HelfiTestContentFormController extends ControllerBase {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   The config factory.
+   */
+  public function __construct(FormBuilderInterface $form_builder) {
+    $this->formBuilder = $form_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('form_builder'),
+    );
+  }
+
+  /**
+   * Builds the response.
+   *
+   * @return array
+   *   Returns test form.
+   */
+  public function formPage(): array {
+    return [
+      '#type' => 'container',
+      '#prefix' => '<article><div class="components components--test-content">',
+      '#suffix' => '</div></article>',
+      '#attached' => [
+        'library' => [
+          'helfi_test_content/test_focus',
+        ],
+      ],
+      'form' => $this->formBuilder->getForm(HelfiTestContentForm::class),
+    ];
+  }
+
+}

--- a/modules/helfi_test_content/src/Form/HelfiTestContentForm.php
+++ b/modules/helfi_test_content/src/Form/HelfiTestContentForm.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_test_content\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Test content for form.
+ */
+class HelfiTestContentForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'helfi_test_content_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+
+    $form['textfield'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Text field'),
+      '#description' => $this->t('A description for the text field.'),
+    ];
+
+    $form['textarea'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Textarea'),
+      '#description' => $this->t('A description for the textarea.'),
+    ];
+
+    $form['select'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Select list'),
+      '#options' => [
+        'value_a' => $this->t('Option 1'),
+        'value_b' => $this->t('Option 2'),
+      ],
+      '#description' => $this->t('A description for the textarea.'),
+    ];
+
+    $form['fieldset_radio'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Select either one'),
+      '#description' => $this->t('A description for the radio fieldset.'),
+    ];
+    $form['fieldset_radio']['fieldset_radios'] = [
+      '#type' => 'radios',
+      '#default_value' => 'one',
+      '#options' => [
+        'one' => $this->t('Selection 1'),
+        'two' => $this->t('Selection 2'),
+      ],
+    ];
+
+    $form['fieldset_checkbox'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Select either one'),
+      '#description' => $this->t('A description for the checkbox fieldset.'),
+    ];
+
+    $form['fieldset_checkbox']['fieldset_checkbox_not_checked'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Checkbox'),
+      '#default_value' => FALSE,
+    ];
+
+    $form['fieldset_checkbox']['fieldset_checkbox_selected'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Selected checkbox'),
+      '#default_value' => TRUE,
+    ];
+
+    $form['radios'] = [
+      '#type' => 'radios',
+      '#default_value' => 'two',
+      '#options' => [
+        'one' => $this->t('Selection 1'),
+        'two' => $this->t('Selection 2'),
+      ],
+    ];
+
+    $form['checkbox'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Checkbox'),
+      '#default_value' => FALSE,
+    ];
+
+    $form['checkbox_selected'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Selected checkbox'),
+      '#default_value' => TRUE,
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'),
+    ];
+
+    $form['cancel'] = [
+      '#type' => 'button',
+      '#attributes' => [
+        'class' => [
+          'hds-button--secondary',
+        ],
+        'style' => 'margin-left: 16px;',
+      ],
+      '#value' => $this->t('Cancel'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+  }
+
+}

--- a/modules/helfi_test_content/tests/src/Kernel/Controller/HelfiTestContentFormControllerTest.php
+++ b/modules/helfi_test_content/tests/src/Kernel/Controller/HelfiTestContentFormControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_test_content\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\helfi_test_content\Controller\HelfiTestContentFormController;
+
+/**
+ * Kernel test for HelfiTestContentFormController.
+ *
+ * @group helfi_test_content
+ */
+class HelfiTestContentFormControllerTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'helfi_test_content',
+  ];
+
+  /**
+   * The controller under test.
+   *
+   * @var \Drupal\helfi_test_content\Controller\HelfiTestContentFormController
+   */
+  protected HelfiTestContentFormController $controller;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->controller = new HelfiTestContentFormController(
+      $this->container->get('form_builder')
+    );
+  }
+
+  /**
+   * Tests the formPage() method.
+   */
+  public function testFormPage(): void {
+    $build = $this->controller->formPage();
+
+    $this->assertIsArray($build);
+    $this->assertArrayHasKey('#type', $build);
+    $this->assertEquals('container', $build['#type']);
+
+    $this->assertArrayHasKey('#prefix', $build);
+    $this->assertStringContainsString('<article>', $build['#prefix']);
+    $this->assertStringContainsString('components--test-content', $build['#prefix']);
+
+    $this->assertArrayHasKey('#suffix', $build);
+    $this->assertStringContainsString('</article>', $build['#suffix']);
+
+    $this->assertArrayHasKey('form', $build);
+    $this->assertIsArray($build['form']);
+    $this->assertArrayHasKey('#form_id', $build['form']);
+    $this->assertEquals('helfi_test_content_form', $build['form']['#form_id']);
+
+    $this->assertArrayHasKey('#attached', $build);
+    $this->assertArrayHasKey('library', $build['#attached']);
+    $this->assertContains('helfi_test_content/test_focus', $build['#attached']['library']);
+  }
+
+}

--- a/modules/helfi_test_content/tests/src/Kernel/Form/HelfiTestContentFormTest.php
+++ b/modules/helfi_test_content/tests/src/Kernel/Form/HelfiTestContentFormTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_test_content\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\helfi_test_content\Form\HelfiTestContentForm;
+
+/**
+ * Tests the HelfiTestContentForm.
+ *
+ * @group helfi_test_content
+ */
+class HelfiTestContentFormTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'helfi_test_content',
+  ];
+
+  /**
+   * Tests that the form builds correctly.
+   */
+  public function testFormBuild(): void {
+    /** @var \Drupal\Core\Form\FormBuilderInterface $formBuilder */
+    $formBuilder = $this->container->get('form_builder');
+
+    /** @var \Drupal\Core\Form\FormInterface $form */
+    $form = $formBuilder->getForm(HelfiTestContentForm::class);
+    $this->assertIsArray($form);
+
+    // Basic field presence tests.
+    $this->assertArrayHasKey('textfield', $form);
+    $this->assertEquals('textfield', $form['textfield']['#type']);
+
+    $this->assertArrayHasKey('textarea', $form);
+    $this->assertEquals('textarea', $form['textarea']['#type']);
+
+    $this->assertArrayHasKey('select', $form);
+    $this->assertEquals('select', $form['select']['#type']);
+
+    $this->assertArrayHasKey('fieldset_radio', $form);
+    $this->assertArrayHasKey('fieldset_radios', $form['fieldset_radio']);
+    $this->assertEquals('radios', $form['fieldset_radio']['fieldset_radios']['#type']);
+    $this->assertEquals('one', $form['fieldset_radio']['fieldset_radios']['#default_value']);
+
+    $this->assertArrayHasKey('checkbox', $form);
+    $this->assertEquals(FALSE, $form['checkbox']['#default_value']);
+
+    $this->assertArrayHasKey('checkbox_selected', $form);
+    $this->assertEquals(TRUE, $form['checkbox_selected']['#default_value']);
+
+    $this->assertArrayHasKey('submit', $form);
+    $this->assertEquals('submit', $form['submit']['#type']);
+    $this->assertEquals('Submit', $form['submit']['#value']->__toString());
+
+    $this->assertArrayHasKey('cancel', $form);
+    $this->assertEquals('button', $form['cancel']['#type']);
+    $this->assertEquals('Cancel', $form['cancel']['#value']->__toString());
+  }
+
+}


### PR DESCRIPTION
# [UHF-8792](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8792)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added the following: 
   * A route for the form field test content.
   * A JS library that applies focus styles to all form fields when ?focus query parameter is present.
   * A controller for the helfi_test_content_form route.
   * The form which will render the chosen form fields.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Just check the code and that the tests pass. 
   * This functionality is only used in visual regression tests.
 
