### PR TITLE
UHF-12206: Install default configurations during module install

### DIFF
--- a/modules/hdbt_admin_tools/hdbt_admin_tools.install
+++ b/modules/hdbt_admin_tools/hdbt_admin_tools.install
@@ -117,8 +117,11 @@ function hdbt_admin_tools_update_9009(): void {
  * UHF-12206: Install editoria11y module, if it's not installed.
  */
 function hdbt_admin_tools_update_9010(): void {
-  if (!Drupal::moduleHandler()->moduleExists('editoria11y')) {
-    $module_installer = \Drupal::service('module_installer');
-    $module_installer->install(['editoria11y']);
+  $module = 'editoria11y';
+  if (!Drupal::moduleHandler()->moduleExists($module)) {
+    $module_installer = Drupal::service('module_installer');
+    $module_installer->install([$module]);
+    $config_installer = Drupal::service('config.installer');
+    $config_installer->installDefaultConfig('module', $module);
   }
 }


### PR DESCRIPTION
# [UHF-12206](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12206)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fixed update hook where Editoria11y gets installed


[UHF-12206]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ