### PR TITLE
UHF-13494: Revoked AI permissions from all roles except "admin". Make sure AI tools are only visible to those with permission

### DIFF
--- a/modules/helfi_ai/helfi_ai.install
+++ b/modules/helfi_ai/helfi_ai.install
@@ -6,6 +6,7 @@
  */
 
 declare(strict_types=1);
+
 use Drupal\user\Entity\Role;
 
 /**

--- a/modules/helfi_ai/helfi_ai.install
+++ b/modules/helfi_ai/helfi_ai.install
@@ -6,6 +6,8 @@
  */
 
 declare(strict_types=1);
+use Drupal\user\Entity\Role;
+use Drupal\user\Plugin\views\access\Permission;
 
 /**
  * Implements hook_install().
@@ -33,4 +35,31 @@ function helfi_ai_update_11001(): void {
     }
   }
   $config->save();
+}
+
+/**
+ * Remove AI permissions from all roles. Grant permission to 'admin' role.
+ */
+function helfi_ai_update_11002(): void {
+  /** @var \Drupal\user\RoleInterface[] $roles */
+  $roles = Role::loadMultiple();
+
+  $permissions = ['use helfi ai title suggestion', 'use helfi ai tone check'];
+
+  foreach ($roles as $role) {
+    foreach ($permissions as $permission) {
+      if (!$role->hasPermission($permission)) {
+        continue;
+      }
+      $role->revokePermission($permission);
+    }
+    $role->save();
+  }
+
+  if ($role = Role::load('admin')) {
+    foreach ($permissions as $permission) {
+      $role->grantPermission($permission);
+    }
+    $role->save();
+  }
 }

--- a/modules/helfi_ai/helfi_ai.install
+++ b/modules/helfi_ai/helfi_ai.install
@@ -7,7 +7,6 @@
 
 declare(strict_types=1);
 use Drupal\user\Entity\Role;
-use Drupal\user\Plugin\views\access\Permission;
 
 /**
  * Implements hook_install().

--- a/modules/helfi_ai/helfi_ai.install
+++ b/modules/helfi_ai/helfi_ai.install
@@ -44,7 +44,11 @@ function helfi_ai_update_11002(): void {
   /** @var \Drupal\user\RoleInterface[] $roles */
   $roles = Role::loadMultiple();
 
-  $permissions = ['use helfi ai title suggestion', 'use helfi ai tone check'];
+  $permissions = [
+    'use helfi ai title suggestion',
+    'use helfi ai tone check',
+    'use helfi ai summary',
+  ];
 
   foreach ($roles as $role) {
     foreach ($permissions as $permission) {

--- a/modules/helfi_ai/helfi_ai.permissions.yml
+++ b/modules/helfi_ai/helfi_ai.permissions.yml
@@ -7,3 +7,8 @@
   title: 'Use HELfi AI tone check'
   description: 'Run the AI tone check on editor content.'
   restrict_access: true
+
+'use helfi ai summary':
+  title: 'Use HELfi AI summary'
+  description: 'Run the AI summary on editor content.'
+  restrict_access: true

--- a/modules/helfi_ai/src/Config/ToneCheckToolbarOverride.php
+++ b/modules/helfi_ai/src/Config/ToneCheckToolbarOverride.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorableConfigBase;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 
 /**
  * Add the AI tone check button to editor toolbars.
@@ -29,6 +30,7 @@ final class ToneCheckToolbarOverride implements ConfigFactoryOverrideInterface {
 
   public function __construct(
     private readonly StorageInterface $configStorage,
+    private readonly AccountProxyInterface $currentUser,
   ) {
   }
 
@@ -69,7 +71,10 @@ final class ToneCheckToolbarOverride implements ConfigFactoryOverrideInterface {
    */
   private function toneCheckEnabled() : bool {
     if ($this->toneCheckEnabled === NULL) {
-      $this->toneCheckEnabled = (bool) ($this->configStorage->read('helfi_ai.settings')['enable_tone_check'] ?? FALSE);
+      $isEnabled = (bool) ($this->configStorage->read('helfi_ai.settings')['enable_tone_check'] ?? FALSE);
+      $hasPermission = $this->currentUser->hasPermission('use helfi ai tone check');
+
+      $this->toneCheckEnabled = $isEnabled && $hasPermission;
     }
     return $this->toneCheckEnabled;
   }

--- a/modules/helfi_ai/src/Hook/PermissionsHooks.php
+++ b/modules/helfi_ai/src/Hook/PermissionsHooks.php
@@ -22,6 +22,7 @@ class PermissionsHooks {
     $permissions = [
       'use helfi ai title suggestion',
       'use helfi ai tone check',
+      'use helfi ai summary',
     ];
     return [
       'admin' => $permissions,

--- a/modules/helfi_ai/src/Hook/PermissionsHooks.php
+++ b/modules/helfi_ai/src/Hook/PermissionsHooks.php
@@ -25,10 +25,6 @@ class PermissionsHooks {
     ];
     return [
       'admin' => $permissions,
-      'editor' => $permissions,
-      'content_producer' => $permissions,
-      // @todo This needs a proper permission after the PoC period.
-      'survey_editor' => ['manage ai prompts'],
     ];
   }
 

--- a/modules/helfi_ai/src/Plugin/Field/FieldWidget/AiSummaryWidget.php
+++ b/modules/helfi_ai/src/Plugin/Field/FieldWidget/AiSummaryWidget.php
@@ -14,10 +14,10 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\helfi_ai\PreviewEntityBuilder;
 use Drupal\helfi_ai\Service\AiGenerator;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Widget for the AI summary field.
@@ -47,24 +47,9 @@ final class AiSummaryWidget extends WidgetBase implements ContainerFactoryPlugin
     array $settings,
     array $third_party_settings,
     private readonly ConfigFactoryInterface $configFactory,
+    private readonly AccountProxyInterface $accountProxy,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * @phpstan-param array<string, mixed> $configuration
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static {
-    return new static(
-      $plugin_id,
-      $plugin_definition,
-      $configuration['field_definition'],
-      $configuration['settings'],
-      $configuration['third_party_settings'],
-      $container->get('config.factory'),
-    );
   }
 
   /**
@@ -99,6 +84,19 @@ final class AiSummaryWidget extends WidgetBase implements ContainerFactoryPlugin
   }
 
   /**
+   * Checks if the widget should be visible.
+   *
+   * @return bool
+   *   TRUE if the widget should be shown.
+   */
+  private function isVisible(): bool {
+    if (!$this->configFactory->get('helfi_ai.settings')->get('enable_ai_summary')) {
+      return FALSE;
+    }
+    return $this->accountProxy->hasPermission('use helfi ai title suggestion');
+  }
+
+  /**
    * Builds the widget form element for a single field delta.
    *
    * @param \Drupal\Core\Field\FieldItemListInterface<\Drupal\Core\Field\FieldItemInterface> $items
@@ -117,7 +115,7 @@ final class AiSummaryWidget extends WidgetBase implements ContainerFactoryPlugin
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state): array {
     // Hide the widget when the AI summary feature is disabled.
-    if (!$this->configFactory->get('helfi_ai.settings')->get('enable_ai_summary')) {
+    if (!$this->isVisible()) {
       $element['#access'] = FALSE;
       return $element;
     }

--- a/modules/helfi_ai/src/Plugin/Field/FieldWidget/AiSummaryWidget.php
+++ b/modules/helfi_ai/src/Plugin/Field/FieldWidget/AiSummaryWidget.php
@@ -47,7 +47,7 @@ final class AiSummaryWidget extends WidgetBase implements ContainerFactoryPlugin
     array $settings,
     array $third_party_settings,
     private readonly ConfigFactoryInterface $configFactory,
-    private readonly AccountProxyInterface $accountProxy,
+    private readonly AccountProxyInterface $currentUser,
   ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings);
   }
@@ -93,7 +93,7 @@ final class AiSummaryWidget extends WidgetBase implements ContainerFactoryPlugin
     if (!$this->configFactory->get('helfi_ai.settings')->get('enable_ai_summary')) {
       return FALSE;
     }
-    return $this->accountProxy->hasPermission('use helfi ai title suggestion');
+    return $this->currentUser->hasPermission('use helfi ai summary');
   }
 
   /**

--- a/modules/helfi_ai/tests/src/Unit/Config/ToneCheckToolbarOverrideTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Config/ToneCheckToolbarOverrideTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\helfi_ai\Unit\Config;
 
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\helfi_ai\Config\ToneCheckToolbarOverride;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -31,14 +32,16 @@ class ToneCheckToolbarOverrideTest extends UnitTestCase {
    * @return \Drupal\helfi_ai\Config\ToneCheckToolbarOverride
    *   The override under test.
    */
-  private function createOverride(bool $enabled, array $stored = []): ToneCheckToolbarOverride {
+  private function createOverride(bool $enabled, bool $hasPermission, array $stored = []): ToneCheckToolbarOverride {
     $storage = $this->prophesize(StorageInterface::class);
     $storage->read('helfi_ai.settings')->willReturn(['enable_tone_check' => $enabled]);
+    $currentUser = $this->prophesize(AccountProxyInterface::class);
+    $currentUser->hasPermission('use helfi ai tone check')->willReturn($hasPermission);
 
     foreach ($stored as $name => $data) {
       $storage->read($name)->willReturn($data);
     }
-    return new ToneCheckToolbarOverride($storage->reveal());
+    return new ToneCheckToolbarOverride($storage->reveal(), $currentUser->reveal());
   }
 
   /**
@@ -58,7 +61,7 @@ class ToneCheckToolbarOverrideTest extends UnitTestCase {
    * Test that the button is inserted.
    */
   public function testButtonInsertedBeforeSourceEditing(): void {
-    $override = $this->createOverride(TRUE, [
+    $override = $this->createOverride(TRUE, TRUE, [
       'editor.editor.full_html' => $this->editor(['bold', '|', 'sourceEditing']),
     ]);
     $overrides = $override->loadOverrides(['editor.editor.full_html']);
@@ -68,7 +71,7 @@ class ToneCheckToolbarOverrideTest extends UnitTestCase {
       $overrides['editor.editor.full_html']['settings']['toolbar']['items'],
     );
 
-    $override = $this->createOverride(TRUE, [
+    $override = $this->createOverride(TRUE, TRUE, [
       'editor.editor.full_html' => $this->editor(['bold', 'aiToneCheck', 'sourceEditing']),
     ]);
     $this->assertSame([], $override->loadOverrides(['editor.editor.full_html']));
@@ -78,7 +81,7 @@ class ToneCheckToolbarOverrideTest extends UnitTestCase {
    * Tests that editor overrides depend on the settings config.
    */
   public function testCacheableMetadataTagsSettings(): void {
-    $override = $this->createOverride(TRUE);
+    $override = $this->createOverride(TRUE, TRUE);
     $this->assertContains(
       'config:helfi_ai.settings',
       $override->getCacheableMetadata('editor.editor.full_html')->getCacheTags(),

--- a/modules/helfi_ai/tests/src/Unit/Config/ToneCheckToolbarOverrideTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Config/ToneCheckToolbarOverrideTest.php
@@ -26,6 +26,8 @@ class ToneCheckToolbarOverrideTest extends UnitTestCase {
    *
    * @param bool $enabled
    *   Whether the tone check feature is enabled.
+   * @param bool $hasPermission
+   *   Whether user has permission to view tone check button.
    * @param array<string, array<mixed>> $stored
    *   Stored editor config keyed by config name.
    *

--- a/modules/helfi_ai/tests/src/Unit/Hook/PermissionsHooksTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Hook/PermissionsHooksTest.php
@@ -22,7 +22,7 @@ class PermissionsHooksTest extends UnitTestCase {
   public function testPermissions(): void {
     $permissions = (new PermissionsHooks())->grantPermissions();
 
-    foreach (['admin', 'editor', 'content_producer'] as $role) {
+    foreach (['admin'] as $role) {
       $this->assertArrayHasKey($role, $permissions);
       $this->assertSame([
         'use helfi ai title suggestion',

--- a/modules/helfi_ai/tests/src/Unit/Hook/PermissionsHooksTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Hook/PermissionsHooksTest.php
@@ -27,6 +27,7 @@ class PermissionsHooksTest extends UnitTestCase {
       $this->assertSame([
         'use helfi ai title suggestion',
         'use helfi ai tone check',
+        'use helfi ai summary',
       ], $permissions[$role]);
     }
   }

--- a/modules/helfi_ai/tests/src/Unit/Plugin/Field/FieldWidget/AiSummaryWidgetTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Plugin/Field/FieldWidget/AiSummaryWidgetTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormState;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\helfi_ai\Plugin\Field\FieldWidget\AiSummaryWidget;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
@@ -34,7 +35,7 @@ class AiSummaryWidgetTest extends UnitTestCase {
   /**
    * Creates a widget instance for the given field name.
    */
-  private function createWidget(string $fieldName = 'ai_summary', bool $enabled = TRUE): AiSummaryWidget {
+  private function createWidget(string $fieldName = 'ai_summary', bool $enabled = TRUE, bool $access = TRUE): AiSummaryWidget {
     $fieldDef = $this->prophesize(FieldDefinitionInterface::class);
     $fieldDef->getName()->willReturn($fieldName);
 
@@ -43,7 +44,10 @@ class AiSummaryWidgetTest extends UnitTestCase {
     $configFactory = $this->prophesize(ConfigFactoryInterface::class);
     $configFactory->get('helfi_ai.settings')->willReturn($config->reveal());
 
-    $widget = new AiSummaryWidget('ai_summary', [], $fieldDef->reveal(), [], [], $configFactory->reveal());
+    $accountProxy = $this->prophesize(AccountProxyInterface::class);
+    $accountProxy->hasPermission('use helfi ai title suggestion')->willReturn($access);
+
+    $widget = new AiSummaryWidget('ai_summary', [], $fieldDef->reveal(), [], [], $configFactory->reveal(), $accountProxy->reveal());
     $widget->setStringTranslation($this->getStringTranslationStub());
     return $widget;
   }

--- a/modules/helfi_ai/tests/src/Unit/Plugin/Field/FieldWidget/AiSummaryWidgetTest.php
+++ b/modules/helfi_ai/tests/src/Unit/Plugin/Field/FieldWidget/AiSummaryWidgetTest.php
@@ -45,7 +45,7 @@ class AiSummaryWidgetTest extends UnitTestCase {
     $configFactory->get('helfi_ai.settings')->willReturn($config->reveal());
 
     $accountProxy = $this->prophesize(AccountProxyInterface::class);
-    $accountProxy->hasPermission('use helfi ai title suggestion')->willReturn($access);
+    $accountProxy->hasPermission('use helfi ai summary')->willReturn($access);
 
     $widget = new AiSummaryWidget('ai_summary', [], $fieldDef->reveal(), [], [], $configFactory->reveal(), $accountProxy->reveal());
     $widget->setStringTranslation($this->getStringTranslationStub());


### PR DESCRIPTION

# [UHF-13494](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13494)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Revoked permissions to use AI tools from all roles except "admin".
* Show AI Tone check tool only for users with correct permission

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13494`
* Run database updates `drush updb`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [x] Log in as user with "admin" role
* [x] Add new Standard page
* [x] Make sure "Generate SEO title with AI" is visible under the "Title" field
* [x] Make sure "Check tone" button is visible in Ckeditor field
* [x] Log in as "content editor" and make sure both fields are hidden

<img width="1377" height="1055" alt="image" src="https://github.com/user-attachments/assets/b15324a6-99c9-4feb-b2ba-6b3fd9ebb5bc" />




[UHF-13494]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ