### PR TITLE
UHF-11867: Translatable menu link uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/default_content": ">2.0.0-alpha2",
-        "drupal/translatable_menu_link_uri": ">2.1.2",
+        "drupal/translatable_menu_link_uri": ">2.1.1",
         "drush/drush": "<12"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "drupal/ctools": "<3.11 || ^4.0.1",
         "drupal/helfi_media_map": "*",
         "drupal/default_content": ">2.0.0-alpha2",
+        "drupal/translatable_menu_link_uri": ">2.1.2",
         "drush/drush": "<12"
     },
     "extra": {


### PR DESCRIPTION
# [UHF-11867](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11867)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Don't update the `translatable_menu_link_uri` to 2.1.2 until the overridden options issue has been resolved.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11867 -W`
  * `composer i`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that installed version of translatable_menu_link_uri module is 2.1.1
* [x] Check that code follows our standards


[UHF-11867]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ