### PR TITLE
UHF-12888: Prevent error: calling get on null

### DIFF
--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -39,9 +39,13 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
     }
 
     $title_level = $this->getTitleLevel();
-    $heading_level = (int) $this->getParentEntity()
-      ->get('field_accordion_heading_level')
-      ->getString();
+    $heading_level = 3;
+    if ($parentEntity = $this->getParentEntity()) {
+     $heading_level = $parentEntity
+       ->get('field_accordion_heading_level')
+       ->getString();
+    }
+
 
     // Remove inaccessible skipping between title level and item level.
     // For example:

--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -20,8 +20,8 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
    */
   public function hasTitle(): bool {
     return !$this->getParentEntity()
-      ->get('field_accordion_title')
-      ->isEmpty();
+      ?->get('field_accordion_title')
+      ?->isEmpty() ?? FALSE;
   }
 
   /**

--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -19,9 +19,12 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
    *   Parent paragraph has a heading.
    */
   public function hasTitle(): bool {
-    return !$this->getParentEntity()
-      ?->get('field_accordion_title')
-      ?->isEmpty() ?? FALSE;
+    if ($parentEntity = $this->getParentEntity()) {
+      return !$parentEntity
+        ->get('field_accordion_title')
+        ->isEmpty();
+    }
+    return FALSE;
   }
 
   /**

--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -41,11 +41,10 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
     $title_level = $this->getTitleLevel();
     $heading_level = 3;
     if ($parentEntity = $this->getParentEntity()) {
-     $heading_level = $parentEntity
-       ->get('field_accordion_heading_level')
-       ->getString();
+      $heading_level = $parentEntity
+        ->get('field_accordion_heading_level')
+        ->getString();
     }
-
 
     // Remove inaccessible skipping between title level and item level.
     // For example:

--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -41,7 +41,7 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
     $title_level = $this->getTitleLevel();
     $heading_level = 3;
     if ($parentEntity = $this->getParentEntity()) {
-      $heading_level = $parentEntity
+      $heading_level = (int) $parentEntity
         ->get('field_accordion_heading_level')
         ->getString();
     }

--- a/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
+++ b/modules/helfi_paragraphs_accordion/src/Entity/AccordionItem.php
@@ -59,9 +59,13 @@ class AccordionItem extends Paragraph implements ParagraphInterface {
    *   The title level.
    */
   protected function getTitleLevel(): int {
-    return (int) $this->getParentEntity()
-      ->get('field_accordion_title_level')
-      ->getString();
+    if ($parentEntity = $this->getParentEntity()) {
+      return (int) $parentEntity
+        ->get('field_accordion_title_level')
+        ->getString();
+    }
+    // 2 is set as default value for the required field.
+    return 2;
   }
 
 }


### PR DESCRIPTION
Fixed sentry error, trying to call get on null.

### How to reproduce 
- Add an accordion to a basic page
  - Leave the accordion main title empty (the non-required title field)
- Add new accordion item, fill the accordion item fields
- Try previewing the page without saving, you'll get error "Call to a member function get() on null"

This PR fixes the "call to member function on null" -error but will lead into another error. Ticket has been created to fix the preview feature.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-12888`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`


## How to test
- Try reproducing the error
- The original error should be fixed
- You might get another error, something like `TwigTweakExtension::drupalEntity(): Argument #2 ($selector) must be of type string, null given`
- The twigtweak error came from lower_content_block.twig.html

