### PR TITLE
UHF-12901 tel link href encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
                 "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "./public/modules/contrib/helfi_platform_config/patches/3396318.patch",
                 "[#UHF-11784] Sort the source and target arrays in the configuration storage comparer to avoid false positives": "./public/modules/contrib/helfi_platform_config/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch",
                 "[#UHF-13252] ...account administration pages causes RouteMatch to be Null in some cases (https://www.drupal.org/i/3265213)": "./public/modules/contrib/helfi_platform_config/patches/3265213.patch",
-                "[#UHF-12901] Prevent accessibility issue when multiple tel links with same number but different hrefs on same page": "./publis/modules/contrib/helfi_platform_config/patches/non-encoded-tel-link-href.patch"
+                "[#UHF-12901] Prevent accessibility issue when multiple tel links with same number but different hrefs on same page": "./public/modules/contrib/helfi_platform_config/patches/non-encoded-tel-link-href.patch"
             },
             "drupal/diff": {
                 "Revision overview form problem (https://www.drupal.org/i/3390329)": "./public/modules/contrib/helfi_platform_config/patches/diff_8.x_1.3_revision_overview_form.patch"

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
                 "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "./public/modules/contrib/helfi_platform_config/patches/3396318.patch",
                 "[#UHF-11784] Sort the source and target arrays in the configuration storage comparer to avoid false positives": "./public/modules/contrib/helfi_platform_config/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch",
                 "[#UHF-13252] ...account administration pages causes RouteMatch to be Null in some cases (https://www.drupal.org/i/3265213)": "./public/modules/contrib/helfi_platform_config/patches/3265213.patch",
-                "[#UHF-12901] Prevent accessibility issue when multiple tel links with same number but different hrefs on same page": "./public/modules/contrib/helfi_platform_config/patches/non-encoded-tel-link-href.patch"
+                "[#UHF-12901] TODO remove on D12 once telephone field is moved to contrib module: Prevent accessibility issue due to difference in tel href encoding between ckeditor and telephone field formatter": "./public/modules/contrib/helfi_platform_config/patches/non-encoded-tel-link-href.patch"
             },
             "drupal/diff": {
                 "Revision overview form problem (https://www.drupal.org/i/3390329)": "./public/modules/contrib/helfi_platform_config/patches/diff_8.x_1.3_revision_overview_form.patch"

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
                 "[#UHF-9952, #UHF-9980] Duplicate <br /> tags (https://www.drupal.org/i/3083786)": "./public/modules/contrib/helfi_platform_config/patches/3083786.patch",
                 "[#UHF-11025] Status message templates missing theme when bigpipe is enabled (https://www.drupal.org/i/3396318)": "./public/modules/contrib/helfi_platform_config/patches/3396318.patch",
                 "[#UHF-11784] Sort the source and target arrays in the configuration storage comparer to avoid false positives": "./public/modules/contrib/helfi_platform_config/patches/drupal-core-sort-storage-comparer-source-and-target-arrays.patch",
-                "[#UHF-13252] ...account administration pages causes RouteMatch to be Null in some cases (https://www.drupal.org/i/3265213)": "./public/modules/contrib/helfi_platform_config/patches/3265213.patch"
+                "[#UHF-13252] ...account administration pages causes RouteMatch to be Null in some cases (https://www.drupal.org/i/3265213)": "./public/modules/contrib/helfi_platform_config/patches/3265213.patch",
+                "[#UHF-12901] Prevent accessibility issue when multiple tel links with same number but different hrefs on same page": "./publis/modules/contrib/helfi_platform_config/patches/non-encoded-tel-link-href.patch"
             },
             "drupal/diff": {
                 "Revision overview form problem (https://www.drupal.org/i/3390329)": "./public/modules/contrib/helfi_platform_config/patches/diff_8.x_1.3_revision_overview_form.patch"

--- a/patches/non-encoded-tel-link-href.patch
+++ b/patches/non-encoded-tel-link-href.patch
@@ -1,0 +1,12 @@
+diff --git a/core/modules/telephone/src/Plugin/Field/FieldFormatter/TelephoneLinkFormatter.php b/core/modules/telephone/src/Plugin/Field/FieldFormatter/TelephoneLinkFormatter.php
+index e1fbcf3402b..15d1bd9dd65 100644
+--- a/core/modules/telephone/src/Plugin/Field/FieldFormatter/TelephoneLinkFormatter.php
++++ b/core/modules/telephone/src/Plugin/Field/FieldFormatter/TelephoneLinkFormatter.php
+@@ -90,7 +90,7 @@ public function viewElements(FieldItemListInterface $items, $langcode) {
+         // itself as title.
+         '#title' => $title_setting ?: $item->value,
+         // Prepend 'tel:' to the telephone number.
+-        '#url' => Url::fromUri('tel:' . rawurlencode($phone_number)),
++        '#url' => Url::fromUri('tel:' . $phone_number),
+         '#options' => ['external' => TRUE],
+       ];


### PR DESCRIPTION
# [UHF-12901](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12901)

## What was done

Added patch to remove encoding from tel link formatter instead of ckeditor change

[Check this out](https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1329)



[UHF-12901]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ