### PR TITLE
UHF-10647: Fixing the role name used for checking access to recommendations block

### DIFF
--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -277,7 +277,7 @@ function helfi_recommendations_field_widget_single_element_suggested_topics_refe
 function _helfi_recommendations_can_see_review_mode() : bool {
   $current_user = \Drupal::currentUser();
   $roles = $current_user->getRoles();
-  return in_array('administrator', $roles) || $current_user->hasPermission('administer modules');
+  return in_array('admin', $roles) || $current_user->hasPermission('administer modules');
 }
 
 /**


### PR DESCRIPTION
# [UHF-10647](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647)

## What was done

This PR updates the role machine name used for the temporary access check on recommendations block.

## How to test

Maybe trivial enough to confirm in test environment?


[UHF-10647]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ