### PR TITLE
UHF-13177: Moved HTMX patch from Etusivu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     "extra": {
         "patches": {
             "drupal/core": {
+                "[#UHF-13177, #3569803] htmx:beforeSwap fails with TypeError requestAssetsLoaded.get(...) is undefined": "./public/modules/contrib/helfi_platform_config/patches/3569803.patch",
                 "[#UHF-12709] Patch 'Deleted and replaced ...' error messages": "./public/modules/contrib/helfi_platform_config/patches/UHF-12709-skip_deleted_and_replaced_log.patch",
                 "[#UHF-181] Hide untranslated menu links (https://www.drupal.org/project/drupal/issues/3091246)": "./public/modules/contrib/helfi_platform_config/patches/3091246.patch",
                 "[#UHF-3812] Ajax exposed filters not working for multiple instances of the same Views block placed on one page (https://www.drupal.org/project/drupal/issues/3163299)": "./public/modules/contrib/helfi_platform_config/patches/3163299-104-D10.patch",

--- a/modules/helfi_base_content/config/rewrite/core.entity_form_display.paragraph.from_library.default.yml
+++ b/modules/helfi_base_content/config/rewrite/core.entity_form_display.paragraph.from_library.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - paragraphs.paragraphs_type.from_library
   module:
     - select2
+    - paragraphs_library
 id: paragraph.from_library.default
 targetEntityType: paragraph
 bundle: from_library

--- a/modules/helfi_base_content/config/rewrite/core.entity_form_display.paragraph.from_library.default.yml
+++ b/modules/helfi_base_content/config/rewrite/core.entity_form_display.paragraph.from_library.default.yml
@@ -7,7 +7,6 @@ dependencies:
     - paragraphs.paragraphs_type.from_library
   module:
     - select2
-    - paragraphs_library
 id: paragraph.from_library.default
 targetEntityType: paragraph
 bundle: from_library

--- a/patches/3569803.patch
+++ b/patches/3569803.patch
@@ -1,0 +1,13 @@
+diff --git a/core/misc/htmx/htmx-assets.js b/core/misc/htmx/htmx-assets.js
+index 0a1533f5ea2..867cf49e5c9 100644
+--- a/core/misc/htmx/htmx-assets.js
++++ b/core/misc/htmx/htmx-assets.js
+@@ -130,7 +130,7 @@
+     // Helps with memory management.
+     responseHTML = null;
+ 
+-    requestAssetsLoaded.get(detail.xhr).then(() => Drupal.htmx.addAssets(data));
++    requestAssetsLoaded.get(detail.xhr)?.then(() => Drupal.htmx.addAssets(data));
+   });
+ 
+   // Trigger the Drupal processing once all assets have been loaded.


### PR DESCRIPTION
# [UHF-13177](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13177)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* HTMX is used in Curated event list now as well. Moved the HTMX patch from Etusivu to here to fix the `htmx:beforeSwap fails with TypeError requestAssetsLoaded.get(...) is undefined` Javascript error.

[UHF-13177]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ