### PR TITLE
UHF-8792: Visual regression tests (focus)

### DIFF
--- a/modules/helfi_test_content/assets/js/focus.js
+++ b/modules/helfi_test_content/assets/js/focus.js
@@ -4,23 +4,7 @@ const params = new URLSearchParams(window.location.search);
 // Act on URL param "focus".
 if (params.has('focus') && params.get('focus') === '') {
 
-  // Apply styles to the element.
-  const applyElementStyles = (element) => {
-    element.focus();
-
-    // Save the focus styles to a variable to be used later.
-    const computedStyles = window.getComputedStyle(element);
-
-    Array.from(computedStyles).forEach(prop => {
-      // Only apply the style to an element if the style has a value.
-      const value = computedStyles.getPropertyValue(prop);
-      if (value) {
-        element.style[prop] = value;
-      }
-    });
-  };
-
-  // Simulate hover on inputs.
+  // Simulate focus on inputs.
   const simulateFocusOnInputs = () => {
     const inputs = [
       'input.hds-text-input__input',
@@ -28,31 +12,20 @@ if (params.has('focus') && params.get('focus') === '') {
       'input.hds-checkbox__input',
       'input.hds-button--primary',
       'input.hds-button--secondary',
+      'input.hds-radio-button__input',
       'select.hdbt--select',
     ];
 
     inputs.forEach(tag => {
       // Get all elements that match the tag.
-      const elements = document.querySelectorAll(`.components--test-content ${tag}`);
+      const elements = document.querySelectorAll(
+        `.components--test-content ${tag}`
+      );
 
-      // Iterate over each element and simulate focus.
+      // Iterate over each element and add the simulation classes.
       elements.forEach((element) => {
-        applyElementStyles(element);
+        element.classList.add('simulate-focus');
       })
-    });
-
-    // Focusing the radio input element does not apply the styles to the
-    // label::before pseudo-element. We need to apply the styles via class
-    // instead.
-    const radioInputs = document.querySelectorAll('.components--test-content input.hds-radio-button__input');
-
-    // Iterate over each element and apply the
-    // hds-radio-button--simulate-focus class.
-    radioInputs.forEach((radioInput) => {
-      const radioLabel = radioInput.nextElementSibling;
-      if (radioLabel && radioLabel.classList.contains('hds-radio-button__label')) {
-        radioLabel.classList.add('hds-radio-button--simulate-focus');
-      }
     });
   }
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Changed the way focus styles are simulated; visual regression tests cannot render styles correctly. Added class instead of copying the focus styles to fix the issue.
