### PR TITLE
UHF-12086: Expose field_media_hel_map in media_library entity form type

### DIFF
--- a/modules/helfi_media_map/config/install/core.entity_form_display.media.hel_map.media_library.yml
+++ b/modules/helfi_media_map/config/install/core.entity_form_display.media.hel_map.media_library.yml
@@ -6,11 +6,21 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.hel_map.field_media_hel_map
     - media.type.hel_map
+  module:
+    - link
 id: media.hel_map.media_library
 targetEntityType: media
 bundle: hel_map
 mode: media_library
 content:
+  field_media_hel_map:
+    type: link_default
+    weight: 1
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0
@@ -21,7 +31,6 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_media_hel_map: true
   langcode: true
   path: true
   status: true

--- a/modules/helfi_media_map/config/install/field.field.media.hel_map.field_media_hel_map.yml
+++ b/modules/helfi_media_map/config/install/field.field.media.hel_map.field_media_hel_map.yml
@@ -18,6 +18,6 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  title: 1
+  title: 0
   link_type: 17
 field_type: link

--- a/modules/helfi_media_map/src/Plugin/Field/FieldFormatter/MediaMapFormatter.php
+++ b/modules/helfi_media_map/src/Plugin/Field/FieldFormatter/MediaMapFormatter.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_media_map\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\Core\Utility\Error;
 use Drupal\helfi_media_map\UrlParserTrait;
@@ -15,15 +17,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'Map' formatter.
- *
- * @FieldFormatter(
- *   id = "hel_media_map",
- *   label = @Translation("Map"),
- *   field_types = {
- *     "link",
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'hel_media_map',
+  label: new TranslatableMarkup('Map'),
+  field_types: [
+    'link',
+  ]
+)]
 final class MediaMapFormatter extends FormatterBase {
 
   use UrlParserTrait;

--- a/modules/helfi_media_map/src/Plugin/Validation/Constraint/ValidMediaMapLinkConstraintValidator.php
+++ b/modules/helfi_media_map/src/Plugin/Validation/Constraint/ValidMediaMapLinkConstraintValidator.php
@@ -17,7 +17,7 @@ final class ValidMediaMapLinkConstraintValidator extends ConstraintValidator {
   /**
    * {@inheritdoc}
    */
-  public function validate($item, Constraint $constraint) {
+  public function validate($item, Constraint $constraint): void {
     assert($constraint instanceof ValidMediaMapLinkConstraint);
     foreach ($item->getValue() as $value) {
       ['uri' => $uri] = $value;


### PR DESCRIPTION
# [UHF-12086](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12086)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

ValidMediaMapLinkConstraintValidator was not run in media library form, because the field was hidden. By exposing the field, the validator is executed on all saves.

## How to install
* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12086`
* Run `make drush-updb drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update helfi_media_map`
<!-- Running all module updates takes approx. 5 minutes. -->
<!-- To run one module update: `drush helfi:platform-config:update module_name"` -->

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->

## Other PRs
<!-- For example a related PR in another repository -->

* 
