### PR TITLE
UHF-9754: Event list paragraph states

### DIFF
--- a/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_event_location.yml
+++ b/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_event_location.yml
@@ -10,7 +10,7 @@ field_name: field_event_location
 entity_type: paragraph
 bundle: event_list
 label: 'Event location'
-description: 'Show "event location" filter. The API URL field should include all location IDs, otherwise this list will display all active locations.'
+description: 'Show "event location" filter. If Event location is selected, you cannot use the Remote Events filter.'
 required: false
 translatable: false
 default_value:

--- a/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_remote_events.yml
+++ b/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_remote_events.yml
@@ -10,7 +10,7 @@ field_name: field_remote_events
 entity_type: paragraph
 bundle: event_list
 label: 'Remote events'
-description: 'Show "list only remote events" filter.'
+description: 'Show "list only remote events" filter. If Event location is selected, you cannot use the Remote Events filter.'
 required: false
 translatable: false
 default_value:

--- a/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_event_location.yml
+++ b/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_event_location.yml
@@ -1,5 +1,5 @@
 label: Tapahtumapaikka
-description: 'Näytä "tapahtumapaikka" -suodatin.Tapahtumapaikat pitää valita tapahtumakalenterista ennen kuin kopioit linkin.'
+description: 'Näytä "tapahtumapaikka" -suodatin. Jos Tapahtumapaikka on valittuna, et voi käyttää Etätapahtumat-suodatinta.'
 settings:
   on_label: Kyllä
   off_label: Ei

--- a/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_remote_events.yml
+++ b/modules/helfi_react_search/config/optional/language/fi/field.field.paragraph.event_list.field_remote_events.yml
@@ -1,5 +1,5 @@
 label: Etätapahtumat
-description: 'Näytä "näytä vain etätapahtumat" -suodatin.'
+description: 'Näytä "näytä vain etätapahtumat" -suodatin. Jos Tapahtumapaikka on valittuna, et voi käyttää Etätapahtumat-suodatinta.'
 settings:
   on_label: Kyllä
   off_label: Ei

--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -114,18 +114,29 @@ function helfi_react_search_field_widget_single_element_paragraphs_form_alter(ar
     return;
   }
 
-  $type_select = ':input[name="' . $context['items']->getName() . '[' . $element['#delta'] . '][subform][field_event_list_type]"]';
-
+  $select = fn (string $prefix) => ':input[name="' . $context['items']->getName() . '[' . $element['#delta'] . '][subform]' . $prefix . '"]';
   $states = [
-    'field_event_list_category_event' => 'hobbies',
-    'field_event_list_category_hobby' => 'events',
+    'field_event_list_category_event' => [
+      'state' => 'invisible',
+      'condition' => [$select('[field_event_list_type]') => ['value' => 'hobbies']],
+    ],
+    'field_event_list_category_hobby' => [
+      'state' => 'invisible',
+      'condition' => [$select('[field_event_list_type]') => ['value' => 'events']],
+    ],
+    'field_event_location' => [
+      'state' => 'disabled',
+      'condition' => [$select('[field_remote_events][value]') => ['checked' => TRUE]],
+    ],
+    'field_remote_events' => [
+      'state' => 'disabled',
+      'condition' => [$select('[field_event_location][value]') => ['checked' => TRUE]],
+    ],
   ];
 
-  foreach ($states as $field => $condition) {
+  foreach ($states as $field => ['state' => $state, 'condition' => $condition]) {
     $element['subform'][$field]['#states'] = [
-      'invisible' => [
-        [$type_select => ['value' => $condition]],
-      ],
+      $state => [$condition],
     ];
   }
 }


### PR DESCRIPTION
# [UHF-9754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Disable remote event filter if location filter is selected and vice versa.

## How to install
- See: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/978
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Find event_list paragraph or add one to a node.

* [ ] Selecting remote event filter should disable location filter
* [ ] Selecting location filter should disable remote event filter
* [ ] Event type states should still work: changing type should hide/show event/hobby category field like before
* [ ] Code follows our standards.

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* 


[UHF-9754]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ