### PR TITLE
UHF-13491: Removing the option to add map embeds from palvelukartta.dev.hel.ninja

### DIFF
--- a/modules/helfi_media_map/src/Entity/HelMap.php
+++ b/modules/helfi_media_map/src/Entity/HelMap.php
@@ -49,7 +49,7 @@ class HelMap extends MediaEntityBundle implements MediaInterface {
     /** @var \Drupal\link\LinkItemInterface $media */
     $media = $this->get('field_media_hel_map')->first();
     $link = $media->getUrl()->getUri();
-    return $link ? str_contains($link, 'palvelukartta.hel.fi') || str_contains($link, 'palvelukartta.dev.hel.ninja') : FALSE;
+    return $link ? str_contains($link, 'palvelukartta.hel.fi') : FALSE;
   }
 
 }

--- a/modules/helfi_media_map/src/Plugin/media/Source/Map.php
+++ b/modules/helfi_media_map/src/Plugin/media/Source/Map.php
@@ -23,7 +23,6 @@ use Drupal\media\MediaTypeInterface;
 final class Map extends MediaSourceBase {
 
   public const PALVELUKARTTA_URL = 'palvelukartta.hel.fi';
-  public const PALVELUKARTTA_DEV_URL = 'palvelukartta.dev.hel.ninja';
   public const KARTTA_URL = 'kartta.hel.fi';
 
   /**
@@ -31,7 +30,6 @@ final class Map extends MediaSourceBase {
    */
   public const VALID_URLS = [
     'palvelukartta' => self::PALVELUKARTTA_URL,
-    'palvelukartta_dev' => self::PALVELUKARTTA_DEV_URL,
     'kartta' => self::KARTTA_URL,
   ];
 

--- a/modules/helfi_media_map/src/UrlParserTrait.php
+++ b/modules/helfi_media_map/src/UrlParserTrait.php
@@ -61,7 +61,7 @@ trait UrlParserTrait {
       return (string) $uri;
     }
 
-    if ($uri->getHost() === Map::PALVELUKARTTA_URL || $uri->getHost() === Map::PALVELUKARTTA_DEV_URL) {
+    if ($uri->getHost() === Map::PALVELUKARTTA_URL) {
       // Link is already a valid embed link.
       if (str_contains($uri->getPath(), '/embed')) {
         return (string) $uri;
@@ -112,7 +112,7 @@ trait UrlParserTrait {
       return (string) $uri->withPath('/' . $path);
     }
 
-    if ($uri->getHost() === Map::PALVELUKARTTA_URL || $uri->getHost() === Map::PALVELUKARTTA_DEV_URL) {
+    if ($uri->getHost() === Map::PALVELUKARTTA_URL) {
       $path = ltrim(str_replace('/embed', '', $uri->getPath()), '/');
       return (string) $uri->withPath('/' . $path);
     }

--- a/modules/helfi_media_map/tests/src/Functional/MediaMapTest.php
+++ b/modules/helfi_media_map/tests/src/Functional/MediaMapTest.php
@@ -88,7 +88,7 @@ class MediaMapTest extends BrowserTestBase {
     ], 'Save');
 
     // Make sure we only allow valid domains.
-    $this->assertSession()->pageTextContainsOnce('Given host (google.com) is not valid, must be one of: palvelukartta.hel.fi, palvelukartta.dev.hel.ninja, kartta.hel.fi');
+    $this->assertSession()->pageTextContainsOnce('Given host (google.com) is not valid, must be one of: palvelukartta.hel.fi, kartta.hel.fi');
 
     // Make sure we can add valid maps.
     $urls = [


### PR DESCRIPTION
# [UHF-13491](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13491)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Effectively reverting changes from https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1358 , which was a temporary solution to allow debugging and testing the missing marker bug fix from palvelukartta dev environment.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Platform config
  * `composer require drupal/helfi_platform_config:dev-UHF-13491`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Create a test page and add a "Map embed"-paragraph. Click the "Add media"-button and try creating a new embed media from `https://palvelukartta.dev.hel.ninja/fi/embed/unit/62050` ; clicking Save should display an error message about an invalid host.
* [ ] Check that the code follows our standards

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-13491]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ