### PR TITLE
UHF-10647: Removing an install hook to enable helfi_recommendations

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -466,29 +466,3 @@ function helfi_platform_config_update_9321(): void {
     $config->set('matomo_site_id', $matomo_site_id)->save();
   }
 }
-
-/**
- * UHF-10647: Enable cross-instance recommendations block.
- */
-function helfi_platform_config_update_9322(): void {
-  /** @var \Drupal\helfi_api_base\Environment\ActiveProjectRoles $projectRoles */
-  $projectRoles = \Drupal::service(ActiveProjectRoles::class);
-
-  // Only enable on core instances.
-  if ($projectRoles->hasRole(ProjectRoleEnum::Core)) {
-    $module_installer = \Drupal::service('module_installer');
-
-    // Search API is a dependency for helfi_recommendations. It might throw an
-    // error if installed as a dependency when installing
-    // helfi_recommendations, so let's install it separately if not already
-    // installed.
-    if (!\Drupal::moduleHandler()->moduleExists('search_api')) {
-      $module_installer->install(['search_api']);
-    }
-
-    // Install helfi_recommendations module if not installed.
-    if (!\Drupal::moduleHandler()->moduleExists('helfi_recommendations')) {
-      $module_installer->install(['helfi_recommendations']);
-    }
-  }
-}


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

Search API can't reach the elasticsearch server used for suggestion topics indexing in any environment other than local development. We need to wait until we get that routing to enable `helfi_recommendations` on all core instances, and we can then add the install hook again.

## What was done?

Update hook to enable `helfi_recommendations` was removed.

## How to test

Maybe this is trivial enough to not need local testing?

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/946


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ