### PR TITLE
UHF-13509 remove the webp-fallback image module and dependency

### DIFF
--- a/modules/helfi_image_styles/helfi_image_styles.info.yml
+++ b/modules/helfi_image_styles/helfi_image_styles.info.yml
@@ -6,7 +6,6 @@ dependencies:
   - drupal:responsive_image
   - imagemagick:imagemagick
   - webp:webp
-  - wpf:wpf
   - focal_point:focal_point
   - helfi_platform_config:helfi_platform_config
   - image_style_quality:image_style_quality

--- a/modules/helfi_image_styles/helfi_image_styles.install
+++ b/modules/helfi_image_styles/helfi_image_styles.install
@@ -207,3 +207,14 @@ function helfi_image_styles_update_11002(): void {
     \Drupal::service('module_installer')->install(['wpf']);
   }
 }
+
+/**
+ * UHF-12710 Enable webp and wpf modules and flush cached image styles.
+ */
+function helfi_image_styles_update_11003(): void {
+  if (
+    \Drupal::moduleHandler()->moduleExists('wpf')
+  ) {
+    \Drupal::service('module_installer')->uninstall(['wpf']);
+  }
+}

--- a/modules/helfi_image_styles/helfi_image_styles.install
+++ b/modules/helfi_image_styles/helfi_image_styles.install
@@ -209,7 +209,7 @@ function helfi_image_styles_update_11002(): void {
 }
 
 /**
- * UHF-12710 Enable webp and wpf modules and flush cached image styles.
+ * UHF-13509 Disable the fallback image module.
  */
 function helfi_image_styles_update_11003(): void {
   if (


### PR DESCRIPTION
# [UHF-13509 ](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13509 )

## What was done
No need for fallback images.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13509`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`
* Run `make shell`
  * In the shell, run `drush helfi:platform-config:update`
  <!-- 
  Running all module updates takes approx. 5 minutes.
  To run one module update: `drush helfi:platform-config:update module_name"`
  -->

## How to test
- Open any page with images on it
- Inspect the images
- Fallback-images should be .webp and it should load if you copy the image url to browser's address bar