### PR TITLE
UHF-12028 Remove the old field_limit -field

### DIFF
--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\paragraphs\Entity\Paragraph;
 
@@ -91,4 +92,23 @@ function helfi_paragraphs_news_list_update_9007() : void {
  */
 function helfi_paragraphs_news_list_update_9010() : void {
   // This is now automated.
+}
+
+/**
+ * #UHF-12028 Remove the old "field_limit" -field.
+ */
+function helfi_paragraphs_news_list_update_9011() : void {
+  $entity_type = 'paragraph';
+  $field_name = 'field_limit';
+  $bundle = 'news_list';
+
+  $field_storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+
+  if (!$field_storage || !$field) {
+    return;
+  }
+
+  $field_storage->delete();
+  field_purge_batch(50);
 }

--- a/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
+++ b/modules/helfi_paragraphs_news_list/helfi_paragraphs_news_list.install
@@ -95,7 +95,7 @@ function helfi_paragraphs_news_list_update_9010() : void {
 }
 
 /**
- * #UHF-12028 Remove the old "field_limit" -field.
+ * UHF-12028 Remove the old "field_limit" -field.
  */
 function helfi_paragraphs_news_list_update_9011() : void {
   $entity_type = 'paragraph';


### PR DESCRIPTION
# [UHF-12028](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12028)

The changes made to field_limit requires 2 production deployments. The first one created new field (field_news_limit) and copied the values from the old field (field_limit)

This one removes the old field_limit field.

## What was done
- Remove the old field configuration + data + database tables.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12028`
* Run `make drush-updb drush-cr`


## How to test

* Open sql-client `drush sqlc`
    * Run `show tables;`
* The `paragraph__field_limit`should not exist any more
* The new `paragraph__field_news_limit` should be in the tables-list
* Running `drush cex` should delete the `news_list.field_limit` configuration
* Log in as admin
* Go edit any landing page with news list on it (or edit existing and add news list to it)
  * Should work as expected


[UHF-12028]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ