### PR TITLE
UHF-X D10.5 and CKEditor plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,8 +73,8 @@
         "dg/bypass-finals": "^1.0"
     },
     "conflict": {
-        "drupal/core": "<10.4",
-        "drupal/core-composer-scaffold": "<10.4",
+        "drupal/core": "<10.4 || >=10.5",
+        "drupal/core-composer-scaffold": "<10.4 || >=10.5",
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/default_content": ">2.0.0-alpha2",


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Lock Drupal core to 10.4. CKEditor plugins will break in D10.5.


