### PR TITLE
UHF-11833: Configuration import

### DIFF
--- a/helfi_platform_config.module
+++ b/helfi_platform_config.module
@@ -510,6 +510,18 @@ function helfi_platform_config_config_ignore_ignored_alter(ConfigIgnoreConfig $i
       $ignored->setList($direction, $operation, $list);
     }
   }
+
+  // Ignore the external menu block dependencies for menu configurations.
+  // Without this, configuration import will fail with an error when trying
+  // to delete the menu that the block depends on. The dependency is obsolete,
+  // but Drupal still adds it because of the block's plugin.
+  foreach (['create', 'update', 'delete'] as $operation) {
+    $list = array_merge(
+      $ignored->getList('import', $operation),
+      ['block.block.external_*:dependencies.config'],
+    );
+    $ignored->setList('import', $operation, $list);
+  }
 }
 
 /**


### PR DESCRIPTION
# [UHF-11833](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11833)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Ignore the external menu block dependencies during configuration import.
   * This should fix the issues with these configuration import errors: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/actions/runs/15295781879/job/43024463950?pr=927#step:14:60

[UHF-11833]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ