### PR TITLE
UHF-13325: Reverts the text fragment POC

### DIFF
--- a/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.info.yml
+++ b/modules/helfi_paragraphs_curated_event_list/helfi_paragraphs_curated_event_list.info.yml
@@ -3,14 +3,17 @@ type: module
 core_version_requirement: '^10 || ^11'
 container_rebuild_required: true
 dependencies:
+  - drupal:content_translation
   - drupal:link
   - drupal:field
   - drupal:datetime
   - drupal:breakpoint
   - drupal:responsive_image
+  - drupal:text
   - linkit:linkit
   - external_entities:external_entities
   - helfi_api_base:helfi_api_base
+  - helfi_ckeditor:helfi_ckeditor
   - helfi_image_styles:helfi_image_styles
   - helfi_platform_config:helfi_platform_config
   - imagecache_external:imagecache_external

--- a/modules/helfi_search/src/Controller/SearchController.php
+++ b/modules/helfi_search/src/Controller/SearchController.php
@@ -251,7 +251,7 @@ final class SearchController extends ControllerBase {
     $result = [
       'promoted' => $promoted,
       'results' => $this->queryBuilder->parseKnnHits($knnResponse, $model),
-      'total_hits' => $knnResponse['hits']['total']['value'] ?? 0,
+      'total_hits' => ($knnResponse['hits']['total']['value'] ?? 0) + count($promoted),
     ];
     if ($debug && !isset($responses[1]['error'])) {
       $result['debug'] = ['bundles' => $this->queryBuilder->parseBundleAggregations($knnResponse)];

--- a/modules/helfi_search/src/Controller/SearchController.php
+++ b/modules/helfi_search/src/Controller/SearchController.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Semantic search API controller.
+ *
+ * @phpstan-type SearchResult array{promoted: list<mixed>, results: list<mixed>, total_hits: int, debug?: array<string, mixed>}
  */
 final class SearchController extends ControllerBase {
 
@@ -180,7 +182,7 @@ final class SearchController extends ControllerBase {
    * @param bool $debug
    *   Whether to include per-bundle aggregations in the result.
    *
-   * @return array{promoted: list<mixed>, results: list<mixed>, total_hits: int, debug?: array<string, mixed>}
+   * @return SearchResult
    *   The promoted hits, KNN results, total hit count, and optional debug
    *   payload keyed under 'debug' when $debug is TRUE.
    *
@@ -220,7 +222,7 @@ final class SearchController extends ControllerBase {
    * @param bool $debug
    *   Whether to include per-bundle aggregations in the result.
    *
-   * @return array{promoted: list<mixed>, results: list<mixed>, total_hits: int, debug?: array<string, mixed>}
+   * @return SearchResult
    *   The promoted hits, KNN results, total hit count, and optional debug
    *   payload keyed under 'debug' when $debug is TRUE.
    *
@@ -260,7 +262,7 @@ final class SearchController extends ControllerBase {
   /**
    * Assemble the JSON response with cache headers.
    *
-   * @param array{promoted: list<mixed>, results: list<mixed>, total_hits: int, debug?: array<string, mixed>} $result
+   * @param SearchResult $result
    *   The search result payload from one of the execute*() helpers.
    * @param int $page
    *   The 1-based page number echoed back to the client.

--- a/modules/helfi_search/src/Drush/Commands/TextPipelineCommands.php
+++ b/modules/helfi_search/src/Drush/Commands/TextPipelineCommands.php
@@ -87,7 +87,6 @@ final class TextPipelineCommands extends Command {
 
         $output->writeln('Title: ' . ($chunk->heading?->title ?? ''));
         $output->writeln('Fragment: ' . ($chunk->fragment ?? ''));
-        $output->writeln('Text fragment: ' . ($chunk->textFragment ?? ''));
         $output->writeln('Snippet: ' . ($chunk->snippet ?? ''));
         $output->writeln('===');
         $output->writeln((string) $chunk);

--- a/modules/helfi_search/src/Pipeline/Chunk.php
+++ b/modules/helfi_search/src/Pipeline/Chunk.php
@@ -23,7 +23,6 @@ final class Chunk {
     public array $metadata = [],
     public ?string $snippet = NULL,
     public ?string $fragment = NULL,
-    public ?string $textFragment = NULL,
   ) {
   }
 
@@ -64,7 +63,6 @@ final class Chunk {
       heading: $this->heading,
       metadata: $this->metadata,
       fragment: $this->fragment,
-      textFragment: $this->textFragment,
     );
   }
 

--- a/modules/helfi_search/src/Pipeline/ChunkAnnotator.php
+++ b/modules/helfi_search/src/Pipeline/ChunkAnnotator.php
@@ -19,10 +19,11 @@ class ChunkAnnotator {
    *   The chunks with snippet and fragment populated.
    */
   public function annotate(array $chunks, array $headingFragments): array {
+    $perSectionFragment = $this->buildSectionFragmentMap($chunks, $headingFragments);
+
     foreach ($chunks as $i => $chunk) {
       $chunk->snippet = SnippetRenderer::render($chunk->text);
-      $chunk->fragment = $this->buildSectionFragmentMap($chunks, $headingFragments)[$i] ?? NULL;
-      $chunk->textFragment = count($chunks) > 1 ? SnippetRenderer::renderTextFragment($chunk->text) : NULL;
+      $chunk->fragment = $perSectionFragment[$i] ?? NULL;
     }
     return $chunks;
   }

--- a/modules/helfi_search/src/Pipeline/Heading.php
+++ b/modules/helfi_search/src/Pipeline/Heading.php
@@ -38,7 +38,7 @@ final readonly class Heading {
   private static function normalize(string $text): string {
     $text = preg_replace('/[*_`]/u', '', $text) ?? $text;
     $text = preg_replace('/\s+/u', ' ', $text) ?? $text;
-    return htmlspecialchars_decode(mb_strtolower(trim($text)));
+    return mb_strtolower(trim($text));
   }
 
 }

--- a/modules/helfi_search/src/Pipeline/Heading.php
+++ b/modules/helfi_search/src/Pipeline/Heading.php
@@ -38,7 +38,7 @@ final readonly class Heading {
   private static function normalize(string $text): string {
     $text = preg_replace('/[*_`]/u', '', $text) ?? $text;
     $text = preg_replace('/\s+/u', ' ', $text) ?? $text;
-    return mb_strtolower(trim($text));
+    return htmlspecialchars_decode(mb_strtolower(trim($text)));
   }
 
 }

--- a/modules/helfi_search/src/Pipeline/SnippetRenderer.php
+++ b/modules/helfi_search/src/Pipeline/SnippetRenderer.php
@@ -25,54 +25,6 @@ final class SnippetRenderer {
   }
 
   /**
-   * Render a text fragment from markdown.
-   *
-   * Text fragment allows linking and highlighting a specific part of the text.
-   */
-  public static function renderTextFragment(string $markdown): string {
-    $text = self::stripMarkdown($markdown);
-    $text = html_entity_decode(strip_tags($text), ENT_HTML5, 'UTF-8');
-    $lines = explode("\n", $text);
-    $textLines = [];
-
-    // Create a text fragment from all lines that have at least 3 words.
-    // If the line has less than 6 words, use the entire line for an exact
-    // match. Else, use the first 3 and last 3 words to mark the start and end
-    // of the fragment.
-    foreach ($lines as $line) {
-      $words = explode(' ', html_entity_decode($line));
-      if (count($words) < 3) {
-        continue;
-      }
-
-      if (count($words) < 6) {
-        $text = implode(' ', $words);
-        $textLines[] = sprintf('text=%s', self::percentEncode($text));
-      }
-      else {
-        $start = implode(' ', array_slice($words, 0, 3));
-        $end = implode(' ', array_slice($words, -3));
-
-        $textLines[] = sprintf('text=%s,%s', self::percentEncode($start), self::percentEncode($end));
-      }
-    }
-
-    return sprintf(':~:%s', implode('&', $textLines));
-  }
-
-  /**
-   * Percent encode a string according to text matching spec.
-   *
-   * In addition to rawurlencode(), we also replace '-'.
-   *
-   * @see https://wicg.github.io/scroll-to-text-fragment/#syntax
-   */
-  private static function percentEncode(string $text): string {
-    $text = rawurlencode($text);
-    return str_replace('-', '%2D', $text);
-  }
-
-  /**
    * Strip Markdown formatting from a string.
    */
   private static function stripMarkdown(string $markdown): string {

--- a/modules/helfi_search/src/Plugin/search_api/processor/VectorEmbeddingsProcessor.php
+++ b/modules/helfi_search/src/Plugin/search_api/processor/VectorEmbeddingsProcessor.php
@@ -104,7 +104,7 @@ final class VectorEmbeddingsProcessor extends ProcessorPluginBase {
           $field->addValue([
             'vector' => $vector,
             'content' => Unicode::truncate($chunks[$index]->snippet ?? '', 200, TRUE, TRUE),
-            'fragment' => $chunks[$index]->textFragment,
+            'fragment' => $chunks[$index]->fragment,
           ]);
         }
       }

--- a/modules/helfi_search/src/QueryBuilder.php
+++ b/modules/helfi_search/src/QueryBuilder.php
@@ -352,7 +352,9 @@ final class QueryBuilder {
         'metatag_title' => array_first($hit['_source']['metatag_title'] ?? []),
         'published_at' => array_first($hit['_source']['published_at'] ?? []),
         'content' => $innerFields['content'][0] ?? '',
-        'fragment' => $innerFields['fragment'][0] ?? NULL,
+        // @fixme Link fragment system is disabled for now. Matching
+        // individual chunks is not reliable enough at the moment.
+        'fragment' => NULL,
       ];
       // Debug: when more than one inner hit was requested, surface every
       // matching chunk with its individual similarity score.

--- a/modules/helfi_search/tests/src/Kernel/Plugin/search_api/VectorEmbeddingsProcessorTest.php
+++ b/modules/helfi_search/tests/src/Kernel/Plugin/search_api/VectorEmbeddingsProcessorTest.php
@@ -160,7 +160,7 @@ class VectorEmbeddingsProcessorTest extends ProcessorTestBase {
     $this->assertCount(1, $values);
     $this->assertSame([0.1, 0.2, 0.3], $values[0]['vector']);
     $this->assertSame($chunk->snippet, $values[0]['content']);
-    $this->assertNull($values[0]['fragment']);
+    $this->assertSame('how-to-apply', $values[0]['fragment']);
   }
 
   /**

--- a/modules/helfi_search/tests/src/Unit/QueryBuilderTest.php
+++ b/modules/helfi_search/tests/src/Unit/QueryBuilderTest.php
@@ -137,10 +137,7 @@ class QueryBuilderTest extends UnitTestCase {
     $this->assertEquals(50, $query['body']['knn']['k']);
     $this->assertEquals('fi', $query['body']['knn']['filter']['term']['search_api_language']);
     $this->assertEquals(
-      [
-        self::TEST_MODEL_FIELD . '.content',
-        self::TEST_MODEL_FIELD . '.fragment',
-      ],
+      [self::TEST_MODEL_FIELD . '.content', self::TEST_MODEL_FIELD . '.fragment'],
       $query['body']['knn']['inner_hits']['fields'],
     );
     $this->assertEquals(
@@ -410,10 +407,7 @@ class QueryBuilderTest extends UnitTestCase {
 
     [$news, $content] = $query['body']['knn'];
 
-    $expectedFields = [
-      self::TEST_MODEL_FIELD . '.content',
-      self::TEST_MODEL_FIELD . '.fragment',
-    ];
+    $expectedFields = [self::TEST_MODEL_FIELD . '.content', self::TEST_MODEL_FIELD . '.fragment'];
     $this->assertEquals($expectedFields, $news['inner_hits']['fields']);
     $this->assertEquals($expectedFields, $content['inner_hits']['fields']);
     $this->assertEquals('deboosted', $news['inner_hits']['name']);

--- a/modules/helfi_search/tests/src/Unit/QueryBuilderTest.php
+++ b/modules/helfi_search/tests/src/Unit/QueryBuilderTest.php
@@ -266,7 +266,6 @@ class QueryBuilderTest extends UnitTestCase {
     $this->assertCount(1, $results);
     $this->assertEquals('doc1', $results[0]['id']);
     $this->assertEquals('Some content', $results[0]['content']);
-    $this->assertEquals('some-section', $results[0]['fragment']);
   }
 
   /**
@@ -319,7 +318,6 @@ class QueryBuilderTest extends UnitTestCase {
     $results = (new QueryBuilder())->parseKnnHits($response, self::TEST_MODEL);
 
     $this->assertEquals('Named hit content', $results[0]['content']);
-    $this->assertEquals('fragment', $results[0]['fragment']);
   }
 
   /**


### PR DESCRIPTION
# [UHF-13325](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13325)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Reverts the text fragment POC due to subpar highlighting results.
* Keep a bug fix to allow proper heading matching when the heading includes special characters like `&`, that might be encoded only on one side.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your etusivu instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-13325_revert`
* Run code updates
  * `composer install`
  * `make drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* Run `drush helfi:text-pipeline node 18`
  * [ ] Also the chunk with "Title: Osallistu &amp; vaikuta &amp; päätöksenteko" should have a fragment
  * [ ] You should no longer see any text fragments
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-13325]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ