### PR TITLE
UHF-13097: Disable filter settings when using lifts display mode

### DIFF
--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -95,15 +95,23 @@ function helfi_react_search_field_widget_complete_form_alter(
     return;
   }
 
+  // The lifts layout renders a fixed set of cards without the search form, so
+  // nothing under "Search filters" has any effect while it is selected.
+  $lifts_selected = [':input[name$="[field_event_list_layout]"]' => ['value' => 'lifts']];
+
   switch ($items->getFieldDefinition()->getName()) {
     case 'field_search_term':
       // The paragraph's `field_event_list_free_text` is sent to the Linked
       // Events API as `full_text`; so is the user-facing search bar. Letting
       // both be set would mean the user's input overrides the editor's
       // pre-filter. Disable the toggle whenever the pre-filter is already in
-      // use.
+      // use, or when the lifts layout hides the search form altogether.
       $checkbox = &$field_widget_complete_form['widget']['value'];
-      $checkbox['#states']['disabled'][':input[name$="[field_event_list_free_text][0][value]"]'] = ['filled' => TRUE];
+      $checkbox['#states']['disabled'] = [
+        [':input[name$="[field_event_list_free_text][0][value]"]' => ['filled' => TRUE]],
+        'or',
+        $lifts_selected,
+      ];
       $checkbox['#description'] = new TranslatableMarkup(
         'This filter does not work if you have applied filters in "Filter events and hobbies".',
         [],
@@ -111,10 +119,18 @@ function helfi_react_search_field_widget_complete_form_alter(
       );
       break;
 
+    case 'field_event_location':
+    case 'field_event_time':
+    case 'field_language':
+    case 'field_remote_events':
+    case 'field_free_events':
+      $field_widget_complete_form['widget']['value']['#states']['disabled'] = $lifts_selected;
+      break;
+
     case 'field_event_count':
       // The lifts layout always renders the three latest events, so the count
       // is fixed. Disable the widget while that layout is selected.
-      $field_widget_complete_form['widget']['#states']['disabled'][':input[name$="[field_event_list_layout]"]'] = ['value' => 'lifts'];
+      $field_widget_complete_form['widget']['#states']['disabled'] = $lifts_selected;
       break;
   }
 }

--- a/modules/helfi_react_search/helfi_react_search.module
+++ b/modules/helfi_react_search/helfi_react_search.module
@@ -95,42 +95,11 @@ function helfi_react_search_field_widget_complete_form_alter(
     return;
   }
 
-  // The lifts layout renders a fixed set of cards without the search form, so
-  // nothing under "Search filters" has any effect while it is selected.
-  $lifts_selected = [':input[name$="[field_event_list_layout]"]' => ['value' => 'lifts']];
-
-  switch ($items->getFieldDefinition()->getName()) {
-    case 'field_search_term':
-      // The paragraph's `field_event_list_free_text` is sent to the Linked
-      // Events API as `full_text`; so is the user-facing search bar. Letting
-      // both be set would mean the user's input overrides the editor's
-      // pre-filter. Disable the toggle whenever the pre-filter is already in
-      // use, or when the lifts layout hides the search form altogether.
-      $checkbox = &$field_widget_complete_form['widget']['value'];
-      $checkbox['#states']['disabled'] = [
-        [':input[name$="[field_event_list_free_text][0][value]"]' => ['filled' => TRUE]],
-        'or',
-        $lifts_selected,
-      ];
-      $checkbox['#description'] = new TranslatableMarkup(
-        'This filter does not work if you have applied filters in "Filter events and hobbies".',
-        [],
-        ['context' => 'Event list paragraph: search term disabled hint'],
-      );
-      break;
-
-    case 'field_event_location':
-    case 'field_event_time':
-    case 'field_language':
-    case 'field_remote_events':
-    case 'field_free_events':
-      $field_widget_complete_form['widget']['value']['#states']['disabled'] = $lifts_selected;
-      break;
-
-    case 'field_event_count':
-      // The lifts layout always renders the three latest events, so the count
-      // is fixed. Disable the widget while that layout is selected.
-      $field_widget_complete_form['widget']['#states']['disabled'] = $lifts_selected;
-      break;
+  if ($items->getFieldDefinition()->getName() === 'field_search_term') {
+    $field_widget_complete_form['widget']['value']['#description'] = new TranslatableMarkup(
+      'This filter does not work if you have applied filters in "Filter events and hobbies".',
+      [],
+      ['context' => 'Event list paragraph: search term disabled hint'],
+    );
   }
 }

--- a/modules/helfi_react_search/src/Hook/ReactSearchHooks.php
+++ b/modules/helfi_react_search/src/Hook/ReactSearchHooks.php
@@ -107,29 +107,53 @@ final class ReactSearchHooks {
     }
 
     $select = fn (string $prefix) => ':input[name="' . $context['items']->getName() . '[' . $element['#delta'] . '][subform]' . $prefix . '"]';
+
+    $lifts = [$select('[field_event_list_layout]') => ['value' => 'lifts']];
+
     $states = [
       'field_event_list_category_event' => [
-        'state' => 'invisible',
-        'condition' => [$select('[field_event_list_type]') => ['value' => 'hobbies']],
+        'invisible' => [$select('[field_event_list_type]') => ['value' => 'hobbies']],
       ],
       'field_event_list_category_hobby' => [
-        'state' => 'invisible',
-        'condition' => [$select('[field_event_list_type]') => ['value' => 'events']],
+        'invisible' => [$select('[field_event_list_type]') => ['value' => 'events']],
+      ],
+      'field_event_count' => [
+        'disabled' => $lifts,
       ],
       'field_event_location' => [
-        'state' => 'disabled',
-        'condition' => [$select('[field_remote_events][value]') => ['checked' => TRUE]],
+        'disabled' => [
+          [$select('[field_remote_events][value]') => ['checked' => TRUE]],
+          'or',
+          $lifts,
+        ],
+      ],
+      'field_event_time' => [
+        'disabled' => $lifts,
+      ],
+      'field_language' => [
+        'disabled' => $lifts,
       ],
       'field_remote_events' => [
-        'state' => 'disabled',
-        'condition' => [$select('[field_event_location][value]') => ['checked' => TRUE]],
+        'disabled' => [
+          [$select('[field_event_location][value]') => ['checked' => TRUE]],
+          'or',
+          $lifts,
+        ],
+      ],
+      'field_free_events' => [
+        'disabled' => $lifts,
+      ],
+      'field_search_term' => [
+        'disabled' => [
+          [$select('[field_event_list_free_text][0][value]') => ['filled' => TRUE]],
+          'or',
+          $lifts,
+        ],
       ],
     ];
 
-    foreach ($states as $field => ['state' => $state, 'condition' => $condition]) {
-      $element['subform'][$field]['#states'] = [
-        $state => [$condition],
-      ];
+    foreach ($states as $field => $field_states) {
+      $element['subform'][$field]['#states'] = $field_states;
     }
   }
 

--- a/modules/helfi_react_search/tests/src/Unit/Hook/ReactSearchHooksTest.php
+++ b/modules/helfi_react_search/tests/src/Unit/Hook/ReactSearchHooksTest.php
@@ -195,6 +195,20 @@ final class ReactSearchHooksTest extends UnitTestCase {
     $this->assertTrue(
       $element['subform']['field_event_location']['#states']['disabled'][0][':input[name="event_list[0][subform][field_remote_events][value]"]']['checked']
     );
+
+    // Fields that only affect the search form are disabled by the lifts layout.
+    $lifts = [':input[name="event_list[0][subform][field_event_list_layout]"]' => ['value' => 'lifts']];
+    foreach (['field_event_count', 'field_event_time', 'field_language', 'field_free_events'] as $field) {
+      $this->assertSame($lifts, $element['subform'][$field]['#states']['disabled']);
+    }
+
+    // Fields with a condition of their own keep it, with the lifts layout as an
+    // alternative. Both rules have to live in the same `#states` array so that
+    // they cannot override each other.
+    foreach (['field_event_location', 'field_remote_events', 'field_search_term'] as $field) {
+      $this->assertSame($lifts, $element['subform'][$field]['#states']['disabled'][2]);
+      $this->assertSame('or', $element['subform'][$field]['#states']['disabled'][1]);
+    }
   }
 
 }


### PR DESCRIPTION
# [UHF-13097](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13097)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Disable filter settings when using them is useless as per PO wish

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13097-disable-filters`
* Run code updates
  * `make drush-cr`
  <!-- 
  Running all module updates takes approx. 5 minutes.
  To run one module update: `drush helfi:platform-config:update module_name"`
  -->

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] 
* Create a page with events paragraph
* Edit the page, try switching between List and Three cards display modes
* When you've chosen Three cards as the display mode, filter settings a bit below should become disabled

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->




[UHF-13097]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ