### PR TITLE
UHF-X: Fix language translation clash

### DIFF
--- a/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_language.yml
+++ b/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_language.yml
@@ -9,7 +9,7 @@ id: paragraph.event_list.field_language
 field_name: field_language
 entity_type: paragraph
 bundle: event_list
-label: Language
+label: 'Event Language'
 description: 'Show "Language" filter.'
 required: false
 translatable: false

--- a/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_language.yml
+++ b/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_language.yml
@@ -1,4 +1,4 @@
-label: Tapahtuman kieli
+label: 'Tapahtuman kieli'
 description: 'Näytä “Kieli” -suodatin'
 settings:
   on_label: Kyllä

--- a/modules/helfi_react_search/helfi_react_search.install
+++ b/modules/helfi_react_search/helfi_react_search.install
@@ -121,3 +121,12 @@ function helfi_react_search_update_9011() : void {
   \Drupal::service('helfi_platform_config.config_update_helper')
     ->update('helfi_react_search');
 }
+
+
+/**
+ * UHF-X: Fix clashing 'language' label translation.
+ */
+function helfi_react_search_update_9012() : void {
+  \Drupal::service('helfi_platform_config.config_update_helper')
+    ->update('helfi_react_search');
+}

--- a/modules/helfi_react_search/helfi_react_search.install
+++ b/modules/helfi_react_search/helfi_react_search.install
@@ -122,7 +122,6 @@ function helfi_react_search_update_9011() : void {
     ->update('helfi_react_search');
 }
 
-
 /**
  * UHF-X: Fix clashing 'language' label translation.
  */


### PR DESCRIPTION
Change 'language' label to avoid clashing with existing translation.
