### PR TITLE
UHF-13054: hide pages from search

### DIFF
--- a/helfi_platform_config.install
+++ b/helfi_platform_config.install
@@ -598,3 +598,41 @@ function helfi_platform_config_update_11003(): void {
     }
   }
 }
+
+/**
+ * Enable the advanced metatag group.
+ */
+function helfi_platform_config_update_11004(): void {
+  if (!\Drupal::moduleHandler()->moduleExists('metatag')) {
+    return;
+  }
+
+  // The advanced group is enabled on these entity types.
+  $types = [
+    'node' => ['page', 'landing_page'],
+    'tpr_service' => ['tpr_service'],
+    'tpr_unit' => ['tpr_unit'],
+  ];
+
+  $config = \Drupal::configFactory()->getEditable('metatag.settings');
+  $entityTypeGroups = $config->get('entity_type_groups') ?? [];
+  $changed = FALSE;
+
+  foreach ($types as $entityType => $bundles) {
+    foreach ($bundles as $bundle) {
+      $groups = $entityTypeGroups[$entityType][$bundle] ?? [];
+
+      // Only act on bundles that already has metatag groups configuration.
+      if (empty($groups) || isset($groups['advanced'])) {
+        continue;
+      }
+
+      $entityTypeGroups[$entityType][$bundle]['advanced'] = 'advanced';
+      $changed = TRUE;
+    }
+  }
+
+  if ($changed) {
+    $config->set('entity_type_groups', $entityTypeGroups)->save();
+  }
+}

--- a/helfi_platform_config.services.yml
+++ b/helfi_platform_config.services.yml
@@ -5,7 +5,7 @@ services:
 
   # The metatag dependency is optional, so it is injected with "@?" and the
   # service falls back to a no-op when metatag is not installed.
-  Drupal\helfi_platform_config\Token\MetatagTitleResolver:
+  Drupal\helfi_platform_config\Helper\MetatagHelper:
     arguments:
       - '@?metatag.manager'
 

--- a/modules/hdbt_admin_tools/src/Hook/MetatagHooks.php
+++ b/modules/hdbt_admin_tools/src/Hook/MetatagHooks.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\hdbt_admin_tools\Hook;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Routing\AdminContext;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Hook implementations for metatag form alterations.
+ */
+final class MetatagHooks {
+
+  use AutowireTrait;
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly AdminContext $adminContext,
+  ) {
+  }
+
+  /**
+   * Implements hook_form_alter().
+   *
+   * The advanced metatag group exposes a large number of tags that editors
+   * should not need to touch. Hide everything except the robots "noindex"
+   * setting.
+   */
+  #[Hook('form_alter')]
+  public function formAlter(array &$form, FormStateInterface $form_state, string $form_id): void {
+    // Handle only admin routes.
+    if (!$this->adminContext->isAdminRoute()) {
+      return;
+    }
+
+    // Only act on entity forms that contain the advanced metatag group.
+    if (
+      !$form_state->getFormObject() instanceof EntityForm ||
+      !isset($form['field_metatags']['widget'][0]['advanced'])
+    ) {
+      return;
+    }
+
+    $advanced = &$form['field_metatags']['widget'][0]['advanced'];
+
+    // Hide every advanced tag except robots.
+    foreach (Element::children($advanced) as $tag_name) {
+      if ($tag_name !== 'robots') {
+        $advanced[$tag_name]['#access'] = FALSE;
+      }
+    }
+
+    // Reduce the robots tag to the single "noindex" checkbox.
+    if (isset($advanced['robots'])) {
+      $robots = &$advanced['robots'];
+
+      // Hide the extended robots directives.
+      $robots['robots-keyed']['#access'] = FALSE;
+
+      // Hide unnecessary options.
+      $robots['robots']['#options'] = array_intersect_key(
+        $robots['robots']['#options'],
+        array_flip(['noindex', 'nofollow'])
+      );
+    }
+  }
+
+}

--- a/modules/helfi_recommendations/src/Plugin/search_api/processor/ScoredReferenceParentProcessor.php
+++ b/modules/helfi_recommendations/src/Plugin/search_api/processor/ScoredReferenceParentProcessor.php
@@ -6,7 +6,7 @@ namespace Drupal\helfi_recommendations\Plugin\search_api\processor;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\helfi_platform_config\Token\MetatagTitleResolver;
+use Drupal\helfi_platform_config\Helper\MetatagHelper;
 use Drupal\search_api\Attribute\SearchApiProcessor;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
@@ -39,9 +39,9 @@ final class ScoredReferenceParentProcessor extends ProcessorPluginBase {
   private EntityTypeManagerInterface $entityTypeManager;
 
   /**
-   * Metatag title resolver.
+   * The metatag helper.
    */
-  private MetatagTitleResolver $metatagTitleResolver;
+  private MetatagHelper $metatagHelper;
 
   /**
    * {@inheritDoc}
@@ -49,7 +49,7 @@ final class ScoredReferenceParentProcessor extends ProcessorPluginBase {
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->entityTypeManager = $container->get(EntityTypeManagerInterface::class);
-    $instance->metatagTitleResolver = $container->get(MetatagTitleResolver::class);
+    $instance->metatagHelper = $container->get(MetatagHelper::class);
     return $instance;
   }
 
@@ -203,7 +203,7 @@ final class ScoredReferenceParentProcessor extends ProcessorPluginBase {
 
     $translation = $parentEntity->getTranslation($langcode);
 
-    if ($title = $this->metatagTitleResolver->resolve($translation)) {
+    if ($title = $this->metatagHelper->resolveTitle($translation)) {
       return $title;
     }
 

--- a/modules/helfi_search/helfi_search.install
+++ b/modules/helfi_search/helfi_search.install
@@ -218,3 +218,24 @@ function helfi_search_update_11016(): void {
   $ignored_classes[] = 'component--list-of-links';
   $config->set('ignored_classes', $ignored_classes)->save();
 }
+
+/**
+ * Add the metatag noindex processor to the embeddings index.
+ */
+function helfi_search_update_11017(): void {
+  $index = Index::load('embeddings');
+
+  if (!$index) {
+    return;
+  }
+
+  // Exclude entities that have the robots "noindex" metatag set from being
+  // indexed.
+  if (!$index->isValidProcessor('helfi_metatag_noindex')) {
+    $plugin_helper = \Drupal::service('search_api.plugin_helper');
+    $index->addProcessor(
+      $plugin_helper->createProcessorPlugin($index, 'helfi_metatag_noindex')
+    );
+    $index->save();
+  }
+}

--- a/src/Helper/MetatagHelper.php
+++ b/src/Helper/MetatagHelper.php
@@ -2,19 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Drupal\helfi_platform_config\Token;
+namespace Drupal\helfi_platform_config\Helper;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\metatag\MetatagManager;
 
 /**
- * Resolves the customized metatag title of an entity.
- *
- * Editors can override the page title through the metatag fields. This service
- * returns that overridden title (with the configured tokens and leftover
- * separators stripped), or NULL when the entity has no customized title.
+ * Reads metatag values customized on an entity.
  */
-final readonly class MetatagTitleResolver {
+final readonly class MetatagHelper {
 
   /**
    * Tokens to remove from the title template.
@@ -36,7 +32,7 @@ final readonly class MetatagTitleResolver {
    *   The customized metatag title, or NULL when the title has not been
    *   customized (or metatag is not installed).
    */
-  public function resolve(ContentEntityInterface $entity): ?string {
+  public function resolveTitle(ContentEntityInterface $entity): ?string {
     if (!$this->metatagManager) {
       return NULL;
     }

--- a/src/Helper/MetatagHelper.php
+++ b/src/Helper/MetatagHelper.php
@@ -62,6 +62,36 @@ final readonly class MetatagHelper {
   }
 
   /**
+   * Checks whether the entity has the robots "noindex" directive set.
+   *
+   * Only the tags set on the entity itself are inspected. Entity-type and
+   * global defaults don't cause a page to be reported as noindex.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity to check.
+   *
+   * @return bool
+   *   TRUE when the entity is set to noindex.
+   */
+  public function isNoindex(ContentEntityInterface $entity): bool {
+    if (!$this->metatagManager) {
+      return FALSE;
+    }
+
+    $tags = $this->metatagManager->tagsFromEntity($entity);
+
+    if (empty($tags['robots']) || !is_string($tags['robots'])) {
+      return FALSE;
+    }
+
+    // The robots tag is stored as a comma-separated list of directives, e.g.
+    // "noindex, nofollow".
+    $directives = array_map('trim', explode(',', $tags['robots']));
+
+    return in_array('noindex', $directives, TRUE);
+  }
+
+  /**
    * Removes the configured tokens from a raw metatag value.
    */
   private function stripTokens(string $value): string {

--- a/src/Hook/MetatagHooks.php
+++ b/src/Hook/MetatagHooks.php
@@ -2,26 +2,21 @@
 
 declare(strict_types=1);
 
-namespace Drupal\hdbt_admin_tools\Hook;
+namespace Drupal\helfi_platform_config\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\AdminContext;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
- * Hook implementations for metatag form alterations.
+ * Hook implementations for form alterations.
  */
-final class MetatagHooks {
-
-  use AutowireTrait;
-  use StringTranslationTrait;
+final readonly class MetatagHooks {
 
   public function __construct(
-    private readonly AdminContext $adminContext,
+    private AdminContext $adminContext,
   ) {
   }
 
@@ -31,6 +26,8 @@ final class MetatagHooks {
    * The advanced metatag group exposes a large number of tags that editors
    * should not need to touch. Hide everything except the robots "noindex"
    * setting.
+   *
+   * @phpstan-param array<string, mixed> $form
    */
   #[Hook('form_alter')]
   public function formAlter(array &$form, FormStateInterface $form_state, string $form_id): void {

--- a/src/Plugin/search_api/processor/MetatagNoindex.php
+++ b/src/Plugin/search_api/processor/MetatagNoindex.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_platform_config\Plugin\search_api\processor;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\helfi_platform_config\Helper\MetatagHelper;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Excludes entities with the robots "noindex" directive from being indexed.
+ *
+ * Editors can hide individual pages from search engines by setting the robots
+ * "noindex" metatag. This processor reads that field value and removes such
+ * entities from the index.
+ *
+ * The processor depends on the metatag module, but that dependency is optional:
+ * the resolver falls back to a no-op when metatag is not installed.
+ *
+ * @see \Drupal\helfi_platform_config\Helper\MetatagHelper
+ */
+#[SearchApiProcessor(
+  id: 'helfi_metatag_noindex',
+  label: new TranslatableMarkup('Metatag noindex'),
+  description: new TranslatableMarkup('Excludes entities that have the robots "noindex" metatag set from being indexed.'),
+  stages: [
+    'alter_items' => 0,
+  ],
+)]
+final class MetatagNoindex extends ProcessorPluginBase {
+
+  /**
+   * The metatag helper.
+   */
+  private MetatagHelper $metatagHelper;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string, mixed> $configuration
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->metatagHelper = $container->get(MetatagHelper::class);
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @phpstan-param array<string|int, \Drupal\search_api\Item\ItemInterface<mixed>> $items
+   */
+  public function alterIndexedItems(array &$items): void {
+    foreach ($items as $item_id => $item) {
+      $entity = $item->getOriginalObject()->getValue();
+
+      if ($entity instanceof ContentEntityInterface && $this->metatagHelper->isNoindex($entity)) {
+        unset($items[$item_id]);
+      }
+    }
+  }
+
+}

--- a/src/Plugin/search_api/processor/MetatagTitle.php
+++ b/src/Plugin/search_api/processor/MetatagTitle.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_platform_config\Plugin\search_api\processor;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\helfi_platform_config\Token\MetatagTitleResolver;
+use Drupal\helfi_platform_config\Helper\MetatagHelper;
 use Drupal\search_api\Attribute\SearchApiProcessor;
 use Drupal\search_api\Datasource\DatasourceInterface;
 use Drupal\search_api\Item\ItemInterface;
@@ -39,9 +39,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 final class MetatagTitle extends ProcessorPluginBase {
 
   /**
-   * The metatag title resolver.
+   * The metatag helper.
    */
-  private MetatagTitleResolver $titleResolver;
+  private MetatagHelper $metatagHelper;
 
   /**
    * {@inheritdoc}
@@ -50,7 +50,7 @@ final class MetatagTitle extends ProcessorPluginBase {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
     $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
-    $processor->titleResolver = $container->get(MetatagTitleResolver::class);
+    $processor->metatagHelper = $container->get(MetatagHelper::class);
     return $processor;
   }
 
@@ -87,7 +87,7 @@ final class MetatagTitle extends ProcessorPluginBase {
     // Metatag overrides are only available on content entities. Fall back to
     // the entity label when the title has not been customized.
     $title = $entity instanceof ContentEntityInterface
-      ? $this->titleResolver->resolve($entity)
+      ? $this->metatagHelper->resolveTitle($entity)
       : NULL;
     $title ??= (string) $entity->label();
 

--- a/tests/src/Kernel/Plugin/search_api/MetatagNoindexTest.php
+++ b/tests/src/Kernel/Plugin/search_api/MetatagNoindexTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_platform_config\Kernel\Plugin\search_api;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\search_api\Kernel\Processor\ProcessorTestBase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for the MetatagNoindex processor.
+ */
+#[Group('helfi_platform_config')]
+#[RunTestsInSeparateProcesses]
+class MetatagNoindexTest extends ProcessorTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'helfi_platform_config',
+    'config_rewrite',
+    'helfi_api_base',
+    'metatag',
+    'token',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp($processor = NULL): void {
+    parent::setUp('helfi_metatag_noindex');
+
+    $this->installConfig(['metatag']);
+
+    NodeType::create(['type' => 'page'])->save();
+
+    // Attach a metatag field to the node bundle so editors can override tags.
+    FieldStorageConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'field_metatags',
+      'type' => 'metatag',
+    ])->save();
+    FieldConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'field_metatags',
+      'bundle' => 'page',
+    ])->save();
+
+    $this->index->save();
+  }
+
+  /**
+   * Tests that entities with the robots "noindex" directive are excluded.
+   *
+   * @param string|null $robots
+   *   The robots metatag value to set on the node, or NULL to leave it unset.
+   * @param bool $expectedKept
+   *   Whether the item is expected to remain in the index.
+   */
+  #[DataProvider('noindexDataProvider')]
+  public function testAlterIndexedItems(?string $robots, bool $expectedKept): void {
+    $values = ['type' => 'page', 'title' => 'Test node'];
+    if ($robots !== NULL) {
+      $values['field_metatags'] = ['value' => json_encode(['robots' => $robots])];
+    }
+    $node = Node::create($values);
+    $node->save();
+
+    $items = $this->generateItems([
+      [
+        'datasource' => 'entity:node',
+        'item' => $node->getTypedData(),
+        'item_id' => $node->id() . ':en',
+      ],
+    ]);
+
+    $this->processor->alterIndexedItems($items);
+
+    $this->assertSame($expectedKept, $items !== []);
+  }
+
+  /**
+   * Data provider for testAlterIndexedItems().
+   *
+   * @return array<string, array{string|null, bool}>
+   *   Sets of [robots metatag value, whether the item should be kept].
+   */
+  public static function noindexDataProvider(): array {
+    return [
+      'no robots tag is kept' => [NULL, TRUE],
+      'noindex is removed' => ['noindex', FALSE],
+    ];
+  }
+
+}


### PR DESCRIPTION
# [UHF-13054](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13054)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Configure metatag module so that Drupal nodes can set noindex header for pages
* Add search_api processor that excludes entitites that have noindex metatag header enabled.
* Enable this processor on embeddings index.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your etusivu is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13054-hide-pages-from-search`
* Run code updates
  * `composer install`
  * `make drush-updb`
  <!-- 
  Running all module updates takes approx. 5 minutes.
  To run one module update: `drush helfi:platform-config:update module_name"`
  -->

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [x] Node edit sidebar should have new option to hide page from search engines.
* [x] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
* 


[UHF-13054]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ