### PR TITLE
UHF-11784: Storage comparer patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
                 "[#UHF-9388] Process configuration translation files for custom modules (https://www.drupal.org/i/2845437)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fd68277191b8f8ec290e53b5fbbae699b2260384/patches/drupal-2845437-process-custom-module-translation-config-10.3.x.patch",
                 "[#UHF-9690] Allow updating lists when switching from allowed values to allowed values function (https://www.drupal.org/i/2873353)": "https://www.drupal.org/files/issues/2021-05-18/allow-allowed-values-function-update-D9-2873353_1.patch",
                 "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "https://www.drupal.org/files/issues/2024-08-08/3083786--mr-8066--10-3-backport.patch",
-                "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/319cfd8583f985f1af00990481176b1d95d5af65/patches/drupal-3396318-status-message-bigpipe-mr-9329.patch"
+                "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/319cfd8583f985f1af00990481176b1d95d5af65/patches/drupal-3396318-status-message-bigpipe-mr-9329.patch",
+                "[#UHF-11784] Sort the source and target arrays in the configuration storage comparer to avoid false positives": "./public/modules/contrib/helfi_platform_config/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2640734#comment-14638943": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/main/patches/default_content_2.0.0-alpha2-2640734_manual_imports-e164a354.patch"

--- a/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch
+++ b/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Drupal/Core/Config/StorageComparer.php b/lib/Drupal/Core/Config/StorageComparer.php
+index 820fe041fc..42017120f2 100644
+--- a/lib/Drupal/Core/Config/StorageComparer.php
++++ b/lib/Drupal/Core/Config/StorageComparer.php
+@@ -299,7 +299,7 @@ class StorageComparer implements StorageComparerInterface {
+     foreach (array_intersect($this->sourceNames[$collection], $this->targetNames[$collection]) as $name) {
+       $source_data = $this->getSourceStorage($collection)->read($name);
+       $target_data = $this->getTargetStorage($collection)->read($name);
+-      if ($source_data !== $target_data) {
++      if (asort($source_data) !== asort($target_data)) {
+         if (isset($source_data['uuid']) && $source_data['uuid'] !== $target_data['uuid']) {
+           // The entity has the same file as an existing entity but the UUIDs do
+           // not match. This means that the entity has been recreated so config


### PR DESCRIPTION
# [UHF-11784](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11784)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added a patch to sort the source and target arrays when comparing changed configurations.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11784`
  * `composer install`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the following 👻 configuration changes are gone, when running `drush cim`
![image](https://github.com/user-attachments/assets/c746b80a-3ba2-45e5-9ea2-f18c9ec12ddb)
* [ ] Check that code follows our standards
