### PR TITLE
UHF-11611: Move matomo site id to settings.php

### DIFF
--- a/config/schema/helfi_platform_config.schema.yml
+++ b/config/schema/helfi_platform_config.schema.yml
@@ -17,14 +17,6 @@ helfi_platform_config.redirect_cleaner:
     enable:
       type: boolean
 
-helfi_platform_config.matomo_settings:
-  type: config_object
-  label: 'Matomo settings'
-  mapping:
-   matomo_site_id:
-     type: string
-     label: 'Matomo site ID'
-
 # Default value.
 field.value.location:
   type: mapping

--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -380,3 +380,12 @@ function helfi_platform_config_update_9322(): void {
     }
   }
 }
+
+/**
+ * UHF-11535: Move matomo site id to settings.php.
+ */
+function helfi_platform_config_update_9323(): void {
+  \Drupal::configFactory()
+    ->getEditable('helfi_platform_config.matomo_settings')
+    ->delete();
+}

--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -21,6 +21,7 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\block\Entity\Block;
@@ -560,9 +561,7 @@ function helfi_platform_config_cron(): void {
  * Implements hook_preprocess_html().
  */
 function helfi_platform_config_preprocess_html(&$variables): void {
-  $config = \Drupal::config('helfi_platform_config.matomo_settings');
-  $matomo_site_id = $config->get('matomo_site_id');
-
+  $matomo_site_id = Settings::get('matomo_site_id');
   if ($matomo_site_id) {
     $variables['#attached']['drupalSettings']['matomo_site_id'] = $matomo_site_id;
   }


### PR DESCRIPTION
# [UHF-11611](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11611)
<!-- What problem does this solve? -->

## How to test
 - `make fresh`
 - `composer require drupal/helfi_platform_config:dev-UHF-11611`
 - `drush updb`
 - Add: `$settings['matomo_site_id'] = '123';` to your local.settings.php.
 - Check that `window.drupalSettings.matomo_site_id` variable is set in Javascript.

[UHF-11611]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ