### PR TITLE
UHF-11798: Removing temporary access restrictions from content recommendations

### DIFF
--- a/modules/helfi_recommendations/README.md
+++ b/modules/helfi_recommendations/README.md
@@ -1,5 +1,7 @@
 # Helfi annif integration
 
+See also Confluence documentation (in Finnish): https://helsinkisolutionoffice.atlassian.net/wiki/x/AQCFSwI
+
 Recommendation topics are generated for entities that include the `suggested_topics_reference` field. This is a custom
 field extending the core entity reference field.
 
@@ -12,11 +14,28 @@ See the API documentation at: [https://ai.finto.fi/v1/ui/](https://ai.finto.fi/v
 
 ## Suggestions across hel.fi instances
 
-**This feature is work in progress.**
+### Elasticsearch index
 
-Suggested topics entities are synced to suggestions search api index. In the future, other instances communicate with
-etusivu so that suggested topics entity is created for their content, and they can search suggestions for their content
-from the shared search index.
+Suggested topics entities are synced to `suggestions` search api index. The index is hosted with etusivu instance and all instances write and read to/from that shared index.
+
+#### Clearing the index
+
+Search index can be cleared manually or by certain configuration changes on deploy. Search API maintains a db registry for search index status but this registry will become out-of-date when the index is cleared by another instance. A mechanism to handle this will be implemented in UHF-12198, but until that we need to follow these guidelines:
+
+* Clear index on all instances at the same time, to make sure none of the local registries have items that are actually missing from the index.
+* Run indexing on all instances only after each of them has been cleared (this is challenged by the cron based indexing, which might trigger too early) 
+
+### "Recommended for you"-block
+
+All core instances have a "Recommended for you"-block enabled on Article, News, Standard Page and TPR Service content types. The block fetches content recommendations from the `suggestions` index, filtering results based on suggestion topics generated for current entity as well as editor managed settings for instances and content types.
+
+#### Block visibility
+
+Block visibility is controlled per entity ("Show automatically recommended content on this page"-field). This boolean field is enabled by default, but the default visibility can be changed per instance via a State API variable `helfi_recommendations.suggested_topics_default_show_block`:
+
+```shell
+drush sset helfi_recommendations.suggested_topics_default_show_block FALSE
+```
 
 ## Text converter
 

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -250,7 +250,7 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
     return;
   }
 
-  // Set up batch process to loop through 100 entities at a time.
+  // Set up batch process to loop through 10 entities at a time.
   if (!isset($sandbox['progress'])) {
     // Set default show_block value for new content via a State API variable.
     \Drupal::state()->set('helfi_recommendations.suggested_topics_default_show_block', FALSE);
@@ -270,11 +270,8 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
         ->execute();
       $max += $count[$entity_type];
     }
+    $sandbox['count'] = $count;
     $sandbox['max'] = $max;
-    \Drupal::messenger()->addMessage(t('Hiding recommendations block on @count_node node-entities and @count_tpr_service tpr_service-entities.', [
-      '@count_node' => $count['node'],
-      '@count_tpr_service' => $count['tpr_service'],
-    ]));
   }
 
   // Hide recommendations block on all existing content.
@@ -284,7 +281,7 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
     ->condition('field_recommended_topics.show_block', 1)
     ->condition($id_key, $sandbox['current_id'], '>')
     ->sort($id_key, 'ASC')
-    ->range(0, 100)
+    ->range(0, 10)
     ->accessCheck(FALSE)
     ->execute();
 
@@ -304,10 +301,6 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
         $entity->save();
       }
     }
-    \Drupal::messenger()->addMessage(t('Hidden recommendations block on @count @type-entities.', [
-      '@count' => count($entities),
-      '@type' => $sandbox['current_entity_type'],
-    ]));
     $sandbox['#finished'] = FALSE;
   }
   else if ($sandbox['current_entity_type'] === 'node') {
@@ -319,6 +312,10 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
   }
   else {
     // Finished with tpr_service entities, all done.
+    \Drupal::messenger()->addMessage(t('Finished hiding recommendations block on @count_node node-entities and @count_tpr_service tpr_service-entities.', [
+      '@count_node' => $sandbox['count']['node'],
+      '@count_tpr_service' => $sandbox['count']['tpr_service'],
+    ]));
     $sandbox['#finished'] = TRUE;
   }
 

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -22,20 +22,25 @@ function helfi_recommendations_install($is_syncing) : void {
     return;
   }
 
-  /** @var Drupal\helfi_platform_config\Helper\BlockInstaller $block_installer */
-  $block_installer = \Drupal::service('helfi_platform_config.helper.block_installer');
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
+  $moduleHandler = \Drupal::service(ModuleHandlerInterface::class);
 
-  /** @var \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler */
-  $theme_handler = \Drupal::service('theme_handler');
+  if ($moduleHandler->moduleExists('helfi_platform_config')) {
+    /** @var Drupal\helfi_platform_config\Helper\BlockInstaller $block_installer */
+    $block_installer = \Drupal::service('helfi_platform_config.helper.block_installer');
 
-  if (!str_starts_with($theme_handler->getDefault(), 'hdbt')) {
-    return;
+    /** @var \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler */
+    $theme_handler = \Drupal::service('theme_handler');
+
+    if (!str_starts_with($theme_handler->getDefault(), 'hdbt')) {
+      return;
+    }
+
+    $theme = $theme_handler->getDefault();
+    $block_config = helfi_recommendations_get_block_configurations($theme);
+    ['block' => $block, 'variations' => $variations] = $block_config;
+    $block_installer->install($block, $variations);
   }
-
-  $theme = $theme_handler->getDefault();
-  $block_config = helfi_recommendations_get_block_configurations($theme);
-  ['block' => $block, 'variations' => $variations] = $block_config;
-  $block_installer->install($block, $variations);
 
   // Set the text converter view display for the given content types.
   helfi_recommendations_set_text_converter_view_display('node', 'news_article', [
@@ -52,9 +57,6 @@ function helfi_recommendations_install($is_syncing) : void {
     'field_lower_content',
     'field_sidebar_content',
   ]);
-
-  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler */
-  $moduleHandler = \Drupal::service(ModuleHandlerInterface::class);
 
   if ($moduleHandler->moduleExists('helfi_tpr_config')) {
     helfi_recommendations_set_text_converter_view_display('tpr_service', 'tpr_service', [
@@ -303,7 +305,7 @@ function helfi_recommendations_update_10005(&$sandbox) : void {
     }
     $sandbox['#finished'] = FALSE;
   }
-  else if ($sandbox['current_entity_type'] === 'node') {
+  elseif ($sandbox['current_entity_type'] === 'node') {
     // Finished with node entities, moving on to tpr_service entities.
     $sandbox['current_entity_type'] = 'tpr_service';
     $sandbox['current_id_key'] = 'id';

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\helfi_tpr\Entity\Service;
 
 /**
  * Implements hook_install().
@@ -235,6 +237,39 @@ function helfi_recommendations_update_10004() : void {
 
     foreach ($field_storage_definitions as $name => $field_storage_definition) {
       \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition($name, 'tpr_service', 'helfi_recommendations', $field_storage_definition);
+    }
+  }
+}
+
+/**
+ * UHF-11798: Hide recommendations block by default on kuva-instance.
+ */
+function helfi_recommendations_update_10005() : void {
+  $project = \Drupal::service('helfi_api_base.environment_resolver')->getActiveProject();
+  if ($project->getName() !== 'kuva') {
+    return;
+  }
+
+  // Set default show_block value for new content via a State API variable.
+  \Drupal::state()->set('helfi_recommendations.suggested_topics_default_show_block', FALSE);
+
+  // Hide recommendations block on all existing content.
+  foreach (['node', 'tpr_service'] as $entity_type) {
+    $results = \Drupal::entityQuery($entity_type)
+      ->condition('field_recommended_topics.show_block', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    $entities = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($results);
+    foreach ($entities as $entity) {
+      assert($entity instanceof NodeInterface || $entity instanceof Service);
+      if ($entity->hasField('field_recommended_topics')) {
+        $field = $entity->get('field_recommended_topics')->getValue();
+        foreach ($field as &$item) {
+          $item['show_block'] = 0;
+        }
+        $entity->set('field_recommended_topics', $field);
+        $entity->save();
+      }
     }
   }
 }

--- a/modules/helfi_recommendations/helfi_recommendations.install
+++ b/modules/helfi_recommendations/helfi_recommendations.install
@@ -244,24 +244,57 @@ function helfi_recommendations_update_10004() : void {
 /**
  * UHF-11798: Hide recommendations block by default on kuva-instance.
  */
-function helfi_recommendations_update_10005() : void {
+function helfi_recommendations_update_10005(&$sandbox) : void {
   $project = \Drupal::service('helfi_api_base.environment_resolver')->getActiveProject();
   if ($project->getName() !== 'kuva') {
     return;
   }
 
-  // Set default show_block value for new content via a State API variable.
-  \Drupal::state()->set('helfi_recommendations.suggested_topics_default_show_block', FALSE);
+  // Set up batch process to loop through 100 entities at a time.
+  if (!isset($sandbox['progress'])) {
+    // Set default show_block value for new content via a State API variable.
+    \Drupal::state()->set('helfi_recommendations.suggested_topics_default_show_block', FALSE);
+
+    // Initialize sandbox.
+    $sandbox['progress'] = 0;
+    $sandbox['current_entity_type'] = 'node';
+    $sandbox['current_id_key'] = 'nid';
+    $sandbox['current_id'] = 0;
+    $count = [];
+    $max = 0;
+    foreach (['node', 'tpr_service'] as $entity_type) {
+      $count[$entity_type] = \Drupal::entityQuery($entity_type)
+        ->condition('field_recommended_topics.show_block', 1)
+        ->accessCheck(FALSE)
+        ->count()
+        ->execute();
+      $max += $count[$entity_type];
+    }
+    $sandbox['max'] = $max;
+    \Drupal::messenger()->addMessage(t('Hiding recommendations block on @count_node node-entities and @count_tpr_service tpr_service-entities.', [
+      '@count_node' => $count['node'],
+      '@count_tpr_service' => $count['tpr_service'],
+    ]));
+  }
 
   // Hide recommendations block on all existing content.
-  foreach (['node', 'tpr_service'] as $entity_type) {
-    $results = \Drupal::entityQuery($entity_type)
-      ->condition('field_recommended_topics.show_block', 1)
-      ->accessCheck(FALSE)
-      ->execute();
+  $entity_type = $sandbox['current_entity_type'];
+  $id_key = $sandbox['current_id_key'];
+  $results = \Drupal::entityQuery($entity_type)
+    ->condition('field_recommended_topics.show_block', 1)
+    ->condition($id_key, $sandbox['current_id'], '>')
+    ->sort($id_key, 'ASC')
+    ->range(0, 100)
+    ->accessCheck(FALSE)
+    ->execute();
+
+  if ($results) {
     $entities = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple($results);
     foreach ($entities as $entity) {
       assert($entity instanceof NodeInterface || $entity instanceof Service);
+      $sandbox['progress']++;
+      $sandbox['current_id'] = $entity->id();
+
       if ($entity->hasField('field_recommended_topics')) {
         $field = $entity->get('field_recommended_topics')->getValue();
         foreach ($field as &$item) {
@@ -271,5 +304,22 @@ function helfi_recommendations_update_10005() : void {
         $entity->save();
       }
     }
+    \Drupal::messenger()->addMessage(t('Hidden recommendations block on @count @type-entities.', [
+      '@count' => count($entities),
+      '@type' => $sandbox['current_entity_type'],
+    ]));
+    $sandbox['#finished'] = FALSE;
   }
+  else if ($sandbox['current_entity_type'] === 'node') {
+    // Finished with node entities, moving on to tpr_service entities.
+    $sandbox['current_entity_type'] = 'tpr_service';
+    $sandbox['current_id_key'] = 'id';
+    $sandbox['current_id'] = 0;
+    $sandbox['#finished'] = FALSE;
+  }
+  else {
+    // Finished with tpr_service entities, all done.
+    $sandbox['#finished'] = TRUE;
+  }
+
 }

--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -252,58 +252,9 @@ function helfi_recommendations_preprocess_recommendations_block(array &$variable
  * suggested_topics_reference.
  */
 function helfi_recommendations_field_widget_complete_suggested_topics_reference_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) : void {
-  // Hide the field from users other than administrators, when on content types
-  // that are not news items or articles.
-  // @todo This is a temporary restriction to allow validating the cross-instance
-  // recommendations in production before allowing the use for all editors.
-  // Remove this once we have validated the cross-instance recommendations works
-  // as intended.
-  $entity = $context['items']->getEntity();
-  assert($entity instanceof ContentEntityInterface);
-  if (
-    $entity->bundle() !== 'news_item' &&
-    $entity->bundle() !== 'news_article' &&
-    !_helfi_recommendations_can_see_review_mode()
-  ) {
-    return;
-  }
-
   // Wrap the field in a details element to allow users to expand it.
   $field_widget_complete_form['#prefix'] = '<details><summary>' . t('Automatically recommended content', options: ['context' => 'helfi_recommendations']) . '</summary>';
   $field_widget_complete_form['#suffix'] = '</details>';
-}
-
-/**
- * Implements hook_field_widget_single_element_form_alter().
- *
- * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter() for
- * suggested_topics_reference.
- *
- * @todo This is a temporary restriction to allow validating the cross-instance
- * recommendations in production before allowing the use for all editors.
- * Remove this once we have validated the cross-instance recommendations works
- * as intended.
- */
-function helfi_recommendations_field_widget_single_element_suggested_topics_reference_form_alter(array &$element, FormStateInterface $formState, array &$context) : void {
-  $entity = $context['items']->getEntity();
-  assert($entity instanceof ContentEntityInterface);
-
-  if ($entity->bundle() === 'news_item' || $entity->bundle() === 'news_article') {
-    // Hide instance and content type selection from news items and articles.
-    // Not allowed even for admin users to preserve the single instance
-    // behaviour from the previous implementation for now.
-    $element['instances']['#access'] = FALSE;
-    $element['content_types']['#access'] = FALSE;
-  }
-  else {
-    // Hide suggestions field in other content types from users other than
-    // administrators.
-    $element['#access'] = FALSE;
-
-    if (_helfi_recommendations_can_see_review_mode()) {
-      $element['#access'] = TRUE;
-    }
-  }
 }
 
 /**

--- a/modules/helfi_recommendations/helfi_recommendations.module
+++ b/modules/helfi_recommendations/helfi_recommendations.module
@@ -35,6 +35,17 @@ function helfi_recommendations_theme() : array {
 }
 
 /**
+ * Implements hook_platform_config_grant_permissions().
+ */
+function helfi_recommendations_platform_config_grant_permissions() : array {
+  return [
+    'admin' => [
+      'view recommendation score',
+    ],
+  ];
+}
+
+/**
  * Implements hook_entity_insert().
  */
 function helfi_recommendations_entity_insert(EntityInterface $entity) : void {
@@ -233,19 +244,6 @@ function helfi_recommendations_page_attachments_alter(array &$attachments) {
 }
 
 /**
- * Implements template_preprocess_recommendations_block().
- */
-function helfi_recommendations_preprocess_recommendations_block(array &$variables) : void {
-  if (_helfi_recommendations_can_see_review_mode() && !empty($variables['rows'])) {
-    foreach ($variables['rows'] as &$row) {
-      if ($row['score']) {
-        $row['helptext'] = t('Search result score: @score', ['@score' => $row['score']]);
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_field_widget_complete_form_alter().
  *
  * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter() for
@@ -255,21 +253,4 @@ function helfi_recommendations_field_widget_complete_suggested_topics_reference_
   // Wrap the field in a details element to allow users to expand it.
   $field_widget_complete_form['#prefix'] = '<details><summary>' . t('Automatically recommended content', options: ['context' => 'helfi_recommendations']) . '</summary>';
   $field_widget_complete_form['#suffix'] = '</details>';
-}
-
-/**
- * Helper function to check permissions for the review mode.
- *
- * @todo This is a temporary restriction to allow validating the cross-instance
- * recommendations in production before allowing the use for all editors.
- * Remove this once we have validated the cross-instance recommendations works
- * as intended. Or if we wish to have some features enabled only for admins
- * after going public with the cross-instance recommendations, we should
- * refactor this to use a custom permission, and maybe place this check into
- * a RecommendationManager service method.
- */
-function _helfi_recommendations_can_see_review_mode() : bool {
-  $current_user = \Drupal::currentUser();
-  $roles = $current_user->getRoles();
-  return in_array('admin', $roles) || $current_user->hasPermission('administer modules');
 }

--- a/modules/helfi_recommendations/helfi_recommendations.permissions.yml
+++ b/modules/helfi_recommendations/helfi_recommendations.permissions.yml
@@ -1,2 +1,5 @@
 access text converter preview:
   title: 'Access text converter preview page'
+
+view recommendation score:
+  title: 'View recommendation score'

--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -93,14 +93,9 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
    * {@inheritdoc}
    */
   public function getCacheContexts(): array {
-    // @todo "user.roles" context is needed while cross-instance
-    // recommendations are in review mode as part of the content is
-    // displayed to selected roles only. We can replace it with
-    // "user.roles:anonymous" once we have validated the cross-instance
-    // recommendations work as intended.
     return Cache::mergeContexts(
       parent::getCacheContexts(),
-      ['languages:language_content', 'user.roles', 'url.path'],
+      ['languages:language_content', 'user.roles:anonymous', 'url.path'],
     );
   }
 
@@ -126,18 +121,6 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
     ['entity' => $entity] = $this->entityVersionMatcher->getType();
 
     if (!$entity instanceof ContentEntityInterface) {
-      return AccessResult::forbidden();
-    }
-
-    // @todo This is a temporary restriction to allow validating the
-    // cross-instance recommendations in production before allowing the
-    // use for all editors. Remove these once we have validated the
-    // cross-instance recommendations work as intended.
-    if ($entity->bundle() !== 'news_item' && $entity->bundle() !== 'news_article') {
-      if (_helfi_recommendations_can_see_review_mode()) {
-        return AccessResult::allowed();
-      }
-
       return AccessResult::forbidden();
     }
 

--- a/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
+++ b/modules/helfi_recommendations/src/Plugin/Block/RecommendationsBlock.php
@@ -76,7 +76,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
       '#lazy_builder' => [
         RecommendationsLazyBuilder::class . ':build',
         [
-          'isAnonymous' => $this->currentUser->isAnonymous(),
+          'userId' => $this->currentUser->id(),
           'entityType' => $entity->getEntityTypeId(),
           'entityId' => $entity->id(),
           'langcode' => $entity->language()->getId(),
@@ -95,7 +95,7 @@ final class RecommendationsBlock extends BlockBase implements ContainerFactoryPl
   public function getCacheContexts(): array {
     return Cache::mergeContexts(
       parent::getCacheContexts(),
-      ['languages:language_content', 'user.roles:anonymous', 'url.path'],
+      ['languages:language_content', 'user.roles', 'url.path'],
     );
   }
 

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
@@ -11,6 +11,7 @@ use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_recommendations\Entity\SuggestedTopics;
 use Drupal\helfi_recommendations\Entity\SuggestedTopicsInterface;
@@ -38,6 +39,7 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
     array $settings,
     array $third_party_settings,
     private readonly RecommendationManagerInterface $recommendationManager,
+    private readonly StateInterface $state,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
   }
@@ -52,7 +54,8 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       $configuration['field_definition'],
       $configuration['settings'],
       $configuration['third_party_settings'],
-      $container->get(RecommendationManagerInterface::class)
+      $container->get(RecommendationManagerInterface::class),
+      $container->get('state'),
     );
   }
 
@@ -83,12 +86,7 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       '#title' => $this->getFieldPropertyDefinition($field, 'published')->getLabel(),
     ];
 
-    // Allow changing the default value of the show_block field.
-    // This can be changed per instance by running:
-    // @code
-    // drush state:set helfi_recommendations.suggested_topics_default_show_block 0
-    // @endcode
-    $default_show_block = \Drupal::state()->get('helfi_recommendations.suggested_topics_default_show_block', TRUE);
+    $default_show_block = $this->state->get('helfi_recommendations.suggested_topics_default_show_block', TRUE);
     $element['show_block'] = [
       '#type' => 'checkbox',
       '#default_value' => $field->get('show_block')->getValue() ?? $default_show_block,

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
@@ -84,9 +84,15 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       '#title' => $this->getFieldPropertyDefinition($field, 'published')->getLabel(),
     ];
 
+    // Allow changing the default value of the show_block field.
+    // This can be changed per instance by running:
+    // @code
+    // drush state:set helfi_recommendations.suggested_topics_default_show_block 0
+    // @endcode
+    $default_show_block = \Drupal::state()->get('helfi_recommendations.suggested_topics_default_show_block', TRUE);
     $element['show_block'] = [
       '#type' => 'checkbox',
-      '#default_value' => $field->get('show_block')->getValue() ?? TRUE,
+      '#default_value' => $field->get('show_block')->getValue() ?? $default_show_block,
       '#title' => $this->getFieldPropertyDefinition($field, 'show_block')->getLabel(),
     ];
 

--- a/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
+++ b/modules/helfi_recommendations/src/Plugin/Field/FieldWidget/SuggestedTopicsReferenceWidget.php
@@ -12,10 +12,9 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
-use Drupal\helfi_api_base\Environment\Project;
 use Drupal\helfi_recommendations\Entity\SuggestedTopics;
 use Drupal\helfi_recommendations\Entity\SuggestedTopicsInterface;
+use Drupal\helfi_recommendations\RecommendationManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -38,7 +37,7 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
     FieldDefinitionInterface $field_definition,
     array $settings,
     array $third_party_settings,
-    private readonly EnvironmentResolverInterface $environmentResolver,
+    private readonly RecommendationManagerInterface $recommendationManager,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
   }
@@ -53,7 +52,7 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       $configuration['field_definition'],
       $configuration['settings'],
       $configuration['third_party_settings'],
-      $container->get('helfi_api_base.environment_resolver')
+      $container->get(RecommendationManagerInterface::class)
     );
   }
 
@@ -96,12 +95,11 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       '#title' => $this->getFieldPropertyDefinition($field, 'show_block')->getLabel(),
     ];
 
-    $projects = $this->environmentResolver->getProjects();
     $element['instances'] = [
       '#type' => 'checkboxes',
       '#default_value' => $field->get('instances')->getValue() ?? [],
       '#title' => $this->getFieldPropertyDefinition($field, 'instances')->getLabel(),
-      '#options' => array_map(fn (Project $project) => $project->label(), $projects),
+      '#options' => $this->recommendationManager->getAllowedInstances(),
       '#description' => $this->t('Select the instances that should be used for recommendations. If no instances are selected, recommendations will be shown from all instances.', options: ['context' => 'helfi_recommendations']),
     ];
 
@@ -109,12 +107,7 @@ final class SuggestedTopicsReferenceWidget extends WidgetBase {
       '#type' => 'checkboxes',
       '#default_value' => $field->get('content_types')->getValue() ?? [],
       '#title' => $this->getFieldPropertyDefinition($field, 'content_types')->getLabel(),
-      '#options' => [
-        'node|news_article' => $this->t('News article', options: ['context' => 'helfi_recommendations']),
-        'node|news_item' => $this->t('News item', options: ['context' => 'helfi_recommendations']),
-        'node|page' => $this->t('Standard page', options: ['context' => 'helfi_recommendations']),
-        'tpr_service|tpr_service' => $this->t('Service', options: ['context' => 'helfi_recommendations']),
-      ],
+      '#options' => $this->recommendationManager->getAllowedContentTypesAndBundles(),
       '#description' => $this->t('Select the content types that should be used for recommendations. If no content types are selected, recommendations will be shown from all content types.', options: ['context' => 'helfi_recommendations']),
     ];
 

--- a/modules/helfi_recommendations/src/RecommendationManager.php
+++ b/modules/helfi_recommendations/src/RecommendationManager.php
@@ -83,13 +83,6 @@ class RecommendationManager implements RecommendationManagerInterface {
       return FALSE;
     }
 
-    // Allow changing the default value of the show_block field.
-    // This can be changed per instance by running:
-    // @code
-    // drush state:set helfi_recommendations.suggested_topics_default_show_block 0
-    // @endcode
-    $default_show_block = $this->state->get('helfi_recommendations.suggested_topics_default_show_block', TRUE);
-
     // Check if any of the suggested topics reference fields have the show_block
     // property set to FALSE. If so, do not show recommendations.
     foreach ($fields as $key => $definition) {
@@ -104,7 +97,7 @@ class RecommendationManager implements RecommendationManagerInterface {
     }
 
     // Return the default value for entities that do not yet have a value saved.
-    return $default_show_block;
+    return $this->state->get('helfi_recommendations.suggested_topics_default_show_block', TRUE);
   }
 
   /**
@@ -356,7 +349,8 @@ class RecommendationManager implements RecommendationManagerInterface {
   private function setQueryFilterForContentTypesAndBundles(array &$query, ContentEntityInterface $entity, array $options): void {
     $content_types = [];
 
-    // First get allowed content types and bundles from provided options or the entity.
+    // First get allowed content types and bundles from provided options or
+    // the entity.
     $allowed_content_types = $options['content_types'] ?? $this->getEnabledContentTypesAndBundles($entity);
 
     // Validate options against allowed content types and bundles.

--- a/modules/helfi_recommendations/src/RecommendationManagerInterface.php
+++ b/modules/helfi_recommendations/src/RecommendationManagerInterface.php
@@ -75,4 +75,14 @@ interface RecommendationManagerInterface {
    */
   public function invalidateAllRecommendationBlocks(): void;
 
+  /**
+   * Get allowed instances.
+   */
+  public function getAllowedInstances(): array;
+
+  /**
+   * Get allowed content types and bundles.
+   */
+  public function getAllowedContentTypesAndBundles(): array;
+
 }

--- a/modules/helfi_recommendations/src/RecommendationsLazyBuilder.php
+++ b/modules/helfi_recommendations/src/RecommendationsLazyBuilder.php
@@ -104,24 +104,12 @@ final class RecommendationsLazyBuilder implements RecommendationsLazyBuilderInte
   private function getRecommendations(ContentEntityInterface $entity): array {
     $recommendations = [];
 
-    $options = [];
-    if (in_array($entity->bundle(), ['news_item', 'news_article'])) {
-      // @todo This is to preserve the functionality from the previous
-      // implementation. Remove these once we have validated the
-      // cross-instance recommendations work as intended.
-      $options = [
-        'instances' => ['etusivu'],
-        'content_types' => ['node' => ['news_item', 'news_article']],
-      ];
-    }
-
     try {
       $recommendations = $this->recommendationManager
         ->getRecommendations(
           $entity,
           3,
           $entity->language()->getId(),
-          $options,
         );
     }
     catch (\Exception $exception) {

--- a/modules/helfi_recommendations/src/RecommendationsLazyBuilderInterface.php
+++ b/modules/helfi_recommendations/src/RecommendationsLazyBuilderInterface.php
@@ -12,8 +12,8 @@ interface RecommendationsLazyBuilderInterface {
   /**
    * Builds the recommendations block.
    *
-   * @param bool $isAnonymous
-   *   Whether the current user is anonymous.
+   * @param int $userId
+   *   The ID of the user.
    * @param string $entityType
    *   The type of the entity.
    * @param string $entityId
@@ -24,6 +24,6 @@ interface RecommendationsLazyBuilderInterface {
    * @return array
    *   The recommendations block render array.
    */
-  public function build(bool $isAnonymous, string $entityType, string $entityId, string $langcode): array;
+  public function build(int $userId, string $entityType, string $entityId, string $langcode): array;
 
 }

--- a/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
+++ b/modules/helfi_recommendations/tests/src/Functional/TopicSuggestionsMetaTagTest.php
@@ -30,10 +30,7 @@ class TopicSuggestionsMetaTagTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
-    'taxonomy',
-    'node',
     'helfi_recommendations',
-    'helfi_platform_config',
   ];
 
   /**

--- a/modules/helfi_recommendations/tests/src/Kernel/Plugin/Block/RecommendationsBlockKernelTest.php
+++ b/modules/helfi_recommendations/tests/src/Kernel/Plugin/Block/RecommendationsBlockKernelTest.php
@@ -92,10 +92,10 @@ class RecommendationsBlockKernelTest extends AnnifKernelTestBase {
     $this->assertEquals([
       RecommendationsLazyBuilder::class . ':build',
       [
-        'isAnonymous' => TRUE,
         'entityType' => 'node',
         'entityId' => $node->id(),
         'langcode' => $node->language()->getId(),
+        'userId' => 0,
       ],
     ], $result['recommendations']['#lazy_builder']);
   }

--- a/modules/helfi_recommendations/tests/src/Kernel/RecommendationManagerKernelTest.php
+++ b/modules/helfi_recommendations/tests/src/Kernel/RecommendationManagerKernelTest.php
@@ -302,8 +302,6 @@ class RecommendationManagerKernelTest extends AnnifKernelTestBase {
     array $elasticData = [],
   ): RecommendationManager {
     $loggerChannel = $this->prophesize(LoggerChannelInterface::class);
-    $environmentResolver = $this->container->get(EnvironmentResolverInterface::class);
-    $topicsManager = $this->container->get(TopicsManagerInterface::class);
 
     $elasticResponse = $this->prophesize(Elasticsearch::class);
     $elasticResponse->asArray()->willReturn($elasticData);
@@ -315,10 +313,12 @@ class RecommendationManagerKernelTest extends AnnifKernelTestBase {
 
     return new RecommendationManager(
       $loggerChannel->reveal(),
-      $environmentResolver,
-      $topicsManager,
+      $this->container->get(EnvironmentResolverInterface::class),
+      $this->container->get(TopicsManagerInterface::class),
       $elasticsearchClient->reveal(),
       $cacheTagInvalidator->reveal(),
+      $this->container->get('state'),
+      $this->container->get('string_translation'),
     );
   }
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationManagerTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\helfi_api_base\Cache\CacheTagInvalidatorInterface;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_recommendations\RecommendationManager;
@@ -78,6 +79,13 @@ class RecommendationManagerTest extends UnitTestCase {
   protected $cacheTagInvalidator;
 
   /**
+   * The mocked state.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $state;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -88,6 +96,7 @@ class RecommendationManagerTest extends UnitTestCase {
     $this->topicsManager = $this->prophesize(TopicsManagerInterface::class);
     $this->elasticClient = ClientBuilder::create()->build();
     $this->cacheTagInvalidator = $this->prophesize(CacheTagInvalidatorInterface::class);
+    $this->state = $this->prophesize(StateInterface::class);
 
     $this->recommendationManager = new RecommendationManager(
       $this->logger->reveal(),
@@ -95,6 +104,8 @@ class RecommendationManagerTest extends UnitTestCase {
       $this->topicsManager->reveal(),
       $this->elasticClient,
       $this->cacheTagInvalidator->reveal(),
+      $this->state->reveal(),
+      $this->getStringTranslationStub(),
     );
   }
 

--- a/modules/helfi_recommendations/tests/src/Unit/RecommendationsLazyBuilderTest.php
+++ b/modules/helfi_recommendations/tests/src/Unit/RecommendationsLazyBuilderTest.php
@@ -11,6 +11,7 @@ use Drupal\Core\Language\LanguageInterface;
 use Drupal\helfi_recommendations\RecommendationManagerInterface;
 use Drupal\helfi_recommendations\RecommendationsLazyBuilder;
 use Drupal\Tests\UnitTestCase;
+use Drupal\user\UserInterface;
 use Psr\Log\LoggerInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -53,11 +54,18 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
   protected $logger;
 
   /**
-   * The mocked entity storage.
+   * The mocked node entity storage.
    *
    * @var \Prophecy\Prophecy\ObjectProphecy
    */
-  protected $entityStorage;
+  protected $nodeEntityStorage;
+
+  /**
+   * The mocked user entity storage.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $userEntityStorage;
 
   /**
    * The mocked entity.
@@ -65,6 +73,20 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @var \Prophecy\Prophecy\ObjectProphecy
    */
   protected $entity;
+
+  /**
+   * The mocked anonymous user.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $anonymousUser;
+
+  /**
+   * The mocked authenticated user.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected $authenticatedUser;
 
   /**
    * The mocked language.
@@ -83,15 +105,25 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
     $this->recommendationManager->getCacheTagForAll()->willReturn('test_cache_tag_all');
     $this->recommendationManager->getCacheTagForUuid('test_uuid_1')->willReturn('test_cache_tag_uuid_1');
     $this->recommendationManager->getCacheTagForUuid('test_uuid_2')->willReturn('test_cache_tag_uuid_2');
-    $this->entityStorage = $this->prophesize(EntityStorageInterface::class);
+    $this->nodeEntityStorage = $this->prophesize(EntityStorageInterface::class);
+    $this->userEntityStorage = $this->prophesize(EntityStorageInterface::class);
     $this->entityTypeManager = $this->prophesize(EntityTypeManagerInterface::class);
-    $this->entityTypeManager->getStorage(Argument::any())->willReturn($this->entityStorage->reveal());
+    $this->entityTypeManager->getStorage('node')->willReturn($this->nodeEntityStorage->reveal());
+    $this->entityTypeManager->getStorage('user')->willReturn($this->userEntityStorage->reveal());
     $this->logger = $this->prophesize(LoggerInterface::class);
     $this->language = $this->prophesize(LanguageInterface::class);
     $this->entity = $this->prophesize(ContentEntityInterface::class);
     $this->entity->language()->willReturn($this->language->reveal());
     $this->entity->getCacheTags()->willReturn(['test_cache_tag_entity']);
     $this->entity->bundle()->willReturn('news_item');
+    $this->anonymousUser = $this->prophesize(UserInterface::class);
+    $this->anonymousUser->isAnonymous()->willReturn(TRUE);
+    $this->anonymousUser->hasPermission('view recommendation score')->willReturn(FALSE);
+    $this->authenticatedUser = $this->prophesize(UserInterface::class);
+    $this->authenticatedUser->isAnonymous()->willReturn(FALSE);
+    $this->authenticatedUser->hasPermission('view recommendation score')->willReturn(TRUE);
+    $this->userEntityStorage->load(123)->willReturn($this->authenticatedUser->reveal());
+    $this->userEntityStorage->load(0)->willReturn($this->anonymousUser->reveal());
 
     $this->recommendationsLazyBuilder = new RecommendationsLazyBuilder(
       $this->recommendationManager->reveal(),
@@ -107,9 +139,9 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuild(): void {
-    $this->entityStorage->load(Argument::any())->willReturn(NULL);
+    $this->nodeEntityStorage->load(Argument::any())->willReturn(NULL);
 
-    $result = $this->recommendationsLazyBuilder->build(TRUE, 'node', '1', 'en');
+    $result = $this->recommendationsLazyBuilder->build(0, 'node', '1', 'en');
     $this->assertEquals([], $result);
   }
 
@@ -119,11 +151,11 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildWithNonExistingTranslationLanguage(): void {
-    $this->entityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
     $this->language->getId()->willReturn('fi');
     $this->entity->hasTranslation(Argument::any())->willReturn(FALSE);
 
-    $result = $this->recommendationsLazyBuilder->build(TRUE, 'node', '1', 'en');
+    $result = $this->recommendationsLazyBuilder->build(0, 'node', '1', 'en');
     $this->assertEquals([], $result);
   }
 
@@ -133,11 +165,11 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildWithNoRecommendationsAndAnonymousUser(): void {
-    $this->entityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
     $this->language->getId()->willReturn('en');
     $this->recommendationManager->getRecommendations(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn([]);
 
-    $result = $this->recommendationsLazyBuilder->build(TRUE, 'node', '1', 'en');
+    $result = $this->recommendationsLazyBuilder->build(0, 'node', '1', 'en');
     $this->assertArrayHasKey('#cache', $result);
     $this->assertEquals(['test_cache_tag_entity', 'test_cache_tag_all'], $result['#cache']['tags']);
     $this->assertEquals(['languages:language_content', 'user.roles', 'url.path'], $result['#cache']['contexts']);
@@ -150,11 +182,11 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::build
    */
   public function testBuildWithNoRecommendationsAndAuthenticatedUser(): void {
-    $this->entityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
     $this->language->getId()->willReturn('en');
     $this->recommendationManager->getRecommendations(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn([]);
 
-    $result = $this->recommendationsLazyBuilder->build(FALSE, 'node', '1', 'en');
+    $result = $this->recommendationsLazyBuilder->build(123, 'node', '1', 'en');
     $this->assertArrayHasKey('#cache', $result);
     $this->assertArrayHasKey('#no_results_message', $result);
   }
@@ -166,14 +198,14 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::getRecommendations
    */
   public function testBuildWithRecommendations(): void {
-    $this->entityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
     $this->language->getId()->willReturn('en');
     $this->recommendationManager->getRecommendations(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn([
-      ['uuid' => 'test_uuid_1'],
-      ['uuid' => 'test_uuid_2'],
+      ['uuid' => 'test_uuid_1', 'score' => 0.5],
+      ['uuid' => 'test_uuid_2', 'score' => 0.3],
     ]);
 
-    $result = $this->recommendationsLazyBuilder->build(TRUE, 'node', '1', 'en');
+    $result = $this->recommendationsLazyBuilder->build(0, 'node', '1', 'en');
     $this->assertArrayHasKey('#cache', $result);
     $this->assertArrayHasKey('#rows', $result);
     $this->assertEquals([
@@ -183,9 +215,37 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
       'test_cache_tag_uuid_2',
     ], $result['#cache']['tags']);
     $this->assertEquals([
-      ['uuid' => 'test_uuid_1'],
-      ['uuid' => 'test_uuid_2'],
+      ['uuid' => 'test_uuid_1', 'score' => 0.5],
+      ['uuid' => 'test_uuid_2', 'score' => 0.3],
     ], $result['#rows']);
+    $this->assertArrayNotHasKey('#no_results_message', $result);
+  }
+
+  /**
+   * Tests the build method with recommendations and authenticated user.
+   *
+   * @covers ::build
+   * @covers ::getRecommendations
+   */
+  public function testBuildWithRecommendationsAndAuthenticatedUser(): void {
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->language->getId()->willReturn('en');
+    $this->recommendationManager->getRecommendations(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn([
+      ['uuid' => 'test_uuid_1', 'score' => 0.5],
+      ['uuid' => 'test_uuid_2', 'score' => 0.3],
+    ]);
+
+    $result = $this->recommendationsLazyBuilder->build(123, 'node', '1', 'en');
+    $this->assertArrayHasKey('#cache', $result);
+    $this->assertArrayHasKey('#rows', $result);
+    $this->assertEquals([
+      'test_cache_tag_entity',
+      'test_cache_tag_all',
+      'test_cache_tag_uuid_1',
+      'test_cache_tag_uuid_2',
+    ], $result['#cache']['tags']);
+    $this->assertArrayHasKey('helptext', $result['#rows'][0]);
+    $this->assertArrayHasKey('helptext', $result['#rows'][1]);
     $this->assertArrayNotHasKey('#no_results_message', $result);
   }
 
@@ -196,7 +256,7 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
    * @covers ::getRecommendations
    */
   public function testBuildWithRecommendationsAndTranslation(): void {
-    $this->entityStorage->load(Argument::any())->willReturn($this->entity->reveal());
+    $this->nodeEntityStorage->load(Argument::any())->willReturn($this->entity->reveal());
     $this->language->getId()->willReturn('en');
     $this->entity->hasTranslation('fi')->willReturn(TRUE);
     $this->entity->getTranslation('fi')->willReturn($this->entity->reveal());
@@ -204,7 +264,7 @@ class RecommendationsLazyBuilderTest extends UnitTestCase {
       ->shouldBeCalled()
       ->willReturn([]);
 
-    $this->recommendationsLazyBuilder->build(TRUE, 'node', '1', 'fi');
+    $this->recommendationsLazyBuilder->build(0, 'node', '1', 'fi');
   }
 
 }


### PR DESCRIPTION
# [UHF-11798](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11798)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed temporary role based access restrictions, allowing the recommendation block to be visible to all users in all content types.
* Updated the recommendation search score visibility restriction from role to permission based.
* Hiding the recommendation block by default in kuva-instance.
* Updated documentation.

## How to install
* Make sure your `etusivu` and `kuva` instances are up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-11798`
* Run `make drush-updb drush-cr`
* After reaching this far in both instances, run `drush sapi-rt` in both, then `drush sapi-i suggestions` in both.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Log in to https://helfi-kuva.docker.so
* [x] Try creating a new Standard page; "Show automatically recommended content on this page" should be unchecked by default
* [x] Try editing an existing standard page; "Show automatically recommended content on this page" should be unchecked in all of them
* [x] Enable "Show automatically recommended content on this page" and Save; "Recommended for you" block should now be visible, with a "Search result score:" -line displayed in all recommendations for admin users
* [x] Open above page in incognito window; "Recommended for you" should be visible for anonymous users as well, only without the "Search result score:" -lines.
* [x] Edit a TPR Service. Make it published and enable "Show automatically recommended content on this page", then Save; "Recommended for you" block should now be visible, with a "Search result score:" -line displayed in all recommendations for admin users
* [x] Open above TPR service page  in incognito window; "Recommended for you" should be visible for anonymous users as well, only without the "Search result score:" -lines.
* [x] Check that code follows our standards
* [x] Check documentation in Confluence: https://helsinkisolutionoffice.atlassian.net/wiki/x/AQCFSwI

<!-- Check list for the developer. Did you update/add/check the -->
<!-- * documentation -->
<!-- * translations -->
<!-- * coding standards -->


[UHF-11798]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ