### PR TITLE
UHF-11534: Suggested topics for Metatavu crawler

### DIFF
--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -149,6 +149,47 @@ function helfi_recommendations_text_conversion_alter(Document &$document, Entity
 }
 
 /**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_recommendations_page_attachments_alter(array &$attachments) {
+  if (empty($attachments['#attached']['html_head'])) {
+    return;
+  }
+
+  $entities = array_filter(
+    \Drupal::routeMatch()->getParameters()->all(),
+    function ($param) {
+      return $param instanceof ContentEntityInterface;
+    }
+  );
+
+  $entity = !empty($entities) ? reset($entities) : NULL;
+  if ($entity) {
+    // Add a custom meta tag with a comma seprated list of suggested topics.
+    $topicsManager = \Drupal::service(TopicsManagerInterface::class);
+    $keywords = $topicsManager->getKeywords($entity);
+
+    if ($keywords) {
+      $tag_name = 'helfi_suggested_topics';
+      $tag = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => $tag_name,
+          'content' => implode(',', array_map(function ($keyword) {
+            // Wrap the keyword in double quotes to make sure commas inside the
+            // keyword are not interpreted as a delimiter.
+            return $keyword['label'] ? "\"{$keyword['label']}\"" : NULL;
+          }, $keywords)),
+          'class' => 'elastic',
+        ],
+      ];
+
+      $attachments['#attached']['html_head'][] = [$tag, $tag_name];
+    }
+  }
+}
+
+/**
  * Implements template_preprocess_recommendations_block().
  */
 function helfi_recommendations_preprocess_recommendations_block(array &$variables) : void {

--- a/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
+++ b/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
@@ -13,6 +13,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\helfi_recommendations\Entity\SuggestedTopics;
+
 /**
  * Taxonomy related tests.
  *

--- a/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
+++ b/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_recommendations\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\helfi_recommendations\Entity\SuggestedTopics;
+/**
+ * Taxonomy related tests.
+ *
+ * @group helfi_platform_config
+ */
+class TopicSuggestionsMetaTagTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'taxonomy',
+    'node',
+    'helfi_recommendations',
+    'helfi_platform_config',
+  ];
+
+  /**
+   * Tests the topic suggestions meta tag.
+   */
+  public function testTopicSuggestionsMetaTag() : void {
+    NodeType::create([
+      'name' => $this->randomMachineName(),
+      'type' => 'test_node_bundle',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'test_keywords',
+      'entity_type' => 'node',
+      'type' => 'suggested_topics_reference',
+    ])->save();
+
+    FieldConfig::create([
+      'field_name' => 'test_keywords',
+      'entity_type' => 'node',
+      'bundle' => 'test_node_bundle',
+      'label' => 'Test field',
+    ])->save();
+
+    $vocabulary = Vocabulary::create([
+      'name' => 'Test topics vocabulary',
+      'vid' => 'test_topics',
+      'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+    ]);
+    $vocabulary->save();
+
+    $term1 = Term::create([
+      'vid' => $vocabulary->id(),
+      'name' => 'Test topic, with a comma in it',
+      'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+    ]);
+    $term1->save();
+
+    $term2 = Term::create([
+      'vid' => $vocabulary->id(),
+      'name' => 'Another test topic',
+      'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+    ]);
+    $term2->save();
+
+    $node = Node::create([
+      'type' => 'test_node_bundle',
+      'title' => $this->randomString(),
+      'test_keywords' => SuggestedTopics::create([
+        'keywords' => [
+          ['entity' => $term1, 'score' => 0.8],
+          ['entity' => $term2, 'score' => 0.2],
+        ],
+      ]),
+    ]);
+    $node->save();
+
+    $nodeUrl = $node->toUrl()->toString();
+    $this->drupalGet($nodeUrl);
+
+    $xpath = $this->xpath("//meta[@name='helfi_suggested_topics']");
+    $this->assertEquals(1, count($xpath));
+    $this->assertEquals('"Test topic, with a comma in it","Another test topic"', $xpath[0]->getAttribute('content'));
+  }
+
+}


### PR DESCRIPTION
# [UHF-11534](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11534)

## What was done

* Added a meta tag with a comma separated list of suggested topic labels for current content.

## How to install
* Make sure your etusivu instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11534`
* Run `make drush-updb drush-cr`

## How to test

* Test on a few different pages:
  * [ ] meta tag `helfi_suggested_topics` is present with a comma separated list of suggestion topics on all pages that have suggestions generated (should work on existing `news_item`, `news_article`, `page` and `landing_page` content)
  * [ ] meta tag should not appear when suggested topics are not available. This can be tested by creating a new page node, as topics are generated via a cron run and are not present immediately after save.


[UHF-11534]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ