### PR TITLE
UHF-11025 Cookie banner API calling issue

### DIFF
--- a/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
+++ b/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
@@ -1,12 +1,5 @@
 'use strict';
 
-class UnapprovedItemError extends Error {
-  constructor(message, name) {
-    super(message)
-    this.name = name
-  }
-}
-
 ((Drupal, drupalSettings) => {
 
   // Global cookie consent status object.
@@ -66,62 +59,5 @@ class UnapprovedItemError extends Error {
         }
       };
     }
-  }
-
-  // Attach a behavior to capture unapproved cookies with Sentry.
-  Drupal.behaviors.unapprovedCookies = {
-    attach: function attach() {
-      const apiUrl = drupalSettings.hdbt_cookie_banner.apiUrl;
-      fetch(apiUrl)
-        .then(response => response.json())
-        .then(jsonData => {
-
-          // Function to extract cookie names from each group
-          const extractCookiePatterns = (groups) =>
-            groups?.flatMap(group => group.cookies.map(cookie => cookie.name)) || [];
-
-          // Collect all allowed cookie name patterns
-          const validItems = [
-            ...extractCookiePatterns(jsonData.optionalGroups),
-            ...extractCookiePatterns(jsonData.requiredGroups),
-            ...extractCookiePatterns(jsonData.robotGroups),
-          ];
-
-          window.addEventListener(
-            'hds-cookie-consent-unapproved-item-found',
-            (e) => {
-              if (typeof window.Sentry === 'undefined') {
-                return;
-              }
-
-              const { storageType, keys, acceptedGroups } = e.detail;
-              const sortedKeys = keys.sort();
-
-              // Check which keys do not match any pattern in the valid items list
-              const unapprovedItems = sortedKeys.filter(
-                key => !validItems.some(pattern => key.includes(pattern.replace('*', '')))
-              ).sort();
-
-              // Only log if there are unapproved items that are not found in our list
-              if (unapprovedItems.length > 0) {
-                const name = `Unapproved ${storageType}`;
-                const message = `Found: ${unapprovedItems.join(', ')}`;
-
-                window.Sentry.captureException(new UnapprovedItemError(message, name), {
-                  level: 'warning',
-                  tags: {
-                    approvedCategories: acceptedGroups.join(', '),
-                  },
-                  extra: {
-                    storageType,
-                    missingCookies: unapprovedItems,
-                    approvedCategories: acceptedGroups,
-                  },
-                });
-              }
-            }
-          );
-        })
-    },
   }
 })(Drupal, drupalSettings);

--- a/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
+++ b/modules/hdbt_cookie_banner/assets/js/hdbt-cookie-banner.js
@@ -1,6 +1,6 @@
 'use strict';
 
-((Drupal, drupalSettings) => {
+((Drupal) => {
 
   // Global cookie consent status object.
   Drupal.cookieConsent = {
@@ -24,20 +24,26 @@
   };
 
   Drupal.behaviors.hdbt_cookie_banner = {
-    attach: function () {
+    attach: function (context, settings) {
+      // Run only once for the full document.
+      if (context !== document || window.hdsCookieConsentInitialized) {
+        return;
+      }
+
       // The hds-cookie-consent.min.js should be loaded before this script.
       // Check if the script is loaded.
       if (
         typeof window.hds !== 'undefined' &&
         typeof window.hds.CookieConsentCore !== 'undefined'
       ) {
-        const apiUrl = drupalSettings.hdbt_cookie_banner.apiUrl;
+        const apiUrl = settings.hdbt_cookie_banner.apiUrl;
         const options = {
-          language: drupalSettings.hdbt_cookie_banner.langcode,
-          theme: drupalSettings.hdbt_cookie_banner.theme,
-          settingsPageSelector: drupalSettings.hdbt_cookie_banner.settingsPageSelector,
-          spacerParentSelector: drupalSettings.hdbt_cookie_banner.spacerParentSelector || '.footer',
+          language: settings.hdbt_cookie_banner.langcode,
+          theme: settings.hdbt_cookie_banner.theme,
+          settingsPageSelector: settings.hdbt_cookie_banner.settingsPageSelector,
+          spacerParentSelector: settings.hdbt_cookie_banner.spacerParentSelector || '.footer',
         };
+        window.hdsCookieConsentInitialized = true;
         window.hds.CookieConsentCore.create(apiUrl, options);
       }
       else {
@@ -60,4 +66,4 @@
       };
     }
   }
-})(Drupal, drupalSettings);
+})(Drupal);

--- a/modules/hdbt_cookie_banner/assets/js/unapproved-cookies.js
+++ b/modules/hdbt_cookie_banner/assets/js/unapproved-cookies.js
@@ -7,13 +7,13 @@ class UnapprovedItemError extends Error {
   }
 }
 
-((Drupal, drupalSettings) => {
+((Drupal) => {
 
   let unapprovedCookiesInitialized = false;
 
   // Attach a behavior to capture unapproved cookies with Sentry.
   Drupal.behaviors.unapprovedCookies = {
-    attach: function attach(context) {
+    attach: function attach(context, settings) {
       // Run only once for the full document.
       if (context !== document || unapprovedCookiesInitialized) {
         return;
@@ -21,7 +21,7 @@ class UnapprovedItemError extends Error {
 
       unapprovedCookiesInitialized = true;
 
-      const apiUrl = drupalSettings.hdbt_cookie_banner.apiUrl;
+      const apiUrl = settings.hdbt_cookie_banner.apiUrl;
       fetch(apiUrl)
         .then(response => response.json())
         .then(jsonData => {
@@ -74,4 +74,4 @@ class UnapprovedItemError extends Error {
         })
     },
   }
-})(Drupal, drupalSettings);
+})(Drupal);

--- a/modules/hdbt_cookie_banner/assets/js/unapproved-cookies.js
+++ b/modules/hdbt_cookie_banner/assets/js/unapproved-cookies.js
@@ -1,0 +1,77 @@
+'use strict';
+
+class UnapprovedItemError extends Error {
+  constructor(message, name) {
+    super(message)
+    this.name = name
+  }
+}
+
+((Drupal, drupalSettings) => {
+
+  let unapprovedCookiesInitialized = false;
+
+  // Attach a behavior to capture unapproved cookies with Sentry.
+  Drupal.behaviors.unapprovedCookies = {
+    attach: function attach(context) {
+      // Run only once for the full document.
+      if (context !== document || unapprovedCookiesInitialized) {
+        return;
+      }
+
+      unapprovedCookiesInitialized = true;
+
+      const apiUrl = drupalSettings.hdbt_cookie_banner.apiUrl;
+      fetch(apiUrl)
+        .then(response => response.json())
+        .then(jsonData => {
+
+          // Function to extract cookie names from each group
+          const extractCookiePatterns = (groups) =>
+            groups?.flatMap(group => group.cookies.map(cookie => cookie.name)) || [];
+
+          // Collect all allowed cookie name patterns
+          const validItems = [
+            ...extractCookiePatterns(jsonData.optionalGroups),
+            ...extractCookiePatterns(jsonData.requiredGroups),
+            ...extractCookiePatterns(jsonData.robotGroups),
+          ];
+
+          window.addEventListener(
+            'hds-cookie-consent-unapproved-item-found',
+            (e) => {
+              if (typeof window.Sentry === 'undefined') {
+                return;
+              }
+
+              const { storageType, keys, acceptedGroups } = e.detail;
+              const sortedKeys = keys.sort();
+
+              // Check which keys do not match any pattern in the valid items list
+              const unapprovedItems = sortedKeys.filter(
+                key => !validItems.some(pattern => key.includes(pattern.replace('*', '')))
+              ).sort();
+
+              // Only log if there are unapproved items that are not found in our list
+              if (unapprovedItems.length > 0) {
+                const name = `Unapproved ${storageType}`;
+                const message = `Found: ${unapprovedItems.join(', ')}`;
+
+                window.Sentry.captureException(new UnapprovedItemError(message, name), {
+                  level: 'warning',
+                  tags: {
+                    approvedCategories: acceptedGroups.join(', '),
+                  },
+                  extra: {
+                    storageType,
+                    missingCookies: unapprovedItems,
+                    approvedCategories: acceptedGroups,
+                  },
+                });
+              }
+            }
+          );
+        })
+    },
+  }
+})(Drupal, drupalSettings);

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.libraries.yml
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.libraries.yml
@@ -43,7 +43,7 @@ cookie_banner_admin_ui:
     - hdbt_cookie_banner/json_editor
 
 hdbt_cookie_banner:
-  version: 1.0.0
+  version: 1.0.1
   header: true
   js:
     # The weight needs to be as low as drupal.init.js, which is -17.
@@ -57,3 +57,12 @@ hds_cookie_consent:
   header: true
   js:
     assets/js/hds-cookie-consent.min.js: { weight: -17, minified: true, preprocess: false }
+
+unapproved_cookies:
+  version: 1.0.0
+  js:
+    assets/js/unapproved-cookies.js: {}
+  dependencies:
+    - core/drupal
+    - core/drupalSettings
+    - hdbt_cookie_banner/hdbt_cookie_banner

--- a/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
+++ b/modules/hdbt_cookie_banner/hdbt_cookie_banner.module
@@ -94,6 +94,8 @@ function hdbt_cookie_banner_page_attachments(array &$attachments) : void {
 
   // Attach HDBT cookie banner initialization JS file.
   $attachments['#attached']['library'][] = 'hdbt_cookie_banner/hdbt_cookie_banner';
+  // Attach HDBT cookie banner unapproved cookies JS file.
+  $attachments['#attached']['library'][] = 'hdbt_cookie_banner/unapproved_cookies';
 
   // Attach HDBT cookie banner settings.
   $attachments['#attached']['drupalSettings']['hdbt_cookie_banner'] = [


### PR DESCRIPTION
# [UHF-11025](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11025)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Separated the unapproved cookies functionality to its own file and added checks for running the initialisation only for the full document. Switched to use the contextual `settings` instead of the global `drupalSettings`.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11025`
* Run `make drush-cr`
* Check that there is no cache prevention in local.settings.php and that the aggregation is turned on

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as an admin and load any page with the browsers Network tab open and Fetch/XHR filter selected
* [ ] Check that the cookie-banner is fetched only twice and not multiple times like in this screenshot  
   ![image](https://github.com/user-attachments/assets/86e88731-3ec1-441b-9e09-87320f352c8d)
* [ ] Check that code follows our standards


[UHF-11025]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ