### PR TITLE
UHF-11997: When deleting user, node table is not updated correctly.

### DIFF
--- a/modules/helfi_users/helfi_users.module
+++ b/modules/helfi_users/helfi_users.module
@@ -100,6 +100,7 @@ function helfi_users_user_cancel($edit, UserInterface $account, $method): void {
 function _helfi_users_reassign_nodes(AccountInterface $source, AccountInterface $target): void {
   $database = \Drupal::database();
   $tables = [
+    'node' => 'uuid',
     'node_field_data' => 'uid',
     'node_field_revision' => 'uid',
     'node_revision' => 'revision_uid',

--- a/modules/helfi_users/helfi_users.module
+++ b/modules/helfi_users/helfi_users.module
@@ -100,7 +100,6 @@ function helfi_users_user_cancel($edit, UserInterface $account, $method): void {
 function _helfi_users_reassign_nodes(AccountInterface $source, AccountInterface $target): void {
   $database = \Drupal::database();
   $tables = [
-    'node' => 'uuid',
     'node_field_data' => 'uid',
     'node_field_revision' => 'uid',
     'node_revision' => 'revision_uid',
@@ -117,8 +116,6 @@ function _helfi_users_reassign_nodes(AccountInterface $source, AccountInterface 
       continue;
     }
 
-    // Notice: this does not invalidate any caches. This should be fine for
-    // HELfi, where user information is not rendered on public pages.
     $database->update($table)
       ->fields([$uid_field => $target->id()])
       ->condition($uid_field, $source->id())
@@ -130,5 +127,16 @@ function _helfi_users_reassign_nodes(AccountInterface $source, AccountInterface 
       '@target' => $target->id(),
       '@source' => $source->id(),
     ]));
+  }
+
+  // Invalidate cache for these nodes.
+  $affected_node_ids = $database->select('node_field_data')
+    ->fields('node_field_data', ['nid'])
+    ->condition('uid', $target->id())
+    ->execute()
+    ->fetchCol();
+
+  if (!empty($affected_node_ids)) {
+    \Drupal::entityTypeManager()->getStorage('node')->resetCache($affected_node_ids);
   }
 }


### PR DESCRIPTION
# [UHF-11997](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11997)
<!-- What problem does this solve? -->

When deleting user, node_field_data, node_field_revision and node_revision are updated with uid = 1.

Cache is not invalidated on user deletion, making the edit page break for nodes owned by deleted user, until the cache is cleared.

## What was done

Clear cache when user is deleted.

* This thing was fixed

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11997`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`

## How to test

* Checkout some instance (for example  [strategia](https://github.com/City-of-Helsinki/drupal-helfi-strategia).
* Find a node owned by some user (for example /fi/paatoksenteko-ja-hallinto/node/498/edit)
* Delete user owning the node.
* Edit page should still load. Without this change, the page will WSOD until uuid is manually updated in node table

* [ ] Check that this feature works
* [ ] Check that code follows our standards



[UHF-11997]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ