### PR TITLE
UHF-11025: Status messages theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,8 @@
                 "[#UHF-7008] Admin toolbar and contextual links should always be rendered in the admin language (https://www.drupal.org/project/drupal/issues/2313309)": "https://www.drupal.org/files/issues/2023-12-19/2313309-179.patch",
                 "[#UHF-9388] Process configuration translation files for custom modules (https://www.drupal.org/i/2845437)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fd68277191b8f8ec290e53b5fbbae699b2260384/patches/drupal-2845437-process-custom-module-translation-config-10.3.x.patch",
                 "[#UHF-9690] Allow updating lists when switching from allowed values to allowed values function (https://www.drupal.org/i/2873353)": "https://www.drupal.org/files/issues/2021-05-18/allow-allowed-values-function-update-D9-2873353_1.patch",
-                "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "https://www.drupal.org/files/issues/2024-08-08/3083786--mr-8066--10-3-backport.patch"
+                "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "https://www.drupal.org/files/issues/2024-08-08/3083786--mr-8066--10-3-backport.patch",
+                "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/319cfd8583f985f1af00990481176b1d95d5af65/patches/drupal-3396318-status-message-bigpipe-mr-9329.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"

--- a/patches/drupal-3396318-status-message-bigpipe-mr-9329.patch
+++ b/patches/drupal-3396318-status-message-bigpipe-mr-9329.patch
@@ -1,0 +1,90 @@
+diff --git a/core/core.libraries.yml b/core/core.libraries.yml
+index 9e34b6c95bd1fe2e2581c987be2dbfa53dace052..9a6472c2358ceb2a65d2cc6b5d144fcefebdbd16 100644
+--- a/core/core.libraries.yml
++++ b/core/core.libraries.yml
+@@ -617,6 +617,11 @@ drupal.message:
+   dependencies:
+     - core/drupal
+     - core/drupal.announce
++  # These placeholders will be set by system_js_settings_alter().
++  drupalSettings:
++    statusMessagesTemplate: null
++    warningMessagesTemplate: null
++    errorMessagesTemplate: null
+
+ drupal.progress:
+   version: VERSION
+diff --git a/core/misc/message.js b/core/misc/message.js
+index dac4049db508350f2cc989ec782b22651e710b0e..050ff6cc4fbc64bcb9e6beb3ff5a57613c03f87e 100644
+--- a/core/misc/message.js
++++ b/core/misc/message.js
+@@ -248,21 +248,11 @@
+    *   A DOM Node.
+    */
+   Drupal.theme.message = ({ text }, { type, id }) => {
+-    const messagesTypes = Drupal.Message.getMessageTypeLabels();
+-    const messageWrapper = document.createElement('div');
+-
+-    messageWrapper.setAttribute('class', `messages messages--${type}`);
+-    messageWrapper.setAttribute(
+-      'role',
+-      type === 'error' || type === 'warning' ? 'alert' : 'status',
+-    );
+-    messageWrapper.setAttribute('data-drupal-message-id', id);
+-    messageWrapper.setAttribute('data-drupal-message-type', type);
+-
+-    messageWrapper.setAttribute('aria-label', messagesTypes[type]);
+-
+-    messageWrapper.innerHTML = `${text}`;
+-
+-    return messageWrapper;
++    const element = document.createElement('div');
++    element.innerHTML = drupalSettings[`${type}MessagesTemplate`];
++    element.querySelector('[data-drupal-message-template]').innerHTML = text;
++    const fragment = document.createDocumentFragment();
++    fragment.appendChild(element);
++    return fragment.firstElementChild.firstElementChild;
+   };
+ })(Drupal);
+diff --git a/core/modules/system/system.module b/core/modules/system/system.module
+index 98841512879fb3273d6f68e780a34f0802d10d96..605c6b6872441def9150b0d72d1aca1cfa191135 100644
+--- a/core/modules/system/system.module
++++ b/core/modules/system/system.module
+@@ -21,6 +21,7 @@
+ use Drupal\Core\Link;
+ use Drupal\Core\PageCache\RequestPolicyInterface;
+ use Drupal\Core\Queue\QueueGarbageCollectionInterface;
++use Drupal\Core\Render\Markup;
+ use Drupal\Core\Routing\RouteMatchInterface;
+ use Drupal\Core\Routing\StackedRouteMatchInterface;
+ use Drupal\Core\Site\Settings;
+@@ -765,6 +766,29 @@ function system_js_settings_alter(&$settings, AttachedAssetsInterface $assets) {
+     sort($minimal_libraries);
+     $settings['ajaxPageState']['libraries'] = implode(',', $minimal_libraries);
+   }
++
++  // @todo Preferably, retrieve these from the render element.
++  foreach (['status', 'error', 'warning'] as $type) {
++    $message_type_key = $type . 'MessagesTemplate';
++    if (array_key_exists($message_type_key, $settings)) {
++      /** @var \Drupal\Core\Render\RendererInterface $renderer */
++      $renderer = \Drupal::service('renderer');
++      $message_template = [
++        '#theme' => 'status_messages',
++        '#message_list' => [
++          $type => [
++            '#markup' => Markup::create('<div data-drupal-message-template></div>'),
++          ],
++        ],
++        '#status_headings' => [
++          'status' => t('Status message'),
++          'error' => t('Error message'),
++          'warning' => t('Warning message'),
++        ],
++      ];
++      $settings[$message_type_key] = $renderer->renderInIsolation($message_template);
++    }
++  }
+ }
+
+ /**


### PR DESCRIPTION
# [UHF-11025](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11025)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added patch to fix the status messages when bigpipe module is enabled.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11025`
  * `composer install`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the status messages theme works with 
   * [ ] Big pipe module enabled
   * [ ] Big pipe module disabled
* [ ] Check that code follows our standards



[UHF-11025]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ