### PR TITLE
UHF-11840: Duplicating nested paragraph saved bad references to database which caused data loss

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,8 @@
             },
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2904705#comment-13836790": "https://www.drupal.org/files/issues/2020-09-25/2904705-115.patch",
-                "[#UHF-2059] Enhancements for the Admin UI": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fdccb32397cc6fa19b4d0077b21a2b18aa6be297/patches/helfi_customizations_for_paragraphs_widget_8.x-1.12.patch"
+                "[#UHF-2059] Enhancements for the Admin UI": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fdccb32397cc6fa19b4d0077b21a2b18aa6be297/patches/helfi_customizations_for_paragraphs_widget_8.x-1.12.patch",
+                "[#UHF-10840] Duplicating nested paragraph overwriting paragraph references": "https://git.drupalcode.org/issue/paragraphs-3510842/-/compare/8.x-1.x...3510842-cloning-nested-paragraph?from_project_id=59567"
             },
             "drupal/view_unpublished": {
                 "[#UHF-9256] Fix missing dynamic permission dependencies.": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/cbb944ae79643ba7ed895db3fac7f3b3d90ac850/patches/view_unpublished_permissions_missing_dependencies.patch"


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11840)

## What was done

Added a patch which fixes nested paragraph duplication

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11840`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test

- Create a new page, add a paragraph, for example list of links
  - Add a new link
- Duplicate the first paragraph
- Edit the duplicate
  - Change the duplicates title
  - Change the duplicate's child paragraphs, change the link and the texts
- Save the page

The inserted data should not have been overwritten

