### PR TITLE
UHF-9754: Restore field_api_url for now

### DIFF
--- a/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_api_url.yml
+++ b/modules/helfi_react_search/config/install/field.field.paragraph.event_list.field_api_url.yml
@@ -1,0 +1,23 @@
+uuid: dbc3e84c-70c2-4783-ad25-fb61d2226979
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_api_url
+    - paragraphs.paragraphs_type.event_list
+  module:
+    - link
+id: paragraph.event_list.field_api_url
+field_name: field_api_url
+entity_type: paragraph
+bundle: event_list
+label: 'Api URL'
+description: 'Add URL from tapahtumat.hel.fi to form a list of events. Example URL: https://tapahtumat.hel.fi/fi/events?categories=museum. If you want to use the location filter, the URL should contain the IDs of all relevant locations. For example: &places=tprek:123,tprek:456'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/modules/helfi_react_search/config/install/field.storage.paragraph.field_api_url.yml
+++ b/modules/helfi_react_search/config/install/field.storage.paragraph.field_api_url.yml
@@ -1,0 +1,19 @@
+uuid: e3e806c9-2f10-4424-b3e2-bab97148acf6
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_api_url
+field_name: field_api_url
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/helfi_react_search/helfi_react_search.install
+++ b/modules/helfi_react_search/helfi_react_search.install
@@ -270,28 +270,9 @@ function helfi_react_search_update_9016() : void {
 
     assert($paragraph instanceof EventList);
 
+    // @todo delete field_api_url when this functionality is validated.
     if ($updater->migrateApiUrl($paragraph)) {
       $paragraph->save();
-    }
-  }
-
-  $change = [
-    'paragraph' => [
-      'field_api_url' => [
-        'event_list',
-      ],
-    ],
-  ];
-
-  foreach ($change as $entityType => $fieldNames) {
-    foreach ($fieldNames as $fieldName => $bundles) {
-      // Delete field definition.
-      foreach ($bundles as $bundle) {
-        FieldConfig::loadByName($entityType, $bundle, $fieldName)?->delete();
-      }
-
-      // Delete storage config.
-      FieldStorageConfig::loadByName($entityType, $fieldName)?->delete();
     }
   }
 }

--- a/modules/helfi_react_search/tests/src/Kernel/EventListUpdateHelperTest.php
+++ b/modules/helfi_react_search/tests/src/Kernel/EventListUpdateHelperTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_react_search\Kernel;
 
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\helfi_react_search\DTO\LinkedEventsItem;
 use Drupal\helfi_react_search\Entity\EventList;
 use Drupal\helfi_react_search\Enum\EventCategory;
@@ -50,20 +48,6 @@ class EventListUpdateHelperTest extends KernelTestBase {
 
     $this->installEntitySchema('paragraph');
     $this->installConfig('helfi_react_search');
-
-    // Create legacy field.
-    FieldStorageConfig::create([
-      'field_name' => 'field_api_url',
-      'entity_type' => 'paragraph',
-      'type' => 'link',
-      'cardinality' => 1,
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'field_api_url',
-      'label' => 'A test field',
-      'entity_type' => 'paragraph',
-      'bundle' => 'event_list',
-    ])->save();
   }
 
   /**


### PR DESCRIPTION
# [UHF-9754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754)
<!-- What problem does this solve? -->

I chickened out on the decision to delete field_api_url because if something goes wrong with the update hooks, it makes it much harder to reconstruct the previous settings.

The field is no longer used and should be deleted once the new functionality is validated. Everything in the field_api_url should be migrated to the new fields added in https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/978.

## How to install

- Find an instance where your database dump is at least two weeks old. Checkout to latest release tag: `git checkout 2025-06-04.1`.
- Run: `make fresh`.
- Checkout to dev: `git checkout dev`
- Update helfi_platform_config: `composer require drupal/helfi_platform_config:dev-UHF-9754 -W; composer install`

## How to test:

- Run `drush updb`
- Run `drush helfi:platform-config:update`
- Field api url should not be visible on the paragraph page
- Field api url should be present in the database: `drush sqlq "select * from paragraph__field_api_url;"`.
- Code should follow our standards


[UHF-9754]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ