### PR TITLE
UHF-9754 Module translations paths

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.install
+++ b/modules/helfi_react_search/helfi_react_search.install
@@ -295,3 +295,17 @@ function helfi_react_search_update_9016() : void {
     }
   }
 }
+
+/**
+ * UHF-9754: Unset '_info_file_ctime' for helfi_react_search module.
+ */
+function helfi_react_search_update_9017() : void {
+  $module_info = \Drupal::keyValue('locale.project')->get('helfi_react_search');
+
+  // Unset '_info_file_ctime' for helfi_react_search module as it contains
+  // outdated data which prevents the translastions from being updated.
+  if (isset($module_info['info']['_info_file_ctime'])) {
+    unset($module_info['info']['_info_file_ctime']);
+    \Drupal::keyValue('locale.project')->set('helfi_react_search', $module_info);
+  }
+}

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -174,3 +174,17 @@ function helfi_recommendations_get_block_configurations(string $theme) : array {
     ],
   ];
 }
+
+/**
+ * Unset '_info_file_ctime' for helfi_recommendations module.
+ */
+function helfi_recommandations_update_10001() : void {
+  $module_info = \Drupal::keyValue('locale.project')->get('helfi_recommendations');
+
+  // Unset '_info_file_ctime' for helfi_recommendations module as it contains
+  // outdated data which prevents the translastions from being updated.
+  if (isset($module_info['info']['_info_file_ctime'])) {
+    unset($module_info['info']['_info_file_ctime']);
+    \Drupal::keyValue('locale.project')->set('helfi_recommendations', $module_info);
+  }
+}


### PR DESCRIPTION
# [UHF-9754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Unset `_info_file_ctime` for `helfi_recommendations` and `helfi_react_search` modules to fix the issues with obsolete interface translation server patterns.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-9754_translations`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that this feature works
* [x] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->


[UHF-9754]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ