### PR TITLE
UHF-13376: Disabling search snippet highlight

### DIFF
--- a/modules/helfi_search/src/QueryBuilder.php
+++ b/modules/helfi_search/src/QueryBuilder.php
@@ -388,7 +388,12 @@ final class QueryBuilder {
         'metatag_title' => array_first($hit['_source']['metatag_title'] ?? []),
         'published_at' => array_first($hit['_source']['published_at'] ?? []),
         'content' => $innerFields['content'][0] ?? '',
-        'fragment' => $innerFields['fragment'][0] ?? NULL,
+        // @todo Fragment is disabled for now. Plan is to enable it later
+        // in follow-up tickets for UHF-13376.
+        // @code
+        //   'fragment' => $innerFields['fragment'][0] ?? NULL,
+        // @endcode
+        'fragment' => NULL,
       ];
       // Debug: when more than one inner hit was requested, surface every
       // matching chunk with its individual similarity score.


### PR DESCRIPTION
# [UHF-13376](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13376)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Disabling search snippet highlight for now. It will be enable later with an improved ux.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13376_disable`
* Run code updates
  * `composer install`
  * `make drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* Make sure you have content in the `embeddings`-index: `drush sapi-c embeddings && drush sapi-rt embeddings && drush sapi-i embeddings` (letting it run for a few minutes should be enough for testing)
* [ ] Go to https://helfi-etusivu.docker.so/fi/search/new and try searching with a few different terms; no search result should include a fragment part in the url.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-13376]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ