### PR TITLE
UHF-12693: Removing a responsive image style configuration that is no longer used

### DIFF
--- a/modules/helfi_image_styles/helfi_image_styles.install
+++ b/modules/helfi_image_styles/helfi_image_styles.install
@@ -186,3 +186,11 @@ function helfi_image_styles_update_11000(): void {
   $config_factory->getEditable('image.style.1_812w_812h_LQ')->delete();
   $config_factory->getEditable('image.style.1_828w_828h_LQ')->delete();
 }
+
+/**
+ * UHF-12693: Remove responsive image style that is no longer used.
+ */
+function helfi_image_styles_update_11001(): void {
+  $config_factory = Drupal::configFactory();
+  $config_factory->getEditable('responsive_image.styles.contact_card')->delete();
+}


### PR DESCRIPTION
# [UHF-12693](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12693)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* There's a responsive image style that seems to be a leftover from https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/936 . It has a reference to one of the image styles that now has a new machine name
, causing the automatic update workflow to fail: https://github.com/City-of-Helsinki/drupal-helfi-strategia/actions/runs/26284800482/job/77369622753#step:16:490

[UHF-12693]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ