### PR TITLE
UHF-11915: Restricting recommendation visibility on page nodes

### DIFF
--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -133,7 +133,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
     // cross-instance recommendations in production before allowing the
     // use for all editors. Remove these once we have validated the
     // cross-instance recommendations work as intended.
-    if ($entity->bundle() !== 'news_item' && $entity->bundle() !== 'news_article' && $entity->bundle() !== 'page') {
+    if ($entity->bundle() !== 'news_item' && $entity->bundle() !== 'news_article') {
       if (_helfi_recommendations_can_see_review_mode()) {
         return AccessResult::allowed();
       }


### PR DESCRIPTION
# [UHF-11915](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11915)

Recommendations we're visible to all visitors in Page nodes. They should be restricted to admin users only for now, and will be made public later in https://helsinkisolutionoffice.atlassian.net/browse/UHF-11798 .

## What was done

Recommendation visibility was restricted to admin users only in Page nodes.

* This thing was fixed

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11915_page-node-restrictions`
* Run `make drush-updb drush-cr`

## How to test

* [ ] Log in and go to a basic page node; you should see the recommendations block
* [ ] Open the same page in an incognito window; recommendations block should not be visible there
