### PR TITLE
UHF-10647: Updating elastic query

### DIFF
--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -389,7 +389,12 @@ class RecommendationManager implements RecommendationManagerInterface {
         'terms_set' => [
           'parent_instance' => [
             'terms' => $allowed_instances,
-            'minimum_should_match' => 1,
+            'minimum_should_match_script' => [
+              'source' => 'params["minimum_should_match"]',
+              'params' => [
+                'minimum_should_match' => 1,
+              ],
+            ],
           ],
         ],
       ];
@@ -412,7 +417,12 @@ class RecommendationManager implements RecommendationManagerInterface {
           'terms_set' => [
             'parent_type' => [
               'terms' => $allowed_entity_types,
-              'minimum_should_match' => 1,
+              'minimum_should_match_script' => [
+                'source' => 'params["minimum_should_match"]',
+                'params' => [
+                  'minimum_should_match' => 1,
+                ],
+              ],
             ],
           ],
         ];
@@ -424,7 +434,12 @@ class RecommendationManager implements RecommendationManagerInterface {
           'terms_set' => [
             'parent_bundle' => [
               'terms' => $allowed_bundles,
-              'minimum_should_match' => 1,
+              'minimum_should_match_script' => [
+                'source' => 'params["minimum_should_match"]',
+                'params' => [
+                  'minimum_should_match' => 1,
+                ],
+              ],
             ],
           ],
         ];


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

The elastic query was using a feature that was introduced in Elasticquery 8.10.0 (https://github.com/elastic/elasticsearch/pull/96082). Our local development stack covers this, but OpenShift is still on 8.0.0 so the query is failing there.

## What was done

Query was updated to support 8.0.0.

## How to test

Maybe we can confirm the new query format in Postman, and then test directly in the test environment?

- Create a POST request in Postman to url `https://etusivu-elastic-proxy-test.agw.arodevtest.hel.fi/suggestions/_search`
- Use the following json contents as raw request Body:
  - Old, failing query: [old-query.json](https://github.com/user-attachments/files/20064977/old-query.json)
  - New query: [new-query.json](https://github.com/user-attachments/files/20064982/new-query.json)



[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ