### PR TITLE
UHF-X: Removed twitter special case from social media service parse trait

### DIFF
--- a/modules/helfi_paragraphs_contact_card_listing/src/SocialMediaServiceParserTrait.php
+++ b/modules/helfi_paragraphs_contact_card_listing/src/SocialMediaServiceParserTrait.php
@@ -69,11 +69,6 @@ trait SocialMediaServiceParserTrait {
         'youtube' => 'YouTube',
         default => $service['social_media_name'],
       };
-
-      // Handle twitter separately.
-      if ($domain === 'x') {
-        $service['social_media_icon'] = 'twitter';
-      }
     }
     else {
       $service['social_media_icon'] = 'link';

--- a/modules/helfi_paragraphs_contact_card_listing/tests/src/Unit/SocialMediaServiceParserTraitTest.php
+++ b/modules/helfi_paragraphs_contact_card_listing/tests/src/Unit/SocialMediaServiceParserTraitTest.php
@@ -51,7 +51,7 @@ class SocialMediaServiceParserTraitTest extends UnitTestCase {
     return [
       ['https://www.facebook.com/user', 'Facebook', 'facebook', 'https://www.facebook.com/user'],
       ['https://twitter.com/user', 'X', 'twitter', 'https://twitter.com/user'],
-      ['https://x.com/user', 'X', 'twitter', 'https://x.com/user'],
+      ['https://x.com/user', 'X', 'x', 'https://x.com/user'],
       ['https://instagram.com/user', 'Instagram', 'instagram', 'https://instagram.com/user'],
       ['https://linkedin.com/in/user', 'LinkedIn', 'linkedin', 'https://linkedin.com/in/user'],
       ['https://www.youtube.com/channel/xyz', 'YouTube', 'youtube', 'https://www.youtube.com/channel/xyz'],


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Contact cards social media field had a special case for X that set the twitter logo to the card
* The special case was removed and now the correct X logo appears to the contact card

## How to install
* Make sure your **ETUSIVU** instance is up and running on latest dev branch. Remove your dump from local since there's already good test content in etusivu test or you can create some if you don't want to remove the dump
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-X-change-twitter-icon-to-x`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-etusivu.docker.so/fi/hlotesti and make sure the X social media link has the correct icon, you can compare it to the same page on test https://www.test.hel.ninja/fi/hlotesti
* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->
