### PR TITLE
Set content verbose config for content lock module

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -413,3 +413,19 @@ function helfi_platform_config_update_9325(): void {
     }
   }
 }
+
+/**
+ * UHF-11420: Update content_lock config.
+ */
+function helfi_platform_config_update_9326(): void {
+  $configFactory = \Drupal::configFactory();
+
+  // We had issues with content_lock module
+  // update & missing config value on some instances.
+  if (\Drupal::moduleHandler()->moduleExists('content_lock')) {
+    $configFactory
+      ->getEditable('content_lock.settings')
+      ->set('verbose', TRUE)
+      ->save();
+  }
+}


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Fix: `Drupal\content_lock\ContentLock\ContentLock::verbose(): Return value must be of type bool, null returned" at /var/www/html/public/modules/contrib/content_lock/src/ContentLock/ContentLock.php line 260`

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-X-content_lock_config`
* Run `make drush-updb drush-cr`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* 
