### PR TITLE
UHF-11958

### DIFF
--- a/assets/js/telia_ace.js
+++ b/assets/js/telia_ace.js
@@ -86,9 +86,7 @@ class TeliaAceWidget {
         this.cookieSet();
       }
       !this.state.chatInitialized && this.loadChatScript();
-
-      this.openChat(true);
-      this.addCloseEventlistener();
+      this.openChat();
     }, { once: true });
   }
 
@@ -123,7 +121,7 @@ class TeliaAceWidget {
   /**
    * Load the chat script.
    */
-  loadChatScript = () => {
+  loadChatScript = async () => {
     const chatScript = document.createElement('script');
     chatScript.src = this.static.scriptUrl;
     chatScript.type = 'text/javascript';
@@ -143,21 +141,24 @@ class TeliaAceWidget {
   render = () => {
     const { chatOpened, chatLoading } = this.state;
     const label = chatLoading ? Drupal.t('Loading chat...', {}, {context: 'Telia ACE chat'}) : this.static.chatTitle;
-    const element = document.getElementById(this.static.selector);
-    if (!element) {
-      return;
-    }
-    const innerHTML = `
+
+    const i = setInterval(()=>{
+      const element = document.getElementById(this.static.selector);
+      if (element) {
+        const innerHTML = `
         <span class="hel-icon hel-icon--speechbubble-text"></span>
         <span>${label}</span>
         <span class="hel-icon hel-icon--angle-up"></span>
       `;
 
-    if (element.innerHTML !== innerHTML) {
-      element.innerHTML = innerHTML;
-    }
-    element.classList.toggle('loading', chatLoading);
-    element.classList.toggle('hidden', chatOpened);
+        if (element.innerHTML !== innerHTML) {
+          element.innerHTML = innerHTML;
+        }
+        element.classList.toggle('loading', chatLoading);
+        element.classList.toggle('hidden', chatOpened);
+        clearInterval(i)
+      }
+    }, 200);
   }
 
   cookieCheck = () => {
@@ -178,7 +179,6 @@ class TeliaAceWidget {
       chatLoaded: true,
     };
     this.openChat();
-    this.render();
   }
 
   /**
@@ -189,12 +189,16 @@ class TeliaAceWidget {
    */
   openChat = (openWidget) => {
     const teliaAceWidgetInitialized = setInterval(() => {
-      if(typeof window.humany !== 'undefined' && typeof window.humany.widgets !== 'undefined' && window.humany.widgets.find(this.static.chatId)){
-        if (openWidget) {
+      if (
+        typeof window.humany !== 'undefined' &&
+        typeof window.humany.widgets !== 'undefined' &&
+        window.humany.widgets.find(this.static.chatId)
+      ){
+        // if (openWidget) {
           const myWidget = window.humany.widgets.find(this.static.chatId);
           myWidget.activate();
           myWidget.invoke('show');
-        }
+        // }
         clearInterval(teliaAceWidgetInitialized);
         this.state = {
           ...this.state,
@@ -204,7 +208,7 @@ class TeliaAceWidget {
         };
         this.render();
       }
-    }, 50);
+    }, 5000);
   }
 
 }

--- a/assets/js/telia_ace.js
+++ b/assets/js/telia_ace.js
@@ -46,7 +46,7 @@ class TeliaAceWidget {
 
     this.initialize()
 
-    // this.render()
+    this.render();
   }
 
   /**

--- a/assets/js/telia_ace.js
+++ b/assets/js/telia_ace.js
@@ -61,7 +61,7 @@ class TeliaAceWidget {
       document.body.append(wrapper);
     }
 
-    // Open/close-button.
+    // The custom chat-button.
     const button = document.createElement('button');
     button.id = this.static.selector;
     button.classList.add('chat-leijuke');
@@ -72,14 +72,14 @@ class TeliaAceWidget {
   }
 
   /**
-   * Check cookies, add event listener
+   * Check cookies, add event listener.
    */
   initialize = () => {
     if (!this.cookieCheck()) {
       this.cookieSet();
     }
 
-    this.addOpenEventlistener()
+    this.addOpenEventListener()
 
     this.render();
   }
@@ -87,39 +87,42 @@ class TeliaAceWidget {
   /**
    * "Open" -chat button functionality.
    *
-   * Self removing eventlistener, no need for debounce-code since
+   * Self removing event listener, no need for debounce-code since
    * it can only be triggered once. It is added back when
    * "close" -button is pressed
+   *
+   * The very first click also adds the chat script to DOM.
    */
-  addOpenEventlistener = () => {
+  addOpenEventListener = () => {
     this.customChatButton.addEventListener('click', () => {
-      // First click
-      // The chat script cannot be loaded earlier.
+      // Only on first click, the chat script cannot be loaded earlier.
       if (!this.state.chatInitialized) {
         this.state.chatInitialized = true;
-        this.loadChatScript();
+        this.addChatScript();
         this.state.chatLoading = true;
 
         this.render();
         return;
       }
 
+      // second "open" -click only needs to open the chat.
       this.state.chatOpened = true;
       this.openChat(true);
-
       this.render();
     }, {once: true});
   }
 
   /**
    * "Close" -chat button functionality.
+   *
+   * Uses the actual ACE-close button.
    */
   addCloseEventListener = () => {
     this.closeButton.addEventListener('click', () => {
       this.state.chatOpened = false;
-      this.addOpenEventlistener();
+      // readd the self-removing event listener.
+      this.addOpenEventListener();
       this.render();
-
     });
   }
 
@@ -150,9 +153,9 @@ class TeliaAceWidget {
   }
 
   /**
-   * Load the chat script.
+   * Load the chat script by adding it to DOM.
    */
-  loadChatScript = () => {
+  addChatScript = () => {
     const chatScript = document.createElement('script');
     chatScript.src = this.static.scriptUrl;
     chatScript.type = 'text/javascript';
@@ -194,10 +197,16 @@ class TeliaAceWidget {
     element.classList.toggle('hidden', chatOpened);
   }
 
+  /**
+   * Check if cookies has been accepted.
+   */
   cookieCheck = () => {
     return Drupal.cookieConsent.getConsentStatus(['chat']);
   }
 
+  /**
+   * Set the chat acceptance if chat-button is clicked.
+   */
   cookieSet = () => {
     if (Drupal.cookieConsent.getConsentStatus(['chat'])) return;
     Drupal.cookieConsent.setAcceptedCategories(['chat']);
@@ -205,6 +214,8 @@ class TeliaAceWidget {
 
   /**
    * Onload-callback.
+   *
+   * This is triggered after the third party library has been loaded.
    */
   onload = () => {
     // Interval must be set because onload triggers too soon.
@@ -234,6 +245,11 @@ class TeliaAceWidget {
 
 }
 
+/**
+ * Chat settings class.
+ *
+ * Check that all required settings exist.
+ */
 class ChatSettings {
   constructor(settings) {
     const requiredSettings = [


### PR DESCRIPTION
# [UHF-11958](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11958)

## What was done
Prevent chat from dying when opening it for the first time (or cache disabled)

The onload-function was triggered too early which caused the issue.
The on load function now has a mechanism which waits until the chat is actually loaded before 
trying to do anything.


## How to install
STRATEGIA is a good place to test.
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11958`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
- Log in as admin
- Disable the original chat and anable the disabled ACE chat implementation

- Open incognito window, [go here](https://helfi-strategia.docker.so/fi/paatoksenteko-ja-hallinto/ota-yhteytta/helsinki-info)
- Disable browser caching, disabled cache caused the issues consistently
- Click the chat button
- Wait for it to open
- Close it
- Open it again
