### PR TITLE
UHF-X: Updating the way recommendation image url is built to support absolute urls

### DIFF
--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -517,15 +517,16 @@ class RecommendationManager implements RecommendationManagerInterface {
       ];
 
       if ($image_url) {
+        $image_url_absolute = str_starts_with($image_url, 'http://') || str_starts_with($image_url, 'https://');
         $theme = 'responsive_image';
         $image_uri = $image_url;
 
         // Use external image when the recommendation item is from a different
-        // instance.
-        if ($instance !== $this->getParentInstance()) {
+        // instance or the image is an absolute URL.
+        if ($image_url_absolute || $instance !== $this->getParentInstance()) {
           $theme = 'imagecache_external_responsive';
           $environment = $this->environmentResolver->getEnvironment($instance, $this->environmentResolver->getActiveEnvironmentName());
-          $image_uri = sprintf('%s%s', $environment->getInternalBaseUrl(), $image_url);
+          $image_uri = $image_url_absolute ? $image_url : sprintf('%s%s', $environment->getInternalBaseUrl(), $image_url);
         }
 
         $data['image'] = [


### PR DESCRIPTION
# UHF-X

Recommendation images in production do not work:

- https://www.hel.fi/fi/uutiset/helsinkilaisille-tarkea-meri-on-ollut-monen-omastadi-ehdotuksen-innoittaja
- https://www.hel.fi/fi/kaupunkiymparisto-ja-liikenne/pysakointi/pysakointipaikat-hinnat-ja-maksutavat/pysakoinnin-mobiilisovellusten-hintavertailu

## What was done

The image url generation was assuming the indexed url is always a relative path, which is true in local development environments, but not in openshift. Added a check for absolute image url.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-X_recommendation-images`
* Edit file `public/modules/contrib/helfi_platform_config/modules/helfi_recommendations/src/ElasticClientBuilder.php` to force fetching the suggestion results from the production index
  Comment out this part (starting from row 37):
  ```
  // try {
  //   $environment = $this->environmentResolver
  //     ->getEnvironment(Project::ETUSIVU, $this->environmentResolver->getActiveEnvironmentName());
  // }
  // catch (\InvalidArgumentException) {
  //   // Use prod in case matching environment does not exist.
  //   $environment = $this->environmentResolver
  //     ->getEnvironment(Project::ETUSIVU, EnvironmentEnum::Prod->value);
  // }
  ```
  Then add this below the commented part:
  ```
  $environment = $this->environmentResolver
      ->getEnvironment(Project::ETUSIVU, EnvironmentEnum::Prod->value);
  ```
  This will fetch the recommendation content from the production index and should confirm our image url handling behaves ok with image url values there.
* Run `make drush-updb drush-cr`
  
## How to test

- Open one of the news items and check the recommendations block; images should appear.
- If the block is empty, edit the news item and save without changes. Then run `drush queue:run helfi_recommendations_queue` and `drush cr` --> suggestions should now appear.