### PR TITLE
UHF-12130: Updating CSP configuration

### DIFF
--- a/config/rewrite/csp.settings.yml
+++ b/config/rewrite/csp.settings.yml
@@ -15,47 +15,62 @@ report-only:
         - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
         - 'https://*.hel.fi'
         - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://data.reactandshare.com'
+        - 'https://webanalytics.digiaiiris.com'
+        - 'https://*.siteimprove.com'
+        - 'https://connect.facebook.net'
+        - 'https://hel.humany.net'
+        - 'https://wds.ace.teliacompany.com'
+        - 'https://chat.ace.teliacompany.net'
+        - 'https://api.ace.teliacompany.net'
     img-src:
-      base: self
+      base: any
       sources:
         - 'data:'
         - '*.blob.core.windows.net'
         - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
         - 'https://*.hel.fi'
         - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://data.reactandshare.com'
     script-src:
       base: self
       flags:
         - report-sample
         - unsafe-inline
+        - unsafe-eval
+        - wasm-unsafe-eval
+      sources:
+        - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
+        - 'https://*.hel.fi'
+        - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://cdn.reactandshare.com'
+        - 'https://data.reactandshare.com'
+        - 'https://webanalytics.digiaiiris.com'
+        - 'https://connect.facebook.net'
+        - 'https://wds.ace.teliacompany.com'
+        - 'https://e.infogram.com'
     style-src:
       base: self
       flags:
         - report-sample
-    script-src-elem:
-      base: self
-      flags:
-        - report-sample
         - unsafe-inline
       sources:
         - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
         - 'https://*.hel.fi'
         - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
-    style-src-elem:
-      base: self
-      flags:
-        - report-sample
-        - unsafe-inline
-      sources:
-        - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
-        - 'https://*.hel.fi'
-        - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://fonts.googleapis.com'
+        - 'https://hel.humany.net'
+        - 'https://wds.ace.teliacompany.com'
     font-src:
       base: self
       sources:
         - 'https://coh-chat-app-prod.ow6i4n9pdzm.eu-de.codeengine.appdomain.cloud'
         - 'https://*.hel.fi'
         - 'https://coh-chat-app-test.mo1wrhhyog0.eu-de.codeengine.appdomain.cloud'
+        - 'https://fonts.gstatic.com'
+        - 'https://hel.humany.net'
+        - 'https://makasiini.hel.ninja'
+        - 'https://ace-knowledge-cdn.teliacompany.net'
     frame-src:
       base: self
       sources:
@@ -86,6 +101,7 @@ report-only:
         - 'https://dreambroker.com'
         - 'https://pollev.com'
         - 'https://e.infogram.com'
+        - 'https://infogram.com'
         - 'https://tyoterveys-helsinki-pv.mail-eur.net'
         - 'https://walls.io'
         - 'https://*.youtube-nocookie.com'
@@ -118,8 +134,12 @@ report-only:
         - 'https://players.icareus.com'
         - 'https://events.icareus.com'
         - 'https://*.helsinkikanava.fi'
+    media-src:
+      base: self
+      sources:
+        - 'data:'
   reporting:
-    plugin: raven
+    plugin: none
 enforce:
   enable: true
   directives:
@@ -165,6 +185,7 @@ enforce:
         - 'https://dreambroker.com'
         - 'https://pollev.com'
         - 'https://e.infogram.com'
+        - 'https://infogram.com'
         - 'https://tyoterveys-helsinki-pv.mail-eur.net'
         - 'https://walls.io'
         - 'https://*.youtube-nocookie.com'


### PR DESCRIPTION
# [UHF-12130](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12130)
<!-- What problem does this solve? -->

## What was done

* Updated `Content-Security-Policy-Report-Only`-configuration according to Sentry logs
* Disabled policy violation reporting by default for report-only directives, to allow enabling it manually in a controlled way, and disable again if Sentry becomes flooded

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12130`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update helfi_platform_config`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->
* Get Sentry environment variables from Azure DevOps (https://dev.azure.com/City-of-Helsinki/helfi-etusivu/_git/helfi-etusivu-pipelines?path=/components/drupal/vars/drupal-testing.yml&version=GBmaster&line=53&lineEnd=56&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) and add them to `compose.yaml`:
  ```diff
  diff --git a/compose.yaml b/compose.yaml
  index 99f55b2..2e408f2 100644
  --- a/compose.yaml
  +++ b/compose.yaml
  @@ -31,6 +31,11 @@ services:
       DRUPAL_VARNISH_PORT: 6081
       REDIS_HOST: redis
       PROJECT_NAME: "${PROJECT_NAME}"
  +    SENTRY_DSN: xyz
  +    SENTRY_DSN_REACT: xyz
  +    SENTRY_DSN_PUBLIC: xyz
  +    SENTRY_ENVIRONMENT: 'local'
  +    SENTRY_RELEASE: 'dev'
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "${DRUPAL_HOSTNAME}:host-gateway"
  ```
* Run `make stop && make up`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any page and check the response headers; you should see both `Content-Security-Policy` and `Content-Security-Policy-Report-Only` headers.
* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->
