### PR TITLE
prevent error when value is int

### DIFF
--- a/modules/helfi_paragraphs_phasing/src/Entity/Phasing.php
+++ b/modules/helfi_paragraphs_phasing/src/Entity/Phasing.php
@@ -32,7 +32,7 @@ class Phasing extends Paragraph implements ParagraphInterface {
    *   Value of boolean.
    */
   public function getShowNumbers(): string {
-    return $this->get('field_show_phase_numbers')
+    return (string) $this->get('field_show_phase_numbers')
       ->value;
   }
 


### PR DESCRIPTION
Prevent [sentry error](https://sentry.hel.fi/organizations/city-of-helsinki/issues/76865/?project=97&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=8) when previewin node.

## What was done
cast value to string

## How to reproduce on any environment

- Go and edit [this node](https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/node/323/edit), try previewing
Should whitescreen, getShowNumbers -method returns int (0) instead of string

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-X_int_to_string`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test

- Go and edit [this node](https://helfi-kymp.docker.so/fi/kaupunkiymparisto-ja-liikenne/node/323/edit), try previewing
- Preview should work, edit should work, view should work