### PR TITLE
UHF-11812: Fixed logic for aria label

### DIFF
--- a/modules/helfi_tpr_config/src/Entity/UnitContactCard.php
+++ b/modules/helfi_tpr_config/src/Entity/UnitContactCard.php
@@ -21,35 +21,29 @@ class UnitContactCard extends Paragraph implements ParagraphInterface {
    */
   public function getAriaLabel(): ?TranslatableMarkup {
     $langcode = $this->language()->getId();
-    if (!$this->hasField('field_unit_contact_unit')) {
-      return NULL;
-    }
 
     /** @var \Drupal\Core\Entity\ContentEntityInterface $unit */
-    $unit = $this->get('field_unit_contact_unit')->entity;
-    if (!$unit->hasTranslation($langcode)) {
+    $unit = $this->get('field_unit_contact_unit')?->entity;
+
+    if (!$unit instanceof Unit) {
       return NULL;
     }
 
-    $unit = $unit->getTranslation($langcode);
-    if ($unit instanceof Unit && $unit->hasField('name_override') && $unit->hasField('name')) {
-      // If the page is in Swedish or English, or if the unit
-      // does not have a name_override,.
-      if (($langcode === 'sv' || $langcode === 'en') || !$unit->get('name_override')->value && $unit->hasTranslation($langcode)) {
-        $unit_name = $unit->get('name')->value;
-      }
-      // If the unit has a name_override and is in Finnish.
-      else {
-        $unit_name = $unit->get('name_override')->value;
-      }
-      if ($unit_name) {
-        return $this->t('See more details of @unit', [
-          '@unit' => $unit_name,
-        ], [
-          'context' => 'Unit contact card aria label',
-        ]);
-      }
+    $unit = $unit->hasTranslation($langcode) ? $unit->getTranslation($langcode) : $unit;
+
+    $unit_name = $unit->get('name')?->value;
+    if ($langcode == 'fi') {
+      $unit_name = $unit->get('name_override')?->value ? $unit->get('name_override')->value : $unit_name;
     }
+
+    if ($unit_name) {
+      return $this->t('See more details of @unit', [
+        '@unit' => $unit_name,
+      ], [
+        'context' => 'Unit contact card aria label',
+      ]);
+    }
+
     return NULL;
   }
 


### PR DESCRIPTION
# [UHF-11812](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11812)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed logic to consider case where name_override is empty

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11812-logix-fix `
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-sote.docker.so/fi/sosiaali-ja-terveyspalvelut/terveydenhoito/terveys-ja-hyvinvointikeskukset/myllypuro and make sure the hammashoitola cards also have aria label now
* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* 


[UHF-11812]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ