### PR TITLE
UHF-12114: Updating CSP: Adding events.icareus.com to enforced frame-…

### DIFF
--- a/config/rewrite/csp.settings.yml
+++ b/config/rewrite/csp.settings.yml
@@ -56,6 +56,68 @@ report-only:
         - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
         - 'https://*.hel.fi'
         - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+    frame-src:
+      base: self
+      sources:
+        - palvelukartta.hel.fi
+        - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
+        - 'https://*.hel.fi'
+        - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://*.siteimprove.com'
+        - 'https://*.userneeds.com'
+        - 'https://agreeable-island-03e85b803.azurestaticapps.net'
+        - 'https://*.hotjar.com'
+        - 'https://coh-chat-app-ibm.eu-de.mybluemix.net'
+        - 'https://coh-chat-app-prod-ibm.eu-de.mybluemix.net'
+        - 'https://suite.icareus.com'
+        - 'https://*.helsinkikanava.fi'
+        - 'https://*.youtube.com'
+        - 'https://*.youtu.be'
+        - 'https://*.facebook.com'
+        - 'https://*.twitter.com'
+        - 'https://*.linkedin.com'
+        - 'https://*.readspeaker.com'
+        - 'https://*.vimeo.com'
+        - 'https://*.google.com'
+        - 'https://*.siteimproveanalytics.com'
+        - 'https://*.snoobi.com'
+        - 'https://*.dreambroker.com'
+        - 'https://youtu.be'
+        - 'https://dreambroker.com'
+        - 'https://pollev.com'
+        - 'https://e.infogram.com'
+        - 'https://tyoterveys-helsinki-pv.mail-eur.net'
+        - 'https://walls.io'
+        - 'https://*.youtube-nocookie.com'
+        - 'https://*.flockler.com'
+        - 'https://*.lightwidget.com'
+        - 'https://hel-thk-botti.kuurahealth.com'
+        - 'https://*.giosg.com'
+        - 'https://*.giosgusercontent.com'
+        - 'https://helfi.fi1.frosmo.com'
+        - 'https://survey.feedbackly.com'
+        - 'https://survey.userneeds.com'
+        - 'https://*.powerbi.com'
+        - 'https://coh-chat-app-test.eu-de.mybluemix.net'
+        - 'https://coh-chat-app-dev.eu-de.mybluemix.net'
+        - 'https://coh-chat-app-prod.eu-de.mybluemix.net'
+        - 'https://hkp.maanmittauslaitos.fi'
+        - 'https://reittiopas.hsl.fi'
+        - 'https://players.icareus.com'
+        - 'https://wds.ace.teliacompany.com'
+        - 'https://events.icareus.com'
+    object-src:
+      base: self
+      sources:
+        - palvelukartta.hel.fi
+        - 'https://*.youtube-nocookie.com'
+        - 'https://*.youtube.com'
+        - 'https://*.youtu.be'
+        - 'https://*.vimeo.com'
+        - 'https://suite.icareus.com'
+        - 'https://players.icareus.com'
+        - 'https://events.icareus.com'
+        - 'https://*.helsinkikanava.fi'
   reporting:
     plugin: raven
 enforce:
@@ -71,6 +133,7 @@ enforce:
         - 'https://*.vimeo.com'
         - 'https://suite.icareus.com'
         - 'https://players.icareus.com'
+        - 'https://events.icareus.com'
         - 'https://*.helsinkikanava.fi'
     frame-src:
       base: self
@@ -121,5 +184,6 @@ enforce:
         - 'https://reittiopas.hsl.fi'
         - 'https://players.icareus.com'
         - 'https://wds.ace.teliacompany.com'
+        - 'https://events.icareus.com'
   reporting:
     plugin: raven


### PR DESCRIPTION
# [UHF-12114](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12114)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Adding `https://events.icareus.com` to enforced `frame-src `and `object-src` for Päätökset video embeds
* Syncing `frame-src` and `object-src` directives from enforced to report-only rules to avoid potentially confusing / misguiding error messages

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12114`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update helfi_platform_config`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Go to any page in your test instance and check response headers
  * [ ] `Content-Security-Policy`-headers should include `https://events.icareus.com` in both `frame-src` and `object-src` directives
  * [ ] `Content-Security-Policy` and `Content-Security-Policy-Report-Only`-headers should have identical `frame-src` and `object-src` directives

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->


[UHF-12114]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ