### PR TITLE
UHF-9855: Configuration translations

### DIFF
--- a/modules/helfi_base_content/config/optional/language/fi/views.view.scheduler_scheduled_content.yml
+++ b/modules/helfi_base_content/config/optional/language/fi/views.view.scheduler_scheduled_content.yml
@@ -54,6 +54,13 @@ display:
       empty:
         area_text_custom:
           content: 'Ei vielä ajastettua sisältöä.'
+      exposed_form:
+        options:
+          submit_button: Suodata
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
     display_title: Oletus
   overview:
     display_options:

--- a/modules/helfi_tpr_config/config/install/views.view.locked_services.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.locked_services.yml
@@ -400,13 +400,13 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Filter
+          submit_button: Apply
           reset_button: false
           reset_button_label: Reset
-          exposed_sorts_label: Sort
+          exposed_sorts_label: 'Sort by'
           expose_sort_order: true
-          sort_asc_label: Ascending
-          sort_desc_label: Descending
+          sort_asc_label: Asc
+          sort_desc_label: Desc
       access:
         type: perm
         options:

--- a/modules/helfi_tpr_config/config/install/views.view.unit_search.yml
+++ b/modules/helfi_tpr_config/config/install/views.view.unit_search.yml
@@ -308,10 +308,10 @@ display:
           submit_button: Search
           reset_button: false
           reset_button_label: Reset
-          exposed_sorts_label: Sort
+          exposed_sorts_label: 'Sort by'
           expose_sort_order: true
-          sort_asc_label: Ascending
-          sort_desc_label: Descending
+          sort_asc_label: Asc
+          sort_desc_label: Desc
       access:
         type: perm
         options:

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
@@ -32,7 +32,7 @@ display:
       exposed_form:
         options:
           submit_button: Suodata
-          exposed_sorts_label: Järjestä
+          exposed_sorts_label: Lajittele
           sort_asc_label: Nousevasti
           sort_desc_label: Laskevasti
           reset_button_label: Palauta

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.locked_services.yml
@@ -33,8 +33,8 @@ display:
         options:
           submit_button: Suodata
           exposed_sorts_label: Järjestä
-          sort_asc_label: Nouseva
-          sort_desc_label: Laskeva
+          sort_asc_label: Nousevasti
+          sort_desc_label: Laskevasti
           reset_button_label: Palauta
       empty:
         area_text_custom:

--- a/modules/helfi_tpr_config/config/optional/language/fi/views.view.unit_search.yml
+++ b/modules/helfi_tpr_config/config/optional/language/fi/views.view.unit_search.yml
@@ -23,7 +23,7 @@ display:
         options:
           submit_button: Etsi
           reset_button_label: Palauta
-          exposed_sorts_label: Järjestä
+          exposed_sorts_label: Lajittele
           sort_asc_label: Nouseva
           sort_desc_label: Laskeva
       empty:


### PR DESCRIPTION
# [UHF-9855](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9855)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Updated translations for views exposed form options buttons to prevent a reset of translations in automatic update pull requests.



[UHF-9855]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ