### PR TITLE
UHF-12029 Lock Drupal core to 10.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,8 +73,8 @@
         "dg/bypass-finals": "^1.0"
     },
     "conflict": {
-        "drupal/core": "<10.4",
-        "drupal/core-composer-scaffold": "<10.4",
+        "drupal/core": "<10.4 || >=10.5",
+        "drupal/core-composer-scaffold": "<10.4 || >=10.5",
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/default_content": ">2.0.0-alpha2",


### PR DESCRIPTION
# [UHF-12029](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12029)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Lock Drupal core to 10.4. CKEditor plugins will break in D10.5.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12029_lock_core -W`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Drupal 10.4 version is installed
* [ ] Check that code follows our standards


[UHF-12029]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ