### PR TITLE
UHF-11784: Patch fix

### DIFF
--- a/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch
+++ b/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch
@@ -1,13 +1,13 @@
 diff --git a/core/lib/Drupal/Core/Config/StorageComparer.php b/core/lib/Drupal/Core/Config/StorageComparer.php
-index 820fe041fc..42017120f2 100644
+index 820fe041fc..06a1d8c779 100644
 --- a/core/lib/Drupal/Core/Config/StorageComparer.php
 +++ b/core/lib/Drupal/Core/Config/StorageComparer.php
-@@ -299,7 +299,7 @@ class StorageComparer implements StorageComparerInterface {
+@@ -299,6 +299,8 @@ class StorageComparer implements StorageComparerInterface {
      foreach (array_intersect($this->sourceNames[$collection], $this->targetNames[$collection]) as $name) {
        $source_data = $this->getSourceStorage($collection)->read($name);
        $target_data = $this->getTargetStorage($collection)->read($name);
--      if ($source_data !== $target_data) {
-+      if (asort($source_data) !== asort($target_data)) {
++      asort($source_data);
++      asort($target_data);
+       if ($source_data !== $target_data) {
          if (isset($source_data['uuid']) && $source_data['uuid'] !== $target_data['uuid']) {
            // The entity has the same file as an existing entity but the UUIDs do
-           // not match. This means that the entity has been recreated so config


### PR DESCRIPTION
# [UHF-11784](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11784)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The asort() returns always true, so we cannot compare the asort in if statement.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11784 -W`
  * `composer install`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the following 👻 configuration changes are gone, when running `drush cim`
![image](https://github.com/user-attachments/assets/c746b80a-3ba2-45e5-9ea2-f18c9ec12ddb)
* [ ] Check that code follows our standards

[UHF-11784]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ