### PR TITLE
UHF-11640: Config ignore update

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -492,7 +492,7 @@ function helfi_platform_config_config_ignore_ignored_alter(ConfigIgnoreConfig $i
   // Add the configuration objects to the ignore list.
   foreach (['create', 'update', 'delete'] as $operation) {
     foreach (['import', 'export'] as $direction) {
-      // Let the configurations be create during import.
+      // Create the new configurations during import.
       if ($operation === 'create' && $direction === 'import') {
         continue;
       }

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\config_ignore\ConfigIgnoreConfig;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\ContentEntityInterface;
@@ -478,21 +479,29 @@ function helfi_platform_config_set_language_link_disabled(array &$link): void {
 }
 
 /**
- * Implements hook_config_ignore_settings_alter().
+ * Implements hook_config_ignore_ignored_alter().
  */
-function helfi_platform_config_config_ignore_settings_alter(array &$settings) {
-  $add_ignore = [
+function helfi_platform_config_config_ignore_ignored_alter(ConfigIgnoreConfig $ignored): void {
+  $settings_to_ignore = [
     'block.block.ibmchatapp',
     'block.block.ibmchatapp_*',
     'block.block.teliaacewidget*',
     'block.block.hdbt_subtheme_teliaacewidget*',
   ];
 
-  foreach ($add_ignore as $config) {
-    if (in_array($config, $settings)) {
-      continue;
+  // Add the configuration objects to the ignore list.
+  foreach (['create', 'update', 'delete'] as $operation) {
+    foreach (['import', 'export'] as $direction) {
+      // Let the configurations be create during import.
+      if ($operation === 'create' && $direction === 'import') {
+        continue;
+      }
+      $list = array_merge(
+        $ignored->getList($direction, $operation),
+        $settings_to_ignore,
+      );
+      $ignored->setList($direction, $operation, $list);
     }
-    array_push($settings, $config);
   }
 }
 


### PR DESCRIPTION
# [UHF-11640](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11640)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Switched the config ignore alter hook, and modified the operation list to permit the creation of new configurations during import phase.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check instructions from: https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/1027
* [x] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/1027


[UHF-11640]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ