### PR TITLE
UHF-12050: Updating recommended topics field in tpr service

### DIFF
--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -177,12 +177,16 @@ function helfi_recommendations_get_block_configurations(string $theme) : array {
  * Implements hook_update_dependencies().
  */
 function helfi_recommendations_update_dependencies() : array {
-  // Allow tpr config to remove field_recommended_topics before installing
-  // it here again.
-  $dependencies['helfi_recommendations']['10004'] = [
-    'helfi_tpr_config' => '9079',
-  ];
-  return $dependencies;
+  if (\Drupal::moduleHandler()->moduleExists('helfi_tpr_config')) {
+    // Allow tpr config to remove field_recommended_topics before installing
+    // it here again.
+    $dependencies['helfi_recommendations']['10004'] = [
+      'helfi_tpr_config' => '9079',
+    ];
+    return $dependencies;
+  }
+
+  return [];
 }
 
 /**
@@ -226,9 +230,11 @@ function helfi_recommendations_update_10003() : void {
  * Install field storage definition for field_recommended_topics on tpr_service.
  */
 function helfi_recommendations_update_10004() : void {
-  $field_storage_definitions = helfi_recommendations_bundle_fields('tpr_service', 'tpr_service');
+  if (\Drupal::moduleHandler()->moduleExists('helfi_tpr_config')) {
+    $field_storage_definitions = helfi_recommendations_bundle_fields('tpr_service', 'tpr_service');
 
-  foreach ($field_storage_definitions as $name => $field_storage_definition) {
-    \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition($name, 'tpr_service', 'helfi_recommendations', $field_storage_definition);
+    foreach ($field_storage_definitions as $name => $field_storage_definition) {
+      \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition($name, 'tpr_service', 'helfi_recommendations', $field_storage_definition);
+    }
   }
 }

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -174,6 +174,18 @@ function helfi_recommendations_get_block_configurations(string $theme) : array {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function helfi_recommendations_update_dependencies() : array {
+  // Allow tpr config to remove field_recommended_topics before installing
+  // it here again.
+  $dependencies['helfi_recommendations']['10004'] = [
+    'helfi_tpr_config' => '9079',
+  ];
+  return $dependencies;
+}
+
+/**
  * Unset '_info_file_ctime' for helfi_recommendations module.
  */
 function helfi_recommendations_update_10001() : void {
@@ -208,4 +220,15 @@ function helfi_recommendations_update_10003() : void {
   ];
   $recommendations_block->setData($raw_data);
   $recommendations_block->save();
+}
+
+/**
+ * Install field storage definition for field_recommended_topics on tpr_service.
+ */
+function helfi_recommendations_update_10004() : void {
+  $field_storage_definitions = helfi_recommendations_bundle_fields('tpr_service', 'tpr_service');
+
+  foreach ($field_storage_definitions as $name => $field_storage_definition) {
+    \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition($name, 'tpr_service', 'helfi_recommendations', $field_storage_definition);
+  }
 }

--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -124,6 +124,12 @@ function helfi_recommendations_entity_bundle_field_info_alter(&$fields, EntityTy
       $fields[$name] = $field;
     }
   }
+
+  if ($entityType->id() === 'tpr_service' && $bundle === 'tpr_service') {
+    foreach (helfi_recommendations_bundle_fields($entityType->id(), $bundle) as $name => $field) {
+      $fields[$name] = $field;
+    }
+  }
 }
 
 /**
@@ -136,6 +142,10 @@ function helfi_recommendations_entity_field_storage_info(EntityTypeInterface $en
       helfi_recommendations_bundle_fields($entity_type->id(), 'news_article'),
       helfi_recommendations_bundle_fields($entity_type->id(), 'page')
     );
+  }
+
+  if ($entity_type->id() === 'tpr_service') {
+    return helfi_recommendations_bundle_fields($entity_type->id(), 'tpr_service');
   }
 
   return [];

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -11,6 +11,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\linkit\Entity\Profile;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 
 /**
  * Install metatag configurations manually.
@@ -196,26 +197,24 @@ function helfi_tpr_config_update_9077(): void {
 }
 
 /**
- * UHF-8717: Add a field to tpr_service and re-import configs.
+ * UHF-12050: Remove field_recommended_topics from tpr_service.
  */
-function helfi_tpr_config_update_9078() : void {
-  $fields['field_recommended_topics'] = BaseFieldDefinition::create('suggested_topics_reference')
-    ->setName('field_recommended_topics')
-    ->setLabel(new TranslatableMarkup('Automatically selected recommendation topics', [], ['context' => 'Recommendations']))
-    ->setTargetEntityTypeId('tpr_service')
-    ->setTargetBundle('tpr_service')
-    ->setReadonly(TRUE)
-    ->setTranslatable(FALSE)
-    ->setDisplayOptions('form', [
-      'type' => 'suggested_topics_reference',
-      'weight' => 1000,
-      'module' => 'helfi_recommendations',
-    ])
-    ->setDisplayConfigurable('form', FALSE)
-    ->setDisplayConfigurable('view', FALSE);
+function helfi_tpr_config_update_9079(): void {
+  $fieldStorageDefinition = \Drupal::entityDefinitionUpdateManager()->getFieldStorageDefinition('field_recommended_topics', 'tpr_service');
 
-  foreach ($fields as $name => $field) {
-    \Drupal::entityDefinitionUpdateManager()
-      ->installFieldStorageDefinition($name, 'tpr_service', 'helfi_tpr_config', $field);
+  if ($fieldStorageDefinition instanceof FieldStorageDefinitionInterface) {
+    // Remove data from the storage.
+    $database = \Drupal::database();
+    $database->update('tpr_service_field_data')
+      ->fields([
+        'field_recommended_topics__target_id' => NULL,
+        'field_recommended_topics__show_block' => NULL,
+        'field_recommended_topics__instances' => NULL,
+        'field_recommended_topics__content_types' => NULL,
+        ])
+      ->execute();
+
+    // Uninstall the field storage definition.
+    \Drupal::entityDefinitionUpdateManager()->uninstallFieldStorageDefinition($fieldStorageDefinition);
   }
 }

--- a/modules/helfi_tpr_config/helfi_tpr_config.install
+++ b/modules/helfi_tpr_config/helfi_tpr_config.install
@@ -211,7 +211,7 @@ function helfi_tpr_config_update_9079(): void {
         'field_recommended_topics__show_block' => NULL,
         'field_recommended_topics__instances' => NULL,
         'field_recommended_topics__content_types' => NULL,
-        ])
+      ])
       ->execute();
 
     // Uninstall the field storage definition.

--- a/modules/helfi_tpr_config/src/Entity/Service.php
+++ b/modules/helfi_tpr_config/src/Entity/Service.php
@@ -20,21 +20,6 @@ class Service extends BaseService {
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
     $fields = parent::baseFieldDefinitions($entity_type);
 
-    $fields['field_recommended_topics'] = BaseFieldDefinition::create('suggested_topics_reference')
-      ->setName('field_recommended_topics')
-      ->setLabel(new TranslatableMarkup('Automatically selected recommendation topics', [], ['context' => 'Recommendations']))
-      ->setTargetEntityTypeId('tpr_service')
-      ->setTargetBundle('tpr_service')
-      ->setReadonly(TRUE)
-      ->setTranslatable(FALSE)
-      ->setDisplayOptions('form', [
-        'type' => 'suggested_topics_reference',
-        'weight' => 1000,
-        'module' => 'helfi_recommendations',
-      ])
-      ->setDisplayConfigurable('form', FALSE)
-      ->setDisplayConfigurable('view', FALSE);
-
     $fields['hide_service_points'] = BaseFieldDefinition::create('boolean')
       ->setLabel(new TranslatableMarkup('Hide service units listing'))
       ->setDescription(new TranslatableMarkup('Select this if you link from the page to a filter search or another listing.'))


### PR DESCRIPTION
# [UHF-12050](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12050)

In #1031 the field was added as a base field for `tpr_service`-entities, which is causing issues in sites where `helfi_recommendations` isn't enabled.

## What was done

This PR removes the base field and reinstalls the field as a bundle field only when `helfi_recommendations`-module is enabled.

## How to install
* Launch the frontpage instance (it's where the recommendation index lives)
* Make sure your other instance is up and running on latest dev branch. Use one of the instances with tpr-integration, like asuminen.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12050_change_field`
* Run `make drush-updb drush-cr`
* Generate recommendation keywords for testing:
  * Run `drush helfi:recommendations:fix-references` to prime the field for keyword generation
  * Run `drush queue:delete helfi_recommendations_queue` to clear queue items generated by the above. It's much quicker to generate the keywords using a separate command, than processing the queue items.
  * Run `drush helfi:recommendations:generate-keywords tpr_service tpr_service --overwrite` to generate and index recommendation keywords for all TPR services.

## How to test

* [ ] Log in and view some TPR service pages; recommendations block should appear
* [ ] View the same TPR service pages in a incognito window; recommendations block should not appear

[UHF-12050]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ