### PR TITLE
UHF-11178: Fix org chart urls

### DIFF
--- a/modules/helfi_paragraphs_org_chart/src/OrgChartImporter.php
+++ b/modules/helfi_paragraphs_org_chart/src/OrgChartImporter.php
@@ -53,8 +53,9 @@ class OrgChartImporter {
         ->getEnvironment(Project::PAATOKSET, EnvironmentEnum::Prod->value);
     }
 
-    // We want to use public URL so that paatokset generates publicly accessible URLs
-    // for organizations. However, public URL does not work in local environment.
+    // We want to use public URL so that paatokset generates publicly
+    // accessible URLs for organizations. However, public URL does not
+    // work in the local environment.
     if ($environment->getEnvironment() === EnvironmentEnum::Local) {
       return sprintf("%s/ahjo_api/org-chart/$start/$depth", $environment->getInternalAddress($langcode));
     }

--- a/modules/helfi_paragraphs_org_chart/src/OrgChartImporter.php
+++ b/modules/helfi_paragraphs_org_chart/src/OrgChartImporter.php
@@ -53,7 +53,13 @@ class OrgChartImporter {
         ->getEnvironment(Project::PAATOKSET, EnvironmentEnum::Prod->value);
     }
 
-    return sprintf("%s/ahjo_api/org-chart/$start/$depth", $environment->getInternalAddress($langcode));
+    // We want to use public URL so that paatokset generates publicly accessible URLs
+    // for organizations. However, public URL does not work in local environment.
+    if ($environment->getEnvironment() === EnvironmentEnum::Local) {
+      return sprintf("%s/ahjo_api/org-chart/$start/$depth", $environment->getInternalAddress($langcode));
+    }
+
+    return sprintf("%s/ahjo_api/org-chart/$start/$depth", $environment->getUrl($langcode));
   }
 
   /**


### PR DESCRIPTION
# [UHF-11178](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11178)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

We want to use public URL so that paatokset generates publicly accessible URLs
for organizations. However, public URL does not work in local environment.

[UHF-11178]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ